### PR TITLE
fix: polish examples showcase

### DIFF
--- a/examples/App.tsx
+++ b/examples/App.tsx
@@ -14,14 +14,26 @@ import type { ThemeMode } from "./components/Header";
 import Sidebar, { type NavSection } from "./components/Sidebar";
 import styles from "./app.module.css";
 
-import BarChartSource from "./basic/BarChart.tsx?raw";
-import LineChartSource from "./basic/LineChart.tsx?raw";
-import ComponentRefSource from "./component/ComponentRef.tsx?raw";
-import EventChartSource from "./events/EventChart.tsx?raw";
-import LazyChartsSource from "./lazy/LazyCharts.tsx?raw";
-import LinkedChartsSource from "./linkage/LinkedCharts.tsx?raw";
-import LoadingChartSource from "./loading/LoadingChart.tsx?raw";
-import ThemeSwitcherSource from "./themes/ThemeSwitcher.tsx?raw";
+import BarChartRaw from "./basic/BarChart.tsx?raw";
+import LineChartRaw from "./basic/LineChart.tsx?raw";
+import ComponentRefRaw from "./component/ComponentRef.tsx?raw";
+import EventChartRaw from "./events/EventChart.tsx?raw";
+import LazyChartsRaw from "./lazy/LazyCharts.tsx?raw";
+import LinkedChartsRaw from "./linkage/LinkedCharts.tsx?raw";
+import LoadingChartRaw from "./loading/LoadingChart.tsx?raw";
+import ThemeSwitcherRaw from "./themes/ThemeSwitcher.tsx?raw";
+
+const fixImports = (src: string) =>
+  src.replace(/from ["']\.\.\/\.\.\/src["']/g, 'from "react-use-echarts"');
+
+const BarChartSource = fixImports(BarChartRaw);
+const LineChartSource = fixImports(LineChartRaw);
+const ComponentRefSource = fixImports(ComponentRefRaw);
+const EventChartSource = fixImports(EventChartRaw);
+const LazyChartsSource = fixImports(LazyChartsRaw);
+const LinkedChartsSource = fixImports(LinkedChartsRaw);
+const LoadingChartSource = fixImports(LoadingChartRaw);
+const ThemeSwitcherSource = fixImports(ThemeSwitcherRaw);
 
 const STORAGE_KEY = "rce-theme";
 

--- a/examples/basic/BarChart.tsx
+++ b/examples/basic/BarChart.tsx
@@ -6,7 +6,8 @@ const BarChart: React.FC = () => {
   const chartRef = useRef<HTMLDivElement>(null);
 
   const options: EChartsOption = {
-    title: { text: "Basic Bar Chart Example" },
+    backgroundColor: "transparent",
+    title: { text: "Weekly Sales" },
     tooltip: {},
     xAxis: { data: ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"] },
     yAxis: {},

--- a/examples/basic/LineChart.tsx
+++ b/examples/basic/LineChart.tsx
@@ -6,7 +6,8 @@ const LineChart: React.FC = () => {
   const chartRef = useRef<HTMLDivElement>(null);
 
   const options: EChartsOption = {
-    title: { text: "Basic Line Chart Example (v1.0)" },
+    backgroundColor: "transparent",
+    title: { text: "Weekly Trend" },
     xAxis: {
       type: "category",
       data: ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"],

--- a/examples/component/ComponentRef.tsx
+++ b/examples/component/ComponentRef.tsx
@@ -7,18 +7,37 @@ const ComponentRef: React.FC = () => {
   const chartRef = useRef<UseEchartsReturn>(null);
 
   const option: EChartsOption = {
-    title: { text: "EChart Component with Ref" },
-    tooltip: {},
-    xAxis: { type: "category", data: ["A", "B", "C", "D", "E"] },
-    yAxis: { type: "value" },
-    series: [{ type: "bar", data: [40, 60, 80, 50, 70] }],
+    backgroundColor: "transparent",
+    title: { text: "Traffic Sources", left: "center" },
+    tooltip: { trigger: "item" },
+    legend: { bottom: 0 },
+    series: [
+      {
+        type: "pie",
+        radius: ["40%", "65%"],
+        label: { show: true, formatter: "{b}: {d}%" },
+        data: [
+          { value: 1048, name: "Search" },
+          { value: 735, name: "Direct" },
+          { value: 580, name: "Email" },
+          { value: 484, name: "Social" },
+          { value: 300, name: "Referral" },
+        ],
+      },
+    ],
   };
 
   const handleUpdate = () => {
     chartRef.current?.setOption({
       series: [
         {
-          data: Array.from({ length: 5 }, () => Math.floor(Math.random() * 100)),
+          data: [
+            { value: Math.floor(Math.random() * 1000) + 200, name: "Search" },
+            { value: Math.floor(Math.random() * 800) + 200, name: "Direct" },
+            { value: Math.floor(Math.random() * 600) + 200, name: "Email" },
+            { value: Math.floor(Math.random() * 500) + 200, name: "Social" },
+            { value: Math.floor(Math.random() * 400) + 200, name: "Referral" },
+          ],
         },
       ],
     });

--- a/examples/components/CodeBlock.module.css
+++ b/examples/components/CodeBlock.module.css
@@ -22,6 +22,7 @@
 }
 
 .block {
+  max-height: 400px;
   overflow: auto;
 }
 

--- a/examples/components/CodeBlock.tsx
+++ b/examples/components/CodeBlock.tsx
@@ -77,7 +77,7 @@ const CodeBlock: React.FC<CodeBlockProps> = ({ code, language, themeMode }) => {
     <div className={styles.wrapper}>
       <div className={styles.toolbar}>
         <span className={styles.lang}>{language}</span>
-        <button type="button" className="demo-button" onClick={handleCopy}>
+        <button type="button" className="btn" onClick={handleCopy}>
           {copyLabel}
         </button>
       </div>

--- a/examples/components/DemoCard.module.css
+++ b/examples/components/DemoCard.module.css
@@ -2,6 +2,7 @@
   border: 1px solid var(--c-border);
   border-radius: var(--radius);
   background: var(--c-surface);
+  box-shadow: var(--c-shadow);
   overflow: hidden;
 }
 

--- a/examples/components/Header.module.css
+++ b/examples/components/Header.module.css
@@ -27,6 +27,7 @@
   font-size: 15px;
   font-weight: 600;
   letter-spacing: -0.01em;
+  white-space: nowrap;
 }
 
 .right {
@@ -46,5 +47,10 @@
 @media (max-width: 860px) {
   .burger {
     display: flex;
+    padding: 10px;
+  }
+
+  .name {
+    font-size: 13px;
   }
 }

--- a/examples/components/Header.tsx
+++ b/examples/components/Header.tsx
@@ -13,7 +13,12 @@ const Header: React.FC<HeaderProps> = ({ themeMode, onThemeToggle, onSidebarTogg
   return (
     <header className={styles.bar}>
       <div className={styles.left}>
-        <button type="button" className={styles.burger} onClick={onSidebarToggle}>
+        <button
+          type="button"
+          className={styles.burger}
+          onClick={onSidebarToggle}
+          aria-label="Toggle navigation"
+        >
           <svg
             width="18"
             height="18"
@@ -47,7 +52,12 @@ const Header: React.FC<HeaderProps> = ({ themeMode, onThemeToggle, onSidebarTogg
           </svg>
           GitHub
         </a>
-        <button type="button" className="btn" onClick={onThemeToggle}>
+        <button
+          type="button"
+          className="btn"
+          onClick={onThemeToggle}
+          aria-label={themeMode === "dark" ? "Switch to light mode" : "Switch to dark mode"}
+        >
           {themeMode === "dark" ? (
             <svg
               width="15"

--- a/examples/components/Sidebar.module.css
+++ b/examples/components/Sidebar.module.css
@@ -39,6 +39,11 @@
   background: var(--c-surface-dim);
 }
 
+.link:focus-visible {
+  outline: 2px solid var(--c-accent);
+  outline-offset: -2px;
+}
+
 .active {
   color: var(--c-text);
   font-weight: 600;

--- a/examples/events/EventChart.tsx
+++ b/examples/events/EventChart.tsx
@@ -7,24 +7,42 @@ const EventChart: React.FC = () => {
   const [lastEvent, setLastEvent] = useState<string>("(click on chart)");
 
   const option: EChartsOption = {
-    title: { text: "Click or Hover on Bars" },
-    tooltip: {},
-    xAxis: { type: "category", data: ["Mon", "Tue", "Wed", "Thu", "Fri"] },
-    yAxis: { type: "value" },
-    series: [{ type: "bar", data: [120, 200, 150, 80, 70] }],
+    backgroundColor: "transparent",
+    title: { text: "Click or Hover on Points" },
+    tooltip: { trigger: "item" },
+    xAxis: { type: "value", name: "Height (cm)" },
+    yAxis: { type: "value", name: "Weight (kg)" },
+    series: [
+      {
+        type: "scatter",
+        symbolSize: 14,
+        data: [
+          [168, 65],
+          [170, 70],
+          [172, 68],
+          [175, 80],
+          [178, 75],
+          [180, 82],
+          [182, 78],
+          [165, 58],
+          [173, 72],
+          [177, 76],
+        ],
+      },
+    ],
   };
 
   useEcharts(chartRef, {
     option,
     onEvents: {
       click: (params: unknown) => {
-        const p = params as { name: string; value: number };
-        setLastEvent(`click: ${p.name} = ${p.value}`);
+        const p = params as { value: number[] };
+        setLastEvent(`click: [${p.value[0]}, ${p.value[1]}]`);
       },
       mouseover: {
         handler: (params: unknown) => {
-          const p = params as { name: string };
-          setLastEvent(`mouseover: ${p.name}`);
+          const p = params as { value: number[] };
+          setLastEvent(`mouseover: [${p.value[0]}, ${p.value[1]}]`);
         },
         query: "series",
       },

--- a/examples/global.css
+++ b/examples/global.css
@@ -40,6 +40,12 @@ html {
   scroll-padding-top: calc(var(--header-height) + 20px);
 }
 
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+}
+
 body {
   font-family: var(--sans);
   font-size: 14px;
@@ -78,6 +84,11 @@ button {
 .btn:hover {
   border-color: var(--c-text-2);
   background: var(--c-surface-dim);
+}
+
+.btn:focus-visible {
+  outline: 2px solid var(--c-accent);
+  outline-offset: 2px;
 }
 
 .chart-container {
@@ -123,5 +134,10 @@ button {
 @media (max-width: 860px) {
   .grid-2 {
     grid-template-columns: 1fr;
+  }
+
+  .btn {
+    padding: 10px 14px;
+    font-size: 14px;
   }
 }

--- a/examples/lazy/LazyCharts.tsx
+++ b/examples/lazy/LazyCharts.tsx
@@ -2,21 +2,131 @@ import React, { useRef } from "react";
 import { useEcharts } from "../../src";
 import type { EChartsOption } from "echarts";
 
-function LazyChart({ index }: { index: number }) {
-  const chartRef = useRef<HTMLDivElement>(null);
-
-  const option: EChartsOption = {
-    title: { text: `Lazy Chart #${index + 1}` },
+const CHART_CONFIGS: (() => EChartsOption)[] = [
+  () => ({
+    backgroundColor: "transparent",
+    title: { text: "Lazy Chart #1 — Bar" },
     tooltip: {},
     xAxis: { type: "category", data: ["A", "B", "C", "D", "E"] },
     yAxis: { type: "value" },
+    series: [{ type: "bar", data: randArray(5, 100) }],
+  }),
+  () => ({
+    backgroundColor: "transparent",
+    title: { text: "Lazy Chart #2 — Line" },
+    tooltip: { trigger: "axis" },
+    xAxis: { type: "category", data: ["Mon", "Tue", "Wed", "Thu", "Fri"] },
+    yAxis: { type: "value" },
+    series: [{ type: "line", smooth: true, data: randArray(5, 80) }],
+  }),
+  () => ({
+    backgroundColor: "transparent",
+    title: { text: "Lazy Chart #3 — Pie", left: "center" },
+    tooltip: { trigger: "item" },
     series: [
       {
-        type: "bar",
-        data: Array.from({ length: 5 }, () => Math.floor(Math.random() * 100)),
+        type: "pie",
+        radius: "55%",
+        data: [
+          { value: rand(500), name: "Email" },
+          { value: rand(400), name: "Social" },
+          { value: rand(300), name: "Direct" },
+          { value: rand(200), name: "Search" },
+        ],
       },
     ],
-  };
+  }),
+  () => ({
+    backgroundColor: "transparent",
+    title: { text: "Lazy Chart #4 — Area" },
+    tooltip: { trigger: "axis" },
+    xAxis: { type: "category", data: ["Jan", "Feb", "Mar", "Apr", "May"] },
+    yAxis: { type: "value" },
+    series: [{ type: "line", areaStyle: { opacity: 0.4 }, smooth: true, data: randArray(5, 60) }],
+  }),
+  () => ({
+    backgroundColor: "transparent",
+    title: { text: "Lazy Chart #5 — Scatter" },
+    tooltip: { trigger: "item" },
+    xAxis: { type: "value" },
+    yAxis: { type: "value" },
+    series: [
+      {
+        type: "scatter",
+        symbolSize: 10,
+        data: Array.from({ length: 15 }, () => [rand(100), rand(100)]),
+      },
+    ],
+  }),
+  () => ({
+    backgroundColor: "transparent",
+    title: { text: "Lazy Chart #6 — Bar (horizontal)" },
+    tooltip: {},
+    xAxis: { type: "value" },
+    yAxis: { type: "category", data: ["Q1", "Q2", "Q3", "Q4"] },
+    series: [{ type: "bar", data: randArray(4, 120) }],
+  }),
+  () => ({
+    backgroundColor: "transparent",
+    title: { text: "Lazy Chart #7 — Stacked Line" },
+    tooltip: { trigger: "axis" },
+    legend: { bottom: 0 },
+    xAxis: { type: "category", data: ["A", "B", "C", "D"] },
+    yAxis: { type: "value" },
+    series: [
+      { name: "Series 1", type: "line", stack: "total", data: randArray(4, 50) },
+      { name: "Series 2", type: "line", stack: "total", data: randArray(4, 50) },
+    ],
+  }),
+  () => ({
+    backgroundColor: "transparent",
+    title: { text: "Lazy Chart #8 — Donut", left: "center" },
+    tooltip: { trigger: "item" },
+    series: [
+      {
+        type: "pie",
+        radius: ["35%", "55%"],
+        data: [
+          { value: rand(400), name: "Chrome" },
+          { value: rand(300), name: "Firefox" },
+          { value: rand(200), name: "Safari" },
+        ],
+      },
+    ],
+  }),
+  () => ({
+    backgroundColor: "transparent",
+    title: { text: "Lazy Chart #9 — Multi-bar" },
+    tooltip: { trigger: "axis" },
+    legend: { bottom: 0 },
+    xAxis: { type: "category", data: ["Jan", "Feb", "Mar", "Apr"] },
+    yAxis: { type: "value" },
+    series: [
+      { name: "2024", type: "bar", data: randArray(4, 80) },
+      { name: "2025", type: "bar", data: randArray(4, 80) },
+    ],
+  }),
+  () => ({
+    backgroundColor: "transparent",
+    title: { text: "Lazy Chart #10 — Smooth Line" },
+    tooltip: { trigger: "axis" },
+    xAxis: { type: "category", data: ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"] },
+    yAxis: { type: "value" },
+    series: [{ type: "line", smooth: true, data: randArray(7, 90) }],
+  }),
+];
+
+function rand(max: number) {
+  return Math.floor(Math.random() * max) + 10;
+}
+
+function randArray(len: number, max: number) {
+  return Array.from({ length: len }, () => rand(max));
+}
+
+function LazyChart({ index }: { index: number }) {
+  const chartRef = useRef<HTMLDivElement>(null);
+  const option = CHART_CONFIGS[index]();
 
   useEcharts(chartRef, { option, lazyInit: true });
 
@@ -29,7 +139,7 @@ const LazyCharts: React.FC = () => {
       <p className="note-box" style={{ marginBottom: 10 }}>
         Scroll down to see charts initialize lazily:
       </p>
-      {Array.from({ length: 10 }, (_, i) => (
+      {CHART_CONFIGS.map((_, i) => (
         <div key={i} style={{ marginBottom: 12 }}>
           <LazyChart index={i} />
         </div>

--- a/examples/linkage/LinkedCharts.tsx
+++ b/examples/linkage/LinkedCharts.tsx
@@ -7,7 +7,8 @@ const LinkedCharts: React.FC = () => {
   const chartRef2 = useRef<HTMLDivElement>(null);
 
   const option1: EChartsOption = {
-    title: { text: "Chart A (linked)" },
+    backgroundColor: "transparent",
+    title: { text: "Revenue (linked)" },
     tooltip: { trigger: "axis" },
     xAxis: { type: "category", data: ["Jan", "Feb", "Mar", "Apr", "May", "Jun"] },
     yAxis: { type: "value" },
@@ -15,11 +16,14 @@ const LinkedCharts: React.FC = () => {
   };
 
   const option2: EChartsOption = {
-    title: { text: "Chart B (linked)" },
+    backgroundColor: "transparent",
+    title: { text: "Growth Rate (linked)" },
     tooltip: { trigger: "axis" },
     xAxis: { type: "category", data: ["Jan", "Feb", "Mar", "Apr", "May", "Jun"] },
     yAxis: { type: "value" },
-    series: [{ type: "line", data: [30, 60, 40, 80, 50, 70] }],
+    series: [
+      { type: "line", areaStyle: { opacity: 0.3 }, smooth: true, data: [30, 60, 40, 80, 50, 70] },
+    ],
   };
 
   useEcharts(chartRef1, { option: option1, group: "dashboard" });

--- a/examples/loading/LoadingChart.tsx
+++ b/examples/loading/LoadingChart.tsx
@@ -7,7 +7,8 @@ const LoadingChart: React.FC = () => {
   const [loading, setLoading] = useState(true);
 
   const option: EChartsOption = {
-    title: { text: "Loading State Demo" },
+    backgroundColor: "transparent",
+    title: { text: "Quarterly Revenue" },
     tooltip: {},
     xAxis: { type: "category", data: ["Q1", "Q2", "Q3", "Q4"] },
     yAxis: { type: "value" },

--- a/examples/themes/ThemeSwitcher.tsx
+++ b/examples/themes/ThemeSwitcher.tsx
@@ -11,7 +11,6 @@ const ThemeSwitcher: React.FC = () => {
   const customTheme = useMemo(
     () => ({
       color: ["#fc8452", "#9a60b4", "#ea7ccc", "#73c0de"],
-      backgroundColor: "#fafafa",
     }),
     [],
   );
@@ -20,6 +19,7 @@ const ThemeSwitcher: React.FC = () => {
   const theme = currentTheme === "custom" ? customTheme : currentTheme;
 
   const option: EChartsOption = {
+    backgroundColor: "transparent",
     title: { text: `Theme: ${currentTheme}` },
     tooltip: { trigger: "axis" },
     xAxis: { type: "category", data: ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"] },
@@ -40,7 +40,15 @@ const ThemeSwitcher: React.FC = () => {
             key={t}
             onClick={() => setThemeIndex(i)}
             className="btn"
-            style={{ fontWeight: i === themeIndex ? 700 : 400 }}
+            style={
+              i === themeIndex
+                ? {
+                    fontWeight: 700,
+                    background: "var(--c-accent-soft)",
+                    borderColor: "var(--c-text-2)",
+                  }
+                : undefined
+            }
           >
             {t}
           </button>

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -23,6 +23,6 @@
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true
   },
-  "include": ["src"],
+  "include": ["src", "examples"],
   "exclude": ["src/__tests__"]
 }


### PR DESCRIPTION
## Summary
- Replace import paths from `../../src` to `react-use-echarts` in code display so users can copy working code
- Diversify chart types across demos: scatter (events), donut (component), area (linkage), 10 varied lazy charts (bar, line, pie, area, scatter, horizontal bar, stacked line, donut, multi-bar, smooth line)
- Fix dark mode chart backgrounds with `backgroundColor: transparent` — no more white rectangles in dark cards
- Add accessibility: `:focus-visible` indicators, `aria-label` on icon buttons, increased mobile touch targets (44px), `prefers-reduced-motion` support
- Cap code panel height at 400px with scroll overflow
- Fix undefined `demo-button` class → `btn`, clean up placeholder chart titles, activate `--c-shadow` on cards
- Include `examples/` in `tsconfig.app.json` for proper type checking

## Test plan
- [x] `vp check` passes (format + lint + typecheck)
- [x] `vp test run` passes (170 tests)
- [x] `vp build` succeeds
- [x] Visual verification: light mode, dark mode, mobile, code view, theme switcher active state
- [ ] Verify on GitHub Pages after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)