### PR TITLE
docs: simplify README hook example and Other Exports section

### DIFF
--- a/README-zh_CN.md
+++ b/README-zh_CN.md
@@ -75,15 +75,9 @@ import { useEcharts } from "react-use-echarts";
 
 function MyChart() {
   const chartRef = useRef<HTMLDivElement>(null);
-
   const { setOption, getInstance, resize } = useEcharts(chartRef, {
-    option: {
-      xAxis: { type: "category", data: ["Mon", "Tue", "Wed", "Thu", "Fri"] },
-      yAxis: { type: "value" },
-      series: [{ data: [150, 230, 224, 218, 135], type: "line" }],
-    },
+    option: { series: [{ type: "line", data: [150, 230, 224, 218, 135] }] },
   });
-
   return <div ref={chartRef} style={{ width: "100%", height: "400px" }} />;
 }
 ```
@@ -203,34 +197,13 @@ useEcharts(chartRef, {
 ### 其他导出
 
 ```tsx
-// 独立的懒加载 Hook
-import { useLazyInit } from "react-use-echarts";
-const isInView = useLazyInit(elementRef, true);
+import { useLazyInit } from "react-use-echarts"; // 独立的懒加载 Hook
+import { isBuiltinTheme, registerCustomTheme } from "react-use-echarts"; // 主题工具（不含 JSON）
+import { registerBuiltinThemes } from "react-use-echarts/themes/registry"; // 内置主题 JSON（~20KB）
 
-// 主题工具（主入口，轻量，不含 JSON）
-import { isBuiltinTheme, registerCustomTheme } from "react-use-echarts";
-
-// 主题注册表（独立子路径，包含内置主题 JSON）
-import {
-  registerBuiltinThemes, // () => void — 注册内置主题
-  getBuiltinTheme, // (name) => object | null
-  getAvailableThemes, // () => ['light', 'dark', 'macarons']
-} from "react-use-echarts/themes/registry";
-
-// 类型（来自本库）
-import type {
-  UseEchartsOptions,
-  UseEchartsReturn,
-  EChartProps,
-  EChartsEvents,
-  EChartsEventConfig,
-  EChartsInitOpts,
-  BuiltinTheme,
-  LoadingOption,
-} from "react-use-echarts";
-
-// API 签名中使用的类型（来自 echarts 包）
-import type { EChartsOption, SetOptionOpts } from "echarts";
+// 所有导出类型：UseEchartsOptions, UseEchartsReturn, EChartProps,
+// EChartsEvents, EChartsEventConfig, EChartsInitOpts, BuiltinTheme, LoadingOption
+// EChartsOption 和 SetOptionOpts 来自 "echarts" 包。
 ```
 
 ## 贡献

--- a/README.md
+++ b/README.md
@@ -75,15 +75,9 @@ import { useEcharts } from "react-use-echarts";
 
 function MyChart() {
   const chartRef = useRef<HTMLDivElement>(null);
-
   const { setOption, getInstance, resize } = useEcharts(chartRef, {
-    option: {
-      xAxis: { type: "category", data: ["Mon", "Tue", "Wed", "Thu", "Fri"] },
-      yAxis: { type: "value" },
-      series: [{ data: [150, 230, 224, 218, 135], type: "line" }],
-    },
+    option: { series: [{ type: "line", data: [150, 230, 224, 218, 135] }] },
   });
-
   return <div ref={chartRef} style={{ width: "100%", height: "400px" }} />;
 }
 ```
@@ -203,34 +197,13 @@ Declarative component wrapping `useEcharts`. Accepts all hook options as props p
 ### Other Exports
 
 ```tsx
-// Standalone lazy init hook
-import { useLazyInit } from "react-use-echarts";
-const isInView = useLazyInit(elementRef, true);
+import { useLazyInit } from "react-use-echarts"; // standalone lazy init hook
+import { isBuiltinTheme, registerCustomTheme } from "react-use-echarts"; // theme utils (no JSON)
+import { registerBuiltinThemes } from "react-use-echarts/themes/registry"; // ~20KB theme JSON
 
-// Theme utilities (lightweight, from main entry)
-import { isBuiltinTheme, registerCustomTheme } from "react-use-echarts";
-
-// Theme registry (separate entry, includes ~20KB theme JSON)
-import {
-  registerBuiltinThemes, // () => void — register built-in themes
-  getBuiltinTheme, // (name) => object | null
-  getAvailableThemes, // () => ['light', 'dark', 'macarons']
-} from "react-use-echarts/themes/registry";
-
-// Types (from this library)
-import type {
-  UseEchartsOptions,
-  UseEchartsReturn,
-  EChartProps,
-  EChartsEvents,
-  EChartsEventConfig,
-  EChartsInitOpts,
-  BuiltinTheme,
-  LoadingOption,
-} from "react-use-echarts";
-
-// Types used in API signatures (from echarts directly)
-import type { EChartsOption, SetOptionOpts } from "echarts";
+// All exported types: UseEchartsOptions, UseEchartsReturn, EChartProps,
+// EChartsEvents, EChartsEventConfig, EChartsInitOpts, BuiltinTheme, LoadingOption
+// EChartsOption and SetOptionOpts come from the "echarts" package directly.
 ```
 
 ## Contributing


### PR DESCRIPTION
## Summary

- Simplify `useEcharts` hook example in Quick Start — remove duplicate xAxis/yAxis, keep only the essential series
- Condense "Other Exports" section from 30-line code block to 3 import lines + 2-line type comment

## Test plan

- [x] Documentation-only change, no code affected

Made with [Cursor](https://cursor.com)