### PR TITLE
🐳 chore(deps): 更新vite到7.0.2，并同步更新pnpm-lock.yaml中的相关依赖

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "react-dom": "^19.1.0",
     "typescript": "~5.8.3",
     "typescript-eslint": "^8.35.1",
-    "vite": "^7.0.1",
+    "vite": "^7.0.2",
     "vite-plugin-dts": "^4.5.4",
     "vitest": "^3.2.4"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,7 +25,7 @@ importers:
         version: 19.1.6(@types/react@19.1.8)
       '@vitejs/plugin-react-swc':
         specifier: ^3.10.2
-        version: 3.10.2(vite@7.0.1(@types/node@24.0.10))
+        version: 3.10.2(vite@7.0.2(@types/node@24.0.10))
       '@vitest/coverage-v8':
         specifier: 3.2.4
         version: 3.2.4(vitest@3.2.4(@types/node@24.0.10)(jsdom@26.1.0))
@@ -60,11 +60,11 @@ importers:
         specifier: ^8.35.1
         version: 8.35.1(eslint@9.30.1)(typescript@5.8.3)
       vite:
-        specifier: ^7.0.1
-        version: 7.0.1(@types/node@24.0.10)
+        specifier: ^7.0.2
+        version: 7.0.2(@types/node@24.0.10)
       vite-plugin-dts:
         specifier: ^4.5.4
-        version: 4.5.4(@types/node@24.0.10)(rollup@4.44.1)(typescript@5.8.3)(vite@7.0.1(@types/node@24.0.10))
+        version: 4.5.4(@types/node@24.0.10)(rollup@4.44.1)(typescript@5.8.3)(vite@7.0.2(@types/node@24.0.10))
       vitest:
         specifier: ^3.2.4
         version: 3.2.4(@types/node@24.0.10)(jsdom@26.1.0)
@@ -1687,8 +1687,8 @@ packages:
       vite:
         optional: true
 
-  vite@7.0.1:
-    resolution: {integrity: sha512-BiKOQoW5HGR30E6JDeNsati6HnSPMVEKbkIWbCiol+xKeu3g5owrjy7kbk/QEMuzCV87dSUTvycYKmlcfGKq3Q==}
+  vite@7.0.2:
+    resolution: {integrity: sha512-hxdyZDY1CM6SNpKI4w4lcUc3Mtkd9ej4ECWVHSMrOdSinVc2zYOAppHeGc/hzmRo3pxM5blMzkuWHOJA/3NiFw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
@@ -2393,11 +2393,11 @@ snapshots:
       '@typescript-eslint/types': 8.35.1
       eslint-visitor-keys: 4.2.1
 
-  '@vitejs/plugin-react-swc@3.10.2(vite@7.0.1(@types/node@24.0.10))':
+  '@vitejs/plugin-react-swc@3.10.2(vite@7.0.2(@types/node@24.0.10))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-beta.11
       '@swc/core': 1.12.9
-      vite: 7.0.1(@types/node@24.0.10)
+      vite: 7.0.2(@types/node@24.0.10)
     transitivePeerDependencies:
       - '@swc/helpers'
 
@@ -2428,13 +2428,13 @@ snapshots:
       chai: 5.2.0
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.4(vite@7.0.1(@types/node@24.0.10))':
+  '@vitest/mocker@3.2.4(vite@7.0.2(@types/node@24.0.10))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.17
     optionalDependencies:
-      vite: 7.0.1(@types/node@24.0.10)
+      vite: 7.0.2(@types/node@24.0.10)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -3389,7 +3389,7 @@ snapshots:
       debug: 4.4.1
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 7.0.1(@types/node@24.0.10)
+      vite: 7.0.2(@types/node@24.0.10)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -3404,7 +3404,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite-plugin-dts@4.5.4(@types/node@24.0.10)(rollup@4.44.1)(typescript@5.8.3)(vite@7.0.1(@types/node@24.0.10)):
+  vite-plugin-dts@4.5.4(@types/node@24.0.10)(rollup@4.44.1)(typescript@5.8.3)(vite@7.0.2(@types/node@24.0.10)):
     dependencies:
       '@microsoft/api-extractor': 7.52.8(@types/node@24.0.10)
       '@rollup/pluginutils': 5.2.0(rollup@4.44.1)
@@ -3417,13 +3417,13 @@ snapshots:
       magic-string: 0.30.17
       typescript: 5.8.3
     optionalDependencies:
-      vite: 7.0.1(@types/node@24.0.10)
+      vite: 7.0.2(@types/node@24.0.10)
     transitivePeerDependencies:
       - '@types/node'
       - rollup
       - supports-color
 
-  vite@7.0.1(@types/node@24.0.10):
+  vite@7.0.2(@types/node@24.0.10):
     dependencies:
       esbuild: 0.25.5
       fdir: 6.4.6(picomatch@4.0.2)
@@ -3439,7 +3439,7 @@ snapshots:
     dependencies:
       '@types/chai': 5.2.2
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@7.0.1(@types/node@24.0.10))
+      '@vitest/mocker': 3.2.4(vite@7.0.2(@types/node@24.0.10))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -3457,7 +3457,7 @@ snapshots:
       tinyglobby: 0.2.14
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 7.0.1(@types/node@24.0.10)
+      vite: 7.0.2(@types/node@24.0.10)
       vite-node: 3.2.4(@types/node@24.0.10)
       why-is-node-running: 2.3.0
     optionalDependencies:


### PR DESCRIPTION
🤖 Generated with [Claude Code](https://claude.ai/code)