### PR TITLE
chore: bump @rolldown/plugin-babel to ^0.2.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
   },
   "devDependencies": {
     "@babel/core": "^7.29.0",
-    "@rolldown/plugin-babel": "^0.2.2",
+    "@rolldown/plugin-babel": "^0.2.3",
     "@shikijs/langs": "^4.0.2",
     "@shikijs/themes": "^4.0.2",
     "@testing-library/react": "^16.3.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^7.29.0
         version: 7.29.0
       '@rolldown/plugin-babel':
-        specifier: ^0.2.2
-        version: 0.2.2(@babel/core@7.29.0)(@babel/runtime@7.29.2)(@voidzero-dev/vite-plus-core@0.1.16(@types/node@25.6.0)(typescript@6.0.2)(yaml@2.8.2))(rolldown@1.0.0-rc.10)
+        specifier: ^0.2.3
+        version: 0.2.3(@babel/core@7.29.0)(@babel/runtime@7.29.2)(@voidzero-dev/vite-plus-core@0.1.16(@types/node@25.6.0)(typescript@6.0.2)(yaml@2.8.2))(rolldown@1.0.0-rc.10)
       '@shikijs/langs':
         specifier: ^4.0.2
         version: 4.0.2
@@ -34,7 +34,7 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       '@vitejs/plugin-react':
         specifier: ^6.0.1
-        version: 6.0.1(@rolldown/plugin-babel@0.2.2(@babel/core@7.29.0)(@babel/runtime@7.29.2)(@voidzero-dev/vite-plus-core@0.1.16(@types/node@25.6.0)(typescript@6.0.2)(yaml@2.8.2))(rolldown@1.0.0-rc.10))(@voidzero-dev/vite-plus-core@0.1.16(@types/node@25.6.0)(typescript@6.0.2)(yaml@2.8.2))(babel-plugin-react-compiler@1.0.0)
+        version: 6.0.1(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.0)(@babel/runtime@7.29.2)(@voidzero-dev/vite-plus-core@0.1.16(@types/node@25.6.0)(typescript@6.0.2)(yaml@2.8.2))(rolldown@1.0.0-rc.10))(@voidzero-dev/vite-plus-core@0.1.16(@types/node@25.6.0)(typescript@6.0.2)(yaml@2.8.2))(babel-plugin-react-compiler@1.0.0)
       '@vitest/coverage-v8':
         specifier: ^4.1.4
         version: 4.1.4(@voidzero-dev/vite-plus-test@0.1.16(@types/node@25.6.0)(@voidzero-dev/vite-plus-core@0.1.16(@types/node@25.6.0)(typescript@6.0.2)(yaml@2.8.2))(jsdom@29.0.2)(typescript@6.0.2)(yaml@2.8.2))
@@ -616,8 +616,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@rolldown/plugin-babel@0.2.2':
-    resolution: {integrity: sha512-q9pE8+47bQNHb5eWVcE6oXppA+JTSwvnrhH53m0ZuHuK5MLvwsLoWrWzBTFQqQ06BVxz1gp0HblLsch8o6pvZw==}
+  '@rolldown/plugin-babel@0.2.3':
+    resolution: {integrity: sha512-+zEk16yGlz1F9STiRr6uG9hmIXb6nprjLczV/htGptYuLoCuxb+itZ03RKCEeOhBpDDd1NU7qF6x1VLMUp62bw==}
     engines: {node: '>=22.12.0 || ^24.0.0'}
     peerDependencies:
       '@babel/core': ^7.29.0 || ^8.0.0-rc.1
@@ -1866,7 +1866,7 @@ snapshots:
   '@rolldown/binding-win32-x64-msvc@1.0.0-rc.10':
     optional: true
 
-  '@rolldown/plugin-babel@0.2.2(@babel/core@7.29.0)(@babel/runtime@7.29.2)(@voidzero-dev/vite-plus-core@0.1.16(@types/node@25.6.0)(typescript@6.0.2)(yaml@2.8.2))(rolldown@1.0.0-rc.10)':
+  '@rolldown/plugin-babel@0.2.3(@babel/core@7.29.0)(@babel/runtime@7.29.2)(@voidzero-dev/vite-plus-core@0.1.16(@types/node@25.6.0)(typescript@6.0.2)(yaml@2.8.2))(rolldown@1.0.0-rc.10)':
     dependencies:
       '@babel/core': 7.29.0
       picomatch: 4.0.4
@@ -1982,12 +1982,12 @@ snapshots:
 
   '@ungap/structured-clone@1.3.0': {}
 
-  '@vitejs/plugin-react@6.0.1(@rolldown/plugin-babel@0.2.2(@babel/core@7.29.0)(@babel/runtime@7.29.2)(@voidzero-dev/vite-plus-core@0.1.16(@types/node@25.6.0)(typescript@6.0.2)(yaml@2.8.2))(rolldown@1.0.0-rc.10))(@voidzero-dev/vite-plus-core@0.1.16(@types/node@25.6.0)(typescript@6.0.2)(yaml@2.8.2))(babel-plugin-react-compiler@1.0.0)':
+  '@vitejs/plugin-react@6.0.1(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.0)(@babel/runtime@7.29.2)(@voidzero-dev/vite-plus-core@0.1.16(@types/node@25.6.0)(typescript@6.0.2)(yaml@2.8.2))(rolldown@1.0.0-rc.10))(@voidzero-dev/vite-plus-core@0.1.16(@types/node@25.6.0)(typescript@6.0.2)(yaml@2.8.2))(babel-plugin-react-compiler@1.0.0)':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-rc.7
       vite: '@voidzero-dev/vite-plus-core@0.1.16(@types/node@25.6.0)(typescript@6.0.2)(yaml@2.8.2)'
     optionalDependencies:
-      '@rolldown/plugin-babel': 0.2.2(@babel/core@7.29.0)(@babel/runtime@7.29.2)(@voidzero-dev/vite-plus-core@0.1.16(@types/node@25.6.0)(typescript@6.0.2)(yaml@2.8.2))(rolldown@1.0.0-rc.10)
+      '@rolldown/plugin-babel': 0.2.3(@babel/core@7.29.0)(@babel/runtime@7.29.2)(@voidzero-dev/vite-plus-core@0.1.16(@types/node@25.6.0)(typescript@6.0.2)(yaml@2.8.2))(rolldown@1.0.0-rc.10)
       babel-plugin-react-compiler: 1.0.0
 
   '@vitest/coverage-v8@4.1.4(@voidzero-dev/vite-plus-test@0.1.16(@types/node@25.6.0)(@voidzero-dev/vite-plus-core@0.1.16(@types/node@25.6.0)(typescript@6.0.2)(yaml@2.8.2))(jsdom@29.0.2)(typescript@6.0.2)(yaml@2.8.2))':


### PR DESCRIPTION
## Summary
- Bump `@rolldown/plugin-babel` from `^0.2.2` to `^0.2.3` (patch release)

## Test plan
- [x] `vp check` — format + lint + typecheck pass
- [x] `vp test run` — 170/170 tests pass
- [x] `vp pack` — library build succeeds (ESM 23.71 kB / UMD 26.53 kB)

🤖 Generated with [Claude Code](https://claude.com/claude-code)