### PR TITLE
refactor: decompose useEcharts into internal hooks

### DIFF
--- a/src/__tests__/components/EChart.test.tsx
+++ b/src/__tests__/components/EChart.test.tsx
@@ -41,7 +41,7 @@ describe("EChart component", () => {
     expect(echarts.init).toHaveBeenCalled();
   });
 
-  it("should apply default style (width 100%, height 400px)", () => {
+  it("should apply default style (width 100%, height 100%, minHeight 400px)", () => {
     (echarts.init as ReturnType<typeof vi.fn>).mockImplementation((el: HTMLElement) =>
       createMockInstance(el),
     );
@@ -52,7 +52,8 @@ describe("EChart component", () => {
 
     const div = container.firstChild as HTMLDivElement;
     expect(div.style.width).toBe("100%");
-    expect(div.style.height).toBe("400px");
+    expect(div.style.height).toBe("100%");
+    expect(div.style.minHeight).toBe("400px");
   });
 
   it("should merge custom style with defaults", () => {

--- a/src/__tests__/themes/index.test.ts
+++ b/src/__tests__/themes/index.test.ts
@@ -81,6 +81,21 @@ describe("themes utilities", () => {
       expect(echarts.registerTheme).toHaveBeenCalledTimes(2);
     });
 
+    it("should handle circular reference theme objects without throwing", () => {
+      const circularTheme: Record<string, unknown> = { color: ["#ccc"] };
+      circularTheme.self = circularTheme;
+
+      const name1 = getOrRegisterCustomTheme(circularTheme);
+      expect(name1).toMatch(/__custom_theme_\d+/);
+      expect(echarts.registerTheme).toHaveBeenCalled();
+
+      // Same reference should return cached name
+      vi.clearAllMocks();
+      const name2 = getOrRegisterCustomTheme(circularTheme);
+      expect(name2).toBe(name1);
+      expect(echarts.registerTheme).not.toHaveBeenCalled();
+    });
+
     it("should deduplicate content even after many unique registrations", () => {
       // Register 100 unique themes
       for (let i = 0; i < 100; i++) {

--- a/src/__tests__/utils/instance-cache.test.ts
+++ b/src/__tests__/utils/instance-cache.test.ts
@@ -94,6 +94,25 @@ describe("instance-cache utilities", () => {
     });
   });
 
+  describe("clearInstanceCache", () => {
+    it("should dispose all tracked instances", () => {
+      const el1 = document.createElement("div");
+      const el2 = document.createElement("div");
+      const instance1 = createMockInstance();
+      const instance2 = createMockInstance();
+
+      setCachedInstance(el1, instance1);
+      setCachedInstance(el2, instance2);
+
+      clearInstanceCache();
+
+      expect(instance1.dispose).toHaveBeenCalled();
+      expect(instance2.dispose).toHaveBeenCalled();
+      expect(getCachedInstance(el1)).toBeUndefined();
+      expect(getCachedInstance(el2)).toBeUndefined();
+    });
+  });
+
   describe("getReferenceCount", () => {
     it("should return 0 for uncached element", () => {
       const element = document.createElement("div");

--- a/src/__tests__/utils/shallow-equal.test.ts
+++ b/src/__tests__/utils/shallow-equal.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from "vite-plus/test";
+import { shallowEqual } from "../../utils/shallow-equal";
+
+describe("shallowEqual", () => {
+  it("should return true for same reference", () => {
+    const obj = { a: 1 };
+    expect(shallowEqual(obj, obj)).toBe(true);
+  });
+
+  it("should return true for both null", () => {
+    expect(shallowEqual(null, null)).toBe(true);
+  });
+
+  it("should return true for both undefined", () => {
+    expect(shallowEqual(undefined, undefined)).toBe(true);
+  });
+
+  it("should return false for null vs undefined", () => {
+    expect(shallowEqual(null, undefined)).toBe(false);
+  });
+
+  it("should return false for null vs object", () => {
+    expect(shallowEqual(null, { a: 1 })).toBe(false);
+    expect(shallowEqual({ a: 1 }, null)).toBe(false);
+  });
+
+  it("should return true for objects with same keys and values", () => {
+    const series = [{ type: "line", data: [1, 2, 3] }];
+    expect(shallowEqual({ series }, { series })).toBe(true);
+  });
+
+  it("should return false for objects with different values", () => {
+    expect(shallowEqual({ a: 1 }, { a: 2 })).toBe(false);
+  });
+
+  it("should return false for objects with different key counts", () => {
+    expect(shallowEqual({ a: 1 }, { a: 1, b: 2 })).toBe(false);
+  });
+
+  it("should return false for objects with different keys", () => {
+    expect(shallowEqual({ a: 1 }, { b: 1 })).toBe(false);
+  });
+
+  it("should use Object.is semantics for values", () => {
+    expect(shallowEqual({ a: NaN }, { a: NaN })).toBe(true);
+    expect(shallowEqual({ a: 0 }, { a: -0 })).toBe(false);
+  });
+
+  it("should return true for equal primitives", () => {
+    expect(shallowEqual(1, 1)).toBe(true);
+    expect(shallowEqual("hello", "hello")).toBe(true);
+    expect(shallowEqual(true, true)).toBe(true);
+  });
+
+  it("should return false for different primitives", () => {
+    expect(shallowEqual(1, 2)).toBe(false);
+    expect(shallowEqual("a", "b")).toBe(false);
+  });
+
+  it("should compare arrays shallowly by index", () => {
+    expect(shallowEqual([1, 2], [1, 2])).toBe(true);
+    expect(shallowEqual([1, 2], [1, 3])).toBe(false);
+    expect(shallowEqual([1], [1, 2])).toBe(false);
+  });
+
+  it("should return false for different types", () => {
+    expect(shallowEqual(1, "1")).toBe(false);
+  });
+});

--- a/src/components/EChart.tsx
+++ b/src/components/EChart.tsx
@@ -20,7 +20,7 @@ const EChart = forwardRef<UseEchartsReturn, EChartProps>(
     return (
       <div
         ref={containerRef}
-        style={{ width: "100%", height: "400px", ...style }}
+        style={{ width: "100%", height: "100%", minHeight: "400px", ...style }}
         className={className}
       />
     );

--- a/src/hooks/internal/log-error.ts
+++ b/src/hooks/internal/log-error.ts
@@ -1,0 +1,17 @@
+/**
+ * Route error to onError callback or console.error.
+ * Used inside effects where throwing is not safe.
+ * 将错误路由到 onError 回调或 console.error。
+ * 用于 effect 内部不适合 throw 的场景。
+ */
+export function logError(
+  error: unknown,
+  message: string,
+  onError: ((e: unknown) => void) | undefined,
+): void {
+  if (onError) {
+    onError(error);
+  } else {
+    console.error(message, error);
+  }
+}

--- a/src/hooks/internal/types.ts
+++ b/src/hooks/internal/types.ts
@@ -1,0 +1,10 @@
+import type { EChartsOption, SetOptionOpts } from "echarts";
+
+/**
+ * Tracks the last option/opts applied to the ECharts instance.
+ * Shared between useInstanceLifecycle (writes on init) and useOptionSync (reads to skip duplicates).
+ */
+export interface LastApplied {
+  option: EChartsOption;
+  opts: SetOptionOpts | undefined;
+}

--- a/src/hooks/internal/use-events.ts
+++ b/src/hooks/internal/use-events.ts
@@ -1,0 +1,69 @@
+import { useEffect } from "react";
+import type { ECharts } from "echarts";
+import type { EChartsEvents, EChartsEventConfig } from "../../types";
+
+/**
+ * Normalize event config to full object form
+ * 将事件配置标准化为完整对象形式
+ */
+function normalizeEventConfig(config: EChartsEventConfig): {
+  handler: (params: unknown) => void;
+  query?: string | object;
+  context?: object;
+} {
+  if (typeof config === "function") {
+    return { handler: config };
+  }
+  return config;
+}
+
+/**
+ * Bind events to ECharts instance
+ * 绑定事件到 ECharts 实例
+ */
+export function bindEvents(instance: ECharts, events: EChartsEvents | undefined): void {
+  if (!events) return;
+  for (const [eventName, config] of Object.entries(events)) {
+    const { handler, query, context } = normalizeEventConfig(config);
+    if (query) {
+      instance.on(eventName, query, handler, context);
+    } else {
+      instance.on(eventName, handler, context);
+    }
+  }
+}
+
+/**
+ * Unbind events from ECharts instance
+ * 从 ECharts 实例解绑事件
+ */
+export function unbindEvents(instance: ECharts, events: EChartsEvents | undefined): void {
+  if (!events) return;
+  for (const [eventName, config] of Object.entries(events)) {
+    const { handler } = normalizeEventConfig(config);
+    instance.off(eventName, handler);
+  }
+}
+
+/**
+ * Internal hook: Rebind event handlers when onEvents changes.
+ * 内部 hook：当 onEvents 变化时重新绑定事件处理器。
+ */
+export function useEvents(
+  getInstance: () => ECharts | undefined,
+  onEvents: EChartsEvents | undefined,
+  boundEventsRef: React.MutableRefObject<EChartsEvents | undefined>,
+): void {
+  useEffect(() => {
+    const instance = getInstance();
+    if (!instance) return;
+
+    // Same reference — already bound
+    if (boundEventsRef.current === onEvents) return;
+
+    unbindEvents(instance, boundEventsRef.current);
+    bindEvents(instance, onEvents);
+    boundEventsRef.current = onEvents;
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- boundEventsRef is a stable container
+  }, [getInstance, onEvents]);
+}

--- a/src/hooks/internal/use-group.ts
+++ b/src/hooks/internal/use-group.ts
@@ -1,0 +1,19 @@
+import { useEffect } from "react";
+import type { ECharts } from "echarts";
+import { updateGroup, getInstanceGroup } from "../../utils/connect";
+
+/**
+ * Internal hook: Manage chart group membership.
+ * 内部 hook：管理图表的组成员关系。
+ */
+export function useGroup(getInstance: () => ECharts | undefined, group: string | undefined): void {
+  useEffect(() => {
+    const instance = getInstance();
+    if (!instance) return;
+
+    const currentGroup = getInstanceGroup(instance);
+    if (currentGroup === group) return;
+
+    updateGroup(instance, currentGroup, group);
+  }, [getInstance, group]);
+}

--- a/src/hooks/internal/use-instance-lifecycle.ts
+++ b/src/hooks/internal/use-instance-lifecycle.ts
@@ -1,0 +1,135 @@
+import { useLayoutEffect } from "react";
+import * as echarts from "echarts";
+import type { ECharts, SetOptionOpts, EChartsOption } from "echarts";
+import type { EChartsEvents, EChartsInitOpts, UseEchartsOptions } from "../../types";
+import {
+  getCachedInstance,
+  setCachedInstance,
+  releaseCachedInstance,
+} from "../../utils/instance-cache";
+import { updateGroup, getInstanceGroup } from "../../utils/connect";
+import { getOrRegisterCustomTheme } from "../../themes";
+import { bindEvents, unbindEvents } from "./use-events";
+import { logError } from "./log-error";
+import type { LastApplied } from "./types";
+
+/**
+ * Resolve theme to a registered ECharts theme name (has side effects).
+ * Must only be called inside effects, not during render.
+ * 将主题解析为已注册的 ECharts 主题名称（有副作用）。
+ * 仅可在 effect 内部调用，不可在渲染阶段调用。
+ */
+function resolveThemeName(theme: string | object | null | undefined): string | null {
+  if (theme == null) return null;
+  if (typeof theme === "string") return theme;
+  if (typeof theme === "object") return getOrRegisterCustomTheme(theme);
+  return null;
+}
+
+/**
+ * Internal hook: Instance lifecycle management.
+ * Creates, re-creates, and destroys the ECharts instance.
+ * Applies initial option, events, loading, and group on (re-)creation.
+ * 内部 hook：实例生命周期管理。
+ * 创建、重建、销毁 ECharts 实例，并在（重新）创建时应用初始状态。
+ */
+export function useInstanceLifecycle(
+  ref: React.RefObject<HTMLDivElement | null>,
+  shouldInit: boolean,
+  themeKey: string | null,
+  renderer: "canvas" | "svg",
+  initOptsKey: string | null,
+  // Refs for latest values (read during init, not in deps)
+  optionRef: React.RefObject<EChartsOption>,
+  setOptionOptsRef: React.RefObject<SetOptionOpts | undefined>,
+  showLoadingRef: React.RefObject<boolean>,
+  loadingOptionRef: React.RefObject<Record<string, unknown> | undefined>,
+  onEventsRef: React.RefObject<EChartsEvents | undefined>,
+  groupRef: React.RefObject<string | undefined>,
+  onErrorRef: React.RefObject<((e: unknown) => void) | undefined>,
+  themeRef: React.RefObject<UseEchartsOptions["theme"]>,
+  initOptsRef: React.RefObject<EChartsInitOpts | undefined>,
+  // Shared mutable refs
+  lastAppliedRef: React.MutableRefObject<LastApplied | null>,
+  boundEventsRef: React.MutableRefObject<EChartsEvents | undefined>,
+): void {
+  useLayoutEffect(() => {
+    if (!shouldInit) return;
+
+    const element = ref.current;
+    if (!element) return;
+
+    // Resolve theme: strings pass through; custom objects get registered
+    // (side effect safe inside effects). Read from ref to avoid closure capture.
+    const resolvedTheme = resolveThemeName(themeRef.current);
+
+    // Re-use existing instance if another hook (or StrictMode re-mount)
+    // already owns this element, avoiding a redundant init + dispose cycle.
+    const existing = getCachedInstance(element);
+    let instance: ECharts;
+    if (existing) {
+      instance = existing;
+      setCachedInstance(element, existing); // bump ref count
+    } else {
+      try {
+        instance = echarts.init(element, resolvedTheme, {
+          renderer,
+          ...initOptsRef.current,
+        });
+      } catch (error) {
+        logError(error, "ECharts init failed:", onErrorRef.current);
+        return;
+      }
+      setCachedInstance(element, instance);
+    }
+
+    // Apply initial option
+    try {
+      instance.setOption(optionRef.current, setOptionOptsRef.current);
+      lastAppliedRef.current = {
+        option: optionRef.current,
+        opts: setOptionOptsRef.current,
+      };
+    } catch (error) {
+      logError(error, "ECharts setOption failed:", onErrorRef.current);
+    }
+
+    // Apply loading state
+    if (showLoadingRef.current) {
+      instance.showLoading(loadingOptionRef.current);
+    }
+
+    // Bind events
+    bindEvents(instance, onEventsRef.current);
+    boundEventsRef.current = onEventsRef.current;
+
+    // Join group
+    const currentGroup = groupRef.current;
+    if (currentGroup) {
+      updateGroup(instance, undefined, currentGroup);
+    }
+
+    // Cleanup (handles StrictMode double mount via reference counting)
+    return () => {
+      // Reset so option sync effect re-applies option after re-init
+      lastAppliedRef.current = null;
+
+      const inst = getCachedInstance(element);
+      if (!inst) return;
+
+      // Leave group
+      const instGroup = getInstanceGroup(inst);
+      if (instGroup) {
+        updateGroup(inst, instGroup, undefined);
+      }
+
+      // Unbind events
+      unbindEvents(inst, boundEventsRef.current);
+      boundEventsRef.current = undefined;
+
+      // Release (dispose when ref count reaches 0)
+      releaseCachedInstance(element);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- refs are stable containers; only structural deps trigger re-init
+  }, [shouldInit, ref, themeKey, renderer, initOptsKey]);
+}

--- a/src/hooks/internal/use-loading.ts
+++ b/src/hooks/internal/use-loading.ts
@@ -1,0 +1,23 @@
+import { useEffect } from "react";
+import type { ECharts } from "echarts";
+
+/**
+ * Internal hook: Toggle loading state on the ECharts instance.
+ * 内部 hook：切换 ECharts 实例的 loading 状态。
+ */
+export function useLoading(
+  getInstance: () => ECharts | undefined,
+  showLoading: boolean,
+  loadingOption: Record<string, unknown> | undefined,
+): void {
+  useEffect(() => {
+    const instance = getInstance();
+    if (!instance) return;
+
+    if (showLoading) {
+      instance.showLoading(loadingOption);
+    } else {
+      instance.hideLoading();
+    }
+  }, [getInstance, showLoading, loadingOption]);
+}

--- a/src/hooks/internal/use-option-sync.ts
+++ b/src/hooks/internal/use-option-sync.ts
@@ -1,0 +1,36 @@
+import { useEffect } from "react";
+import type { ECharts, SetOptionOpts, EChartsOption } from "echarts";
+import { shallowEqual } from "../../utils/shallow-equal";
+import { logError } from "./log-error";
+import type { LastApplied } from "./types";
+
+/**
+ * Internal hook: Sync option changes to the ECharts instance.
+ * Skips duplicate setOption calls after init and when option is shallowly equal.
+ * 内部 hook：将 option 变更同步到 ECharts 实例。
+ * 在 init 后以及 option 浅比较相等时跳过重复的 setOption 调用。
+ */
+export function useOptionSync(
+  getInstance: () => ECharts | undefined,
+  option: EChartsOption,
+  setOptionOpts: SetOptionOpts | undefined,
+  lastAppliedRef: React.MutableRefObject<LastApplied | null>,
+  onErrorRef: React.RefObject<((e: unknown) => void) | undefined>,
+): void {
+  useEffect(() => {
+    const instance = getInstance();
+    if (!instance) return;
+
+    // Skip if init effect already applied this exact option
+    const last = lastAppliedRef.current;
+    if (last && shallowEqual(last.option, option) && last.opts === setOptionOpts) return;
+
+    try {
+      instance.setOption(option, setOptionOpts);
+      lastAppliedRef.current = { option, opts: setOptionOpts };
+    } catch (error) {
+      logError(error, "ECharts setOption failed:", onErrorRef.current);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- refs are stable containers read for latest values
+  }, [getInstance, option, setOptionOpts]);
+}

--- a/src/hooks/internal/use-resize-observer.ts
+++ b/src/hooks/internal/use-resize-observer.ts
@@ -1,0 +1,43 @@
+import { useEffect } from "react";
+import { getCachedInstance } from "../../utils/instance-cache";
+
+/**
+ * Internal hook: ResizeObserver-based auto-resize with RAF throttle.
+ * 内部 hook：基于 ResizeObserver 的自动 resize，使用 RAF 节流。
+ */
+export function useResizeObserver(
+  ref: React.RefObject<HTMLElement | null>,
+  autoResize: boolean,
+): void {
+  useEffect(() => {
+    if (!autoResize) return;
+
+    const element = ref.current;
+    if (!element) return;
+
+    let resizeObserver: ResizeObserver | undefined;
+    let rafId: number | undefined;
+
+    try {
+      resizeObserver = new ResizeObserver(() => {
+        if (rafId !== undefined) {
+          cancelAnimationFrame(rafId);
+        }
+        rafId = requestAnimationFrame(() => {
+          rafId = undefined;
+          getCachedInstance(element)?.resize();
+        });
+      });
+      resizeObserver.observe(element);
+    } catch (error) {
+      console.warn("ResizeObserver not available:", error);
+    }
+
+    return () => {
+      if (rafId !== undefined) {
+        cancelAnimationFrame(rafId);
+      }
+      resizeObserver?.disconnect();
+    };
+  }, [ref, autoResize]);
+}

--- a/src/hooks/use-echarts.ts
+++ b/src/hooks/use-echarts.ts
@@ -1,20 +1,19 @@
-import { useEffect, useRef, useCallback, useLayoutEffect, useMemo } from "react";
-import * as echarts from "echarts";
+import { useRef, useCallback, useLayoutEffect, useMemo } from "react";
 import type { ECharts, SetOptionOpts, EChartsOption } from "echarts";
-import type {
-  UseEchartsOptions,
-  UseEchartsReturn,
-  EChartsEvents,
-  EChartsEventConfig,
-} from "../types";
+import type { UseEchartsOptions, UseEchartsReturn, EChartsEvents } from "../types";
 import { useLazyInit } from "./use-lazy-init";
-import {
-  getCachedInstance,
-  setCachedInstance,
-  releaseCachedInstance,
-} from "../utils/instance-cache";
-import { updateGroup, getInstanceGroup } from "../utils/connect";
-import { getOrRegisterCustomTheme } from "../themes";
+import { getCachedInstance } from "../utils/instance-cache";
+import { useInstanceLifecycle } from "./internal/use-instance-lifecycle";
+import { useOptionSync } from "./internal/use-option-sync";
+import type { LastApplied } from "./internal/types";
+import { useLoading } from "./internal/use-loading";
+import { useEvents } from "./internal/use-events";
+import { useGroup } from "./internal/use-group";
+import { useResizeObserver } from "./internal/use-resize-observer";
+
+// Stable IDs for theme objects that cannot be JSON-serialized (e.g. circular references)
+const circularThemeIds = new WeakMap<object, string>();
+let circularIdCounter = 0;
 
 /**
  * Pure computation of a stable identity key for theme (no side effects).
@@ -28,80 +27,20 @@ import { getOrRegisterCustomTheme } from "../themes";
 function computeThemeKey(theme: string | object | null | undefined): string | null {
   if (theme == null) return null;
   if (typeof theme === "string") return theme;
-  if (typeof theme === "object") return JSON.stringify(theme);
-  return null;
-}
-
-/**
- * Resolve theme to a registered ECharts theme name (has side effects).
- * Must only be called inside effects, not during render.
- * 将主题解析为已注册的 ECharts 主题名称（有副作用）。
- * 仅可在 effect 内部调用，不可在渲染阶段调用。
- */
-function resolveThemeName(theme: string | object | null | undefined): string | null {
-  if (theme == null) return null;
-  if (typeof theme === "string") return theme;
-  if (typeof theme === "object") return getOrRegisterCustomTheme(theme);
-  return null;
-}
-
-/**
- * Normalize event config to full object form
- * 将事件配置标准化为完整对象形式
- */
-function normalizeEventConfig(config: EChartsEventConfig): {
-  handler: (params: unknown) => void;
-  query?: string | object;
-  context?: object;
-} {
-  if (typeof config === "function") {
-    return { handler: config };
-  }
-  return config;
-}
-
-/**
- * Bind events to ECharts instance
- * 绑定事件到 ECharts 实例
- */
-function bindEvents(instance: ECharts, events: EChartsEvents | undefined): void {
-  if (!events) return;
-  for (const [eventName, config] of Object.entries(events)) {
-    const { handler, query, context } = normalizeEventConfig(config);
-    if (query) {
-      instance.on(eventName, query, handler, context);
-    } else {
-      instance.on(eventName, handler, context);
+  if (typeof theme === "object") {
+    try {
+      return JSON.stringify(theme);
+    } catch {
+      // Circular reference: assign a stable ID via WeakMap
+      let id = circularThemeIds.get(theme);
+      if (!id) {
+        id = `__circular_${circularIdCounter++}`;
+        circularThemeIds.set(theme, id);
+      }
+      return id;
     }
   }
-}
-
-/**
- * Unbind events from ECharts instance
- * 从 ECharts 实例解绑事件
- */
-function unbindEvents(instance: ECharts, events: EChartsEvents | undefined): void {
-  if (!events) return;
-  for (const [eventName, config] of Object.entries(events)) {
-    const { handler } = normalizeEventConfig(config);
-    instance.off(eventName, handler);
-  }
-}
-
-/**
- * Route error to onError callback or console.error.
- * Used inside effects where throwing is not safe.
- */
-function logError(
-  error: unknown,
-  message: string,
-  onError: ((e: unknown) => void) | undefined,
-): void {
-  if (onError) {
-    onError(error);
-  } else {
-    console.error(message, error);
-  }
+  return null;
 }
 
 // ---------- Hook ----------
@@ -162,9 +101,7 @@ function useEcharts(
 
   // Track what option/opts was last applied by init effect,
   // used to prevent duplicate setOption call from the option update effect
-  const lastAppliedRef = useRef<{ option: EChartsOption; opts: SetOptionOpts | undefined } | null>(
-    null,
-  );
+  const lastAppliedRef = useRef<LastApplied | null>(null);
 
   // Lazy initialization
   const shouldInit = useLazyInit(ref, lazyInit);
@@ -176,8 +113,6 @@ function useEcharts(
 
   // Stable identity key for initOpts (same pattern as themeKey).
   // Prevents infinite re-init when users pass inline objects.
-  // 稳定的 initOpts 标识键（与 themeKey 同模式），
-  // 避免用户传入内联对象时 effect 无限重跑。
   const initOptsKey = useMemo(() => (initOpts ? JSON.stringify(initOpts) : null), [initOpts]);
 
   // --- Public API ---
@@ -209,193 +144,36 @@ function useEcharts(
     getInstance()?.resize();
   }, [getInstance]);
 
-  // =====================================================================
-  // Effect 1: INSTANCE LIFECYCLE (init / recreate / cleanup)
-  //
-  // Depends on: shouldInit, ref, themeKey, renderer, initOpts
-  // When theme or renderer changes, cleanup disposes the old instance
-  // and the effect re-runs to create a new one with the new config.
-  // All instance state (option, events, loading, group) is re-applied.
-  // =====================================================================
-  useLayoutEffect(() => {
-    if (!shouldInit) return;
+  // --- Internal effects (one hook per responsibility) ---
 
-    const element = ref.current;
-    if (!element) return;
+  useInstanceLifecycle(
+    ref,
+    shouldInit,
+    themeKey,
+    renderer,
+    initOptsKey,
+    optionRef,
+    setOptionOptsRef,
+    showLoadingRef,
+    loadingOptionRef,
+    onEventsRef,
+    groupRef,
+    onErrorRef,
+    themeRef,
+    initOptsRef,
+    lastAppliedRef,
+    boundEventsRef,
+  );
 
-    // Resolve theme: strings pass through; custom objects get registered
-    // (side effect safe inside effects). Read from ref to avoid closure capture.
-    const resolvedTheme = resolveThemeName(themeRef.current);
+  useOptionSync(getInstance, option, setOptionOpts, lastAppliedRef, onErrorRef);
 
-    // Re-use existing instance if another hook (or StrictMode re-mount)
-    // already owns this element, avoiding a redundant init + dispose cycle.
-    const existing = getCachedInstance(element);
-    let instance: ECharts;
-    if (existing) {
-      instance = existing;
-      setCachedInstance(element, existing); // bump ref count
-    } else {
-      try {
-        instance = echarts.init(element, resolvedTheme, {
-          renderer,
-          ...initOptsRef.current,
-        });
-      } catch (error) {
-        logError(error, "ECharts init failed:", onErrorRef.current);
-        return;
-      }
-      setCachedInstance(element, instance);
-    }
+  useLoading(getInstance, showLoading, loadingOption);
 
-    // Apply initial option
-    try {
-      instance.setOption(optionRef.current, setOptionOptsRef.current);
-      lastAppliedRef.current = {
-        option: optionRef.current,
-        opts: setOptionOptsRef.current,
-      };
-    } catch (error) {
-      logError(error, "ECharts setOption failed:", onErrorRef.current);
-    }
+  useEvents(getInstance, onEvents, boundEventsRef);
 
-    // Apply loading state
-    if (showLoadingRef.current) {
-      instance.showLoading(loadingOptionRef.current);
-    }
+  useGroup(getInstance, group);
 
-    // Bind events
-    bindEvents(instance, onEventsRef.current);
-    boundEventsRef.current = onEventsRef.current;
-
-    // Join group
-    const currentGroup = groupRef.current;
-    if (currentGroup) {
-      updateGroup(instance, undefined, currentGroup);
-    }
-
-    // Cleanup (handles StrictMode double mount via reference counting)
-    return () => {
-      // Reset so Effect 2 re-applies option after re-init
-      lastAppliedRef.current = null;
-
-      const inst = getCachedInstance(element);
-      if (!inst) return;
-
-      // Leave group
-      const instGroup = getInstanceGroup(inst);
-      if (instGroup) {
-        updateGroup(inst, instGroup, undefined);
-      }
-
-      // Unbind events
-      unbindEvents(inst, boundEventsRef.current);
-      boundEventsRef.current = undefined;
-
-      // Release (dispose when ref count reaches 0)
-      releaseCachedInstance(element);
-    };
-  }, [shouldInit, ref, themeKey, renderer, initOptsKey]);
-
-  // =====================================================================
-  // Effect 2: OPTION UPDATES
-  //
-  // Runs when option or setOptionOpts changes after initialization.
-  // Uses lastAppliedRef to skip the first run after init effect
-  // (which already applied the same option).
-  // =====================================================================
-  useEffect(() => {
-    const instance = getInstance();
-    if (!instance) return;
-
-    // Skip if init effect already applied this exact option
-    const last = lastAppliedRef.current;
-    if (last && last.option === option && last.opts === setOptionOpts) return;
-
-    try {
-      instance.setOption(option, setOptionOpts);
-      lastAppliedRef.current = { option, opts: setOptionOpts };
-    } catch (error) {
-      logError(error, "ECharts setOption failed:", onErrorRef.current);
-    }
-  }, [getInstance, option, setOptionOpts]);
-
-  // =====================================================================
-  // Effect 3: LOADING STATE
-  // =====================================================================
-  useEffect(() => {
-    const instance = getInstance();
-    if (!instance) return;
-
-    if (showLoading) {
-      instance.showLoading(loadingOption);
-    } else {
-      instance.hideLoading();
-    }
-  }, [getInstance, showLoading, loadingOption]);
-
-  // =====================================================================
-  // Effect 4: EVENT REBINDING
-  //
-  // When onEvents reference changes, unbind old and bind new handlers.
-  // =====================================================================
-  useEffect(() => {
-    const instance = getInstance();
-    if (!instance) return;
-
-    // Same reference — already bound
-    if (boundEventsRef.current === onEvents) return;
-
-    unbindEvents(instance, boundEventsRef.current);
-    bindEvents(instance, onEvents);
-    boundEventsRef.current = onEvents;
-  }, [getInstance, onEvents]);
-
-  // =====================================================================
-  // Effect 5: GROUP CHANGES
-  // =====================================================================
-  useEffect(() => {
-    const instance = getInstance();
-    if (!instance) return;
-
-    const currentGroup = getInstanceGroup(instance);
-    if (currentGroup === group) return;
-
-    updateGroup(instance, currentGroup, group);
-  }, [getInstance, group]);
-
-  // =====================================================================
-  // Effect 6: RESIZE OBSERVER
-  // =====================================================================
-  useEffect(() => {
-    if (!autoResize) return;
-
-    const element = ref.current;
-    if (!element) return;
-
-    let resizeObserver: ResizeObserver | undefined;
-    let rafId: number | undefined;
-
-    try {
-      resizeObserver = new ResizeObserver(() => {
-        if (rafId !== undefined) {
-          cancelAnimationFrame(rafId);
-        }
-        rafId = requestAnimationFrame(() => {
-          getCachedInstance(element)?.resize();
-        });
-      });
-      resizeObserver.observe(element);
-    } catch (error) {
-      console.warn("ResizeObserver not available:", error);
-    }
-
-    return () => {
-      if (rafId !== undefined) {
-        cancelAnimationFrame(rafId);
-      }
-      resizeObserver?.disconnect();
-    };
-  }, [ref, autoResize]);
+  useResizeObserver(ref, autoResize);
 
   return useMemo(() => ({ setOption, getInstance, resize }), [setOption, getInstance, resize]);
 }

--- a/src/themes/index.ts
+++ b/src/themes/index.ts
@@ -73,19 +73,29 @@ export function getOrRegisterCustomTheme(themeConfig: object): string {
   }
 
   // Content-based dedup: different reference, same content
-  const contentHash = JSON.stringify(themeConfig);
-  const existingName = contentHashCache.get(contentHash);
-  if (existingName) {
-    // Cache the reference for fast lookup next time
-    customThemeCache.set(themeConfig, existingName);
-    return existingName;
+  let contentHash: string | undefined;
+  try {
+    contentHash = JSON.stringify(themeConfig);
+  } catch {
+    // Circular reference or non-serializable value: skip content dedup
+  }
+
+  if (contentHash) {
+    const existingName = contentHashCache.get(contentHash);
+    if (existingName) {
+      // Cache the reference for fast lookup next time
+      customThemeCache.set(themeConfig, existingName);
+      return existingName;
+    }
   }
 
   // Register new theme
   const themeName = `__custom_theme_${customThemeCounter++}`;
   echarts.registerTheme(themeName, themeConfig);
   customThemeCache.set(themeConfig, themeName);
-  contentHashCache.set(contentHash, themeName);
+  if (contentHash) {
+    contentHashCache.set(contentHash, themeName);
+  }
 
   return themeName;
 }

--- a/src/utils/connect.ts
+++ b/src/utils/connect.ts
@@ -23,6 +23,21 @@ function pruneDisposed(group: Set<ECharts>): void {
 }
 
 /**
+ * Synchronize ECharts connect/disconnect state after removing an instance.
+ * 移除实例后根据组大小同步 ECharts 的 connect/disconnect 状态。
+ */
+function syncGroupConnectivity(groupId: string, group: Set<ECharts>): void {
+  if (group.size === 0) {
+    groupRegistry.delete(groupId);
+    echarts.disconnect(groupId);
+  } else if (group.size === 1) {
+    echarts.disconnect(groupId);
+  } else {
+    echarts.connect(groupId);
+  }
+}
+
+/**
  * Add chart instance to group
  * 将图表实例添加到组
  * @param instance ECharts instance
@@ -39,7 +54,6 @@ export function addToGroup(instance: ECharts, groupId: string): void {
   (instance as EChartsWithGroup).group = groupId;
   group.add(instance);
 
-  // Connect all instances in the group
   if (group.size > 1) {
     echarts.connect(groupId);
   }
@@ -62,20 +76,7 @@ export function removeFromGroup(instance: ECharts, groupId: string): void {
   if ((instance as EChartsWithGroup).group === groupId) {
     (instance as EChartsWithGroup).group = undefined;
   }
-
-  // If group becomes empty, clean up
-  if (group.size === 0) {
-    groupRegistry.delete(groupId);
-    echarts.disconnect(groupId);
-  }
-  // If group has only one instance left, disconnect
-  else if (group.size === 1) {
-    echarts.disconnect(groupId);
-  }
-  // If group still has multiple instances, reconnect
-  else {
-    echarts.connect(groupId);
-  }
+  syncGroupConnectivity(groupId, group);
 }
 
 /**

--- a/src/utils/instance-cache.ts
+++ b/src/utils/instance-cache.ts
@@ -19,6 +19,15 @@ interface CacheEntry {
 let instanceCache = new WeakMap<HTMLElement, CacheEntry>();
 
 /**
+ * Parallel set to track cached elements for safe iteration on clear.
+ * WeakMap cannot be enumerated, so this Set allows clearInstanceCache
+ * to dispose all live instances before resetting the cache.
+ * 平行集合，用于在清除时安全遍历。WeakMap 无法枚举，
+ * 此 Set 使 clearInstanceCache 能在重置缓存前 dispose 所有存活实例。
+ */
+const trackedElements = new Set<HTMLElement>();
+
+/**
  * Get cached instance for element
  * 获取元素的缓存实例
  * @param element DOM element
@@ -48,6 +57,7 @@ export function setCachedInstance(element: HTMLElement, instance: ECharts): ECha
       instance,
       refCount: 1,
     });
+    trackedElements.add(element);
     return instance;
   }
 }
@@ -70,6 +80,7 @@ export function releaseCachedInstance(element: HTMLElement): void {
     // Dispose instance and remove from cache
     entry.instance.dispose();
     instanceCache.delete(element);
+    trackedElements.delete(element);
   }
 }
 
@@ -84,9 +95,16 @@ export function getReferenceCount(element: HTMLElement): number {
 }
 
 /**
- * Clear all cached instances (for testing/cleanup)
- * 清除所有缓存实例（用于测试/清理）
+ * Clear all cached instances, disposing any that are still alive.
+ * 清除所有缓存实例，dispose 所有仍存活的实例。
  */
 export function clearInstanceCache(): void {
+  for (const element of trackedElements) {
+    const entry = instanceCache.get(element);
+    if (entry) {
+      entry.instance.dispose();
+    }
+  }
+  trackedElements.clear();
   instanceCache = new WeakMap<HTMLElement, CacheEntry>();
 }

--- a/src/utils/shallow-equal.ts
+++ b/src/utils/shallow-equal.ts
@@ -1,0 +1,32 @@
+/**
+ * Shallow equality check for two values.
+ * 两个值的浅比较。
+ *
+ * - Handles null/undefined via Object.is
+ * - For objects: compares own enumerable keys + values with Object.is
+ * - For non-objects (primitives): uses Object.is
+ */
+export function shallowEqual(a: unknown, b: unknown): boolean {
+  if (Object.is(a, b)) return true;
+
+  if (typeof a !== "object" || typeof b !== "object" || a === null || b === null) {
+    return false;
+  }
+
+  const keysA = Object.keys(a);
+  const keysB = Object.keys(b);
+
+  if (keysA.length !== keysB.length) return false;
+
+  const objB = b as Record<string, unknown>;
+  for (const key of keysA) {
+    if (
+      !Object.prototype.hasOwnProperty.call(b, key) ||
+      !Object.is((a as Record<string, unknown>)[key], objB[key])
+    ) {
+      return false;
+    }
+  }
+
+  return true;
+}


### PR DESCRIPTION
## Summary

- Split monolithic `useEcharts` hook (404 → 148 LOC) into orchestrator + 6 focused internal hooks under `src/hooks/internal/`
- Add `shallowEqual` utility for option update deduplication, preventing unnecessary `setOption` calls
- Extract `syncGroupConnectivity` in `connect.ts` to eliminate duplicated connect/disconnect logic
- Fix `clearInstanceCache` to properly dispose all tracked instances before clearing
- Make `EChart` component responsive with `height: 100%` + `minHeight: 400px` (was fixed `400px`)
- Add circular reference protection for theme objects in `JSON.stringify`
- Fix RAF ID not cleared after execution in resize observer

## Test plan

- [x] All 137 tests pass (`vp test run`)
- [x] Zero lint/type errors (`vp check`)
- [x] Build succeeds with correct outputs (`vp pack`)
- [x] `dist/index.d.ts` does not expose any internal hooks
- [x] Coverage: all internal hooks, utils, themes at 100%

🤖 Generated with [Claude Code](https://claude.com/claude-code)