### PR TITLE
feat: enrich examples with hero, gallery, dynamic data, renderer, and footer

### DIFF
--- a/examples/App.tsx
+++ b/examples/App.tsx
@@ -2,25 +2,43 @@ import React, { useEffect, useMemo, useState } from "react";
 import BarChart from "./basic/BarChart";
 import LineChart from "./basic/LineChart";
 import ComponentRef from "./component/ComponentRef";
+import DynamicChart from "./dynamic/DynamicChart";
 import EventChart from "./events/EventChart";
+import CandlestickChart from "./gallery/CandlestickChart";
+import FunnelChart from "./gallery/FunnelChart";
+import GaugeChart from "./gallery/GaugeChart";
+import HeatmapChart from "./gallery/HeatmapChart";
+import RadarChart from "./gallery/RadarChart";
+import TreemapChart from "./gallery/TreemapChart";
 import LazyCharts from "./lazy/LazyCharts";
 import LinkedCharts from "./linkage/LinkedCharts";
 import LoadingChart from "./loading/LoadingChart";
+import RendererToggle from "./renderer/RendererToggle";
 import ThemeSwitcher from "./themes/ThemeSwitcher";
 import DemoCard from "./components/DemoCard";
 import DemoSection from "./components/DemoSection";
+import Footer from "./components/Footer";
 import Header from "./components/Header";
 import type { ThemeMode } from "./components/Header";
+import Hero from "./components/Hero";
 import Sidebar, { type NavSection } from "./components/Sidebar";
 import styles from "./app.module.css";
 
 import BarChartRaw from "./basic/BarChart.tsx?raw";
 import LineChartRaw from "./basic/LineChart.tsx?raw";
 import ComponentRefRaw from "./component/ComponentRef.tsx?raw";
+import DynamicChartRaw from "./dynamic/DynamicChart.tsx?raw";
 import EventChartRaw from "./events/EventChart.tsx?raw";
+import CandlestickChartRaw from "./gallery/CandlestickChart.tsx?raw";
+import FunnelChartRaw from "./gallery/FunnelChart.tsx?raw";
+import GaugeChartRaw from "./gallery/GaugeChart.tsx?raw";
+import HeatmapChartRaw from "./gallery/HeatmapChart.tsx?raw";
+import RadarChartRaw from "./gallery/RadarChart.tsx?raw";
+import TreemapChartRaw from "./gallery/TreemapChart.tsx?raw";
 import LazyChartsRaw from "./lazy/LazyCharts.tsx?raw";
 import LinkedChartsRaw from "./linkage/LinkedCharts.tsx?raw";
 import LoadingChartRaw from "./loading/LoadingChart.tsx?raw";
+import RendererToggleRaw from "./renderer/RendererToggle.tsx?raw";
 import ThemeSwitcherRaw from "./themes/ThemeSwitcher.tsx?raw";
 
 const fixImports = (src: string) =>
@@ -29,10 +47,18 @@ const fixImports = (src: string) =>
 const BarChartSource = fixImports(BarChartRaw);
 const LineChartSource = fixImports(LineChartRaw);
 const ComponentRefSource = fixImports(ComponentRefRaw);
+const DynamicChartSource = fixImports(DynamicChartRaw);
 const EventChartSource = fixImports(EventChartRaw);
+const CandlestickChartSource = fixImports(CandlestickChartRaw);
+const FunnelChartSource = fixImports(FunnelChartRaw);
+const GaugeChartSource = fixImports(GaugeChartRaw);
+const HeatmapChartSource = fixImports(HeatmapChartRaw);
+const RadarChartSource = fixImports(RadarChartRaw);
+const TreemapChartSource = fixImports(TreemapChartRaw);
 const LazyChartsSource = fixImports(LazyChartsRaw);
 const LinkedChartsSource = fixImports(LinkedChartsRaw);
 const LoadingChartSource = fixImports(LoadingChartRaw);
+const RendererToggleSource = fixImports(RendererToggleRaw);
 const ThemeSwitcherSource = fixImports(ThemeSwitcherRaw);
 
 const STORAGE_KEY = "rce-theme";
@@ -51,9 +77,25 @@ const sections: readonly (NavSection & { description: string })[] = [
     description: "Line and bar charts with auto resize and reactive options.",
   },
   {
+    id: "gallery",
+    title: "Gallery",
+    description:
+      "Diverse chart types powered by ECharts — radar, gauge, K-line, heatmap, and more.",
+  },
+  {
+    id: "dynamic",
+    title: "Dynamic Data",
+    description: "Real-time data updates via setOption for live monitoring scenarios.",
+  },
+  {
     id: "themes",
     title: "Themes",
     description: "Switch between built-in and custom themes at runtime.",
+  },
+  {
+    id: "renderer",
+    title: "Renderer",
+    description: "Canvas vs SVG — choose the right renderer for your use case.",
   },
   {
     id: "linkage",
@@ -114,6 +156,8 @@ const App: React.FC = () => {
 
         <main className={styles.main} onClick={() => setSidebarOpen(false)}>
           <div className={styles.inner}>
+            <Hero />
+
             <DemoSection id="basic" title="Basic Usage" description={sections[0].description}>
               <DemoCard
                 title="Bar Chart"
@@ -135,7 +179,82 @@ const App: React.FC = () => {
               </DemoCard>
             </DemoSection>
 
-            <DemoSection id="themes" title="Themes" description={sections[1].description}>
+            <DemoSection id="gallery" title="Gallery" description={sections[1].description}>
+              <div className="grid-2">
+                <DemoCard
+                  title="Radar"
+                  description="Multi-dimensional comparison."
+                  sourceCode={RadarChartSource}
+                  sourcePath="examples/gallery/RadarChart.tsx"
+                  themeMode={themeMode}
+                >
+                  <RadarChart />
+                </DemoCard>
+                <DemoCard
+                  title="Gauge"
+                  description="Single-value indicator."
+                  sourceCode={GaugeChartSource}
+                  sourcePath="examples/gallery/GaugeChart.tsx"
+                  themeMode={themeMode}
+                >
+                  <GaugeChart />
+                </DemoCard>
+              </div>
+              <div className="grid-2">
+                <DemoCard
+                  title="Candlestick"
+                  description="Financial OHLC data."
+                  sourceCode={CandlestickChartSource}
+                  sourcePath="examples/gallery/CandlestickChart.tsx"
+                  themeMode={themeMode}
+                >
+                  <CandlestickChart />
+                </DemoCard>
+                <DemoCard
+                  title="Heatmap"
+                  description="Matrix density visualization."
+                  sourceCode={HeatmapChartSource}
+                  sourcePath="examples/gallery/HeatmapChart.tsx"
+                  themeMode={themeMode}
+                >
+                  <HeatmapChart />
+                </DemoCard>
+              </div>
+              <div className="grid-2">
+                <DemoCard
+                  title="Funnel"
+                  description="Conversion funnel analysis."
+                  sourceCode={FunnelChartSource}
+                  sourcePath="examples/gallery/FunnelChart.tsx"
+                  themeMode={themeMode}
+                >
+                  <FunnelChart />
+                </DemoCard>
+                <DemoCard
+                  title="Treemap"
+                  description="Hierarchical data proportions."
+                  sourceCode={TreemapChartSource}
+                  sourcePath="examples/gallery/TreemapChart.tsx"
+                  themeMode={themeMode}
+                >
+                  <TreemapChart />
+                </DemoCard>
+              </div>
+            </DemoSection>
+
+            <DemoSection id="dynamic" title="Dynamic Data" description={sections[2].description}>
+              <DemoCard
+                title="Real-time Monitor"
+                description="Live data stream with setOption."
+                sourceCode={DynamicChartSource}
+                sourcePath="examples/dynamic/DynamicChart.tsx"
+                themeMode={themeMode}
+              >
+                <DynamicChart />
+              </DemoCard>
+            </DemoSection>
+
+            <DemoSection id="themes" title="Themes" description={sections[3].description}>
               <DemoCard
                 title="Theme Switcher"
                 sourceCode={ThemeSwitcherSource}
@@ -146,7 +265,18 @@ const App: React.FC = () => {
               </DemoCard>
             </DemoSection>
 
-            <DemoSection id="linkage" title="Chart Linkage" description={sections[2].description}>
+            <DemoSection id="renderer" title="Renderer" description={sections[4].description}>
+              <DemoCard
+                title="Canvas vs SVG"
+                sourceCode={RendererToggleSource}
+                sourcePath="examples/renderer/RendererToggle.tsx"
+                themeMode={themeMode}
+              >
+                <RendererToggle />
+              </DemoCard>
+            </DemoSection>
+
+            <DemoSection id="linkage" title="Chart Linkage" description={sections[5].description}>
               <DemoCard
                 title="Linked Charts"
                 description="Same group syncs tooltips."
@@ -158,7 +288,7 @@ const App: React.FC = () => {
               </DemoCard>
             </DemoSection>
 
-            <DemoSection id="events" title="Events" description={sections[3].description}>
+            <DemoSection id="events" title="Events" description={sections[6].description}>
               <DemoCard
                 title="Click + Hover"
                 sourceCode={EventChartSource}
@@ -169,7 +299,7 @@ const App: React.FC = () => {
               </DemoCard>
             </DemoSection>
 
-            <DemoSection id="loading" title="Loading" description={sections[4].description}>
+            <DemoSection id="loading" title="Loading" description={sections[7].description}>
               <DemoCard
                 title="Toggle Loading"
                 sourceCode={LoadingChartSource}
@@ -180,7 +310,7 @@ const App: React.FC = () => {
               </DemoCard>
             </DemoSection>
 
-            <DemoSection id="component" title="Component" description={sections[5].description}>
+            <DemoSection id="component" title="Component" description={sections[8].description}>
               <DemoCard
                 title="Component + Ref"
                 description="Imperative setOption and resize."
@@ -192,7 +322,7 @@ const App: React.FC = () => {
               </DemoCard>
             </DemoSection>
 
-            <DemoSection id="lazy" title="Lazy Init" description={sections[6].description}>
+            <DemoSection id="lazy" title="Lazy Init" description={sections[9].description}>
               <DemoCard
                 title="Lazy Charts"
                 description="Scroll to init."
@@ -203,6 +333,8 @@ const App: React.FC = () => {
                 <LazyCharts />
               </DemoCard>
             </DemoSection>
+
+            <Footer />
           </div>
         </main>
       </div>

--- a/examples/app.module.css
+++ b/examples/app.module.css
@@ -6,12 +6,12 @@
 }
 
 .main {
-  padding: 32px 36px 64px;
+  padding: 24px 36px 48px;
   min-width: 0;
 }
 
 .inner {
-  max-width: 960px;
+  max-width: 1080px;
   margin: 0 auto;
 }
 

--- a/examples/components/DemoSection.module.css
+++ b/examples/components/DemoSection.module.css
@@ -1,5 +1,5 @@
 .section {
-  margin-bottom: 40px;
+  margin-bottom: 32px;
 }
 
 .section:last-child {

--- a/examples/components/Footer.module.css
+++ b/examples/components/Footer.module.css
@@ -1,0 +1,34 @@
+.footer {
+  margin-top: 32px;
+  padding: 24px 0;
+  border-top: 1px solid var(--c-border);
+  text-align: center;
+}
+
+.links {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 8px;
+  font-size: 13px;
+}
+
+.links a {
+  color: var(--c-text-2);
+  transition: color 0.15s;
+}
+
+.links a:hover {
+  color: var(--c-text);
+}
+
+.dot {
+  color: var(--c-text-2);
+}
+
+.copy {
+  font-size: 12px;
+  color: var(--c-text-2);
+  margin: 0;
+}

--- a/examples/components/Footer.tsx
+++ b/examples/components/Footer.tsx
@@ -1,0 +1,29 @@
+import React from "react";
+import styles from "./Footer.module.css";
+
+const Footer: React.FC = () => {
+  return (
+    <footer className={styles.footer}>
+      <div className={styles.links}>
+        <a href="https://www.npmjs.com/package/react-use-echarts" target="_blank" rel="noreferrer">
+          npm
+        </a>
+        <span className={styles.dot}>·</span>
+        <a href="https://github.com/chensid/react-use-echarts" target="_blank" rel="noreferrer">
+          GitHub
+        </a>
+        <span className={styles.dot}>·</span>
+        <a
+          href="https://github.com/chensid/react-use-echarts#api-reference"
+          target="_blank"
+          rel="noreferrer"
+        >
+          API Reference
+        </a>
+      </div>
+      <p className={styles.copy}>MIT License · Built with React + ECharts</p>
+    </footer>
+  );
+};
+
+export default Footer;

--- a/examples/components/Hero.module.css
+++ b/examples/components/Hero.module.css
@@ -1,0 +1,109 @@
+.hero {
+  text-align: center;
+  padding: 32px 0 28px;
+  margin-bottom: 28px;
+  border-bottom: 1px solid var(--c-border);
+}
+
+.badges {
+  display: flex;
+  justify-content: center;
+  gap: 8px;
+  margin-bottom: 20px;
+  flex-wrap: wrap;
+}
+
+.title {
+  font-size: 32px;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  margin: 0 0 8px;
+}
+
+.tagline {
+  font-size: 15px;
+  color: var(--c-text-2);
+  margin: 0 0 16px;
+  max-width: 480px;
+  margin-left: auto;
+  margin-right: auto;
+  line-height: 1.5;
+}
+
+.features {
+  display: flex;
+  justify-content: center;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-bottom: 18px;
+}
+
+.tag {
+  display: inline-block;
+  padding: 4px 10px;
+  font-size: 12px;
+  font-weight: 500;
+  border: 1px solid var(--c-border);
+  border-radius: 100px;
+  color: var(--c-text-2);
+  background: var(--c-surface);
+}
+
+.install {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 6px 6px 14px;
+  background: var(--c-surface-dim);
+  border: 1px solid var(--c-border);
+  border-radius: var(--radius);
+  margin-bottom: 18px;
+}
+
+.cmd {
+  font-family: var(--mono);
+  font-size: 13px;
+  color: var(--c-text);
+  user-select: all;
+}
+
+.cta {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 18px;
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--c-bg);
+  background: var(--c-accent);
+  border-radius: var(--radius);
+  transition:
+    opacity 0.15s,
+    transform 0.15s;
+}
+
+.cta:hover {
+  opacity: 0.85;
+  transform: translateY(-1px);
+}
+
+@media (max-width: 860px) {
+  .hero {
+    padding: 24px 0 20px;
+    margin-bottom: 20px;
+  }
+
+  .title {
+    font-size: 24px;
+  }
+
+  .tagline {
+    font-size: 14px;
+  }
+
+  .install {
+    flex-direction: column;
+    gap: 6px;
+    padding: 10px;
+  }
+}

--- a/examples/components/Hero.tsx
+++ b/examples/components/Hero.tsx
@@ -1,0 +1,115 @@
+import React, { useState } from "react";
+import styles from "./Hero.module.css";
+
+const INSTALL_CMD = "npm install react-use-echarts echarts";
+
+const FEATURES = [
+  "TypeScript",
+  "Auto-resize",
+  "Themes",
+  "Zero Deps",
+  "Lazy Init",
+  "StrictMode Safe",
+] as const;
+
+const Hero: React.FC = () => {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(INSTALL_CMD);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 1500);
+    } catch {
+      /* noop */
+    }
+  };
+
+  return (
+    <section className={styles.hero}>
+      <div className={styles.badges}>
+        <img
+          src="https://img.shields.io/npm/v/react-use-echarts.svg"
+          alt="npm version"
+          height="20"
+        />
+        <img
+          src="https://img.shields.io/npm/dm/react-use-echarts.svg"
+          alt="npm downloads"
+          height="20"
+        />
+        <img
+          src="https://img.shields.io/github/stars/chensid/react-use-echarts?style=social"
+          alt="GitHub stars"
+          height="20"
+        />
+      </div>
+
+      <h1 className={styles.title}>react-use-echarts</h1>
+      <p className={styles.tagline}>
+        React hooks &amp; component for Apache ECharts — TypeScript, auto-resize, themes, lazy init.
+      </p>
+
+      <div className={styles.features}>
+        {FEATURES.map((f) => (
+          <span key={f} className={styles.tag}>
+            {f}
+          </span>
+        ))}
+      </div>
+
+      <div className={styles.install}>
+        <code className={styles.cmd}>{INSTALL_CMD}</code>
+        <button type="button" className="btn" onClick={handleCopy}>
+          {copied ? (
+            <svg
+              width="14"
+              height="14"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <polyline points="20 6 9 17 4 12" />
+            </svg>
+          ) : (
+            <svg
+              width="14"
+              height="14"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
+              <path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1" />
+            </svg>
+          )}
+          {copied ? "Copied" : "Copy"}
+        </button>
+      </div>
+
+      <a href="#basic" className={styles.cta}>
+        Get Started
+        <svg
+          width="14"
+          height="14"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <path d="M7 17l9.2-9.2M17 17V7H7" />
+        </svg>
+      </a>
+    </section>
+  );
+};
+
+export default Hero;

--- a/examples/dynamic/DynamicChart.tsx
+++ b/examples/dynamic/DynamicChart.tsx
@@ -1,0 +1,91 @@
+import React, { useCallback, useEffect, useRef, useState } from "react";
+import { useEcharts } from "../../src";
+import type { EChartsOption } from "echarts";
+
+function formatTime(date: Date) {
+  return date.toLocaleTimeString("en-US", { hour12: false });
+}
+
+function randomValue(base: number) {
+  return +(base + (Math.random() - 0.5) * 20).toFixed(1);
+}
+
+const INITIAL_COUNT = 20;
+
+function generateInitialData() {
+  const now = Date.now();
+  const times: string[] = [];
+  const values: number[] = [];
+  for (let i = INITIAL_COUNT - 1; i >= 0; i--) {
+    times.push(formatTime(new Date(now - i * 1000)));
+    values.push(randomValue(50));
+  }
+  return { times, values };
+}
+
+const DynamicChart: React.FC = () => {
+  const chartRef = useRef<HTMLDivElement>(null);
+  const [running, setRunning] = useState(true);
+  const [count, setCount] = useState(INITIAL_COUNT);
+  const dataRef = useRef(generateInitialData());
+
+  const optionRef = useRef<EChartsOption>({
+    backgroundColor: "transparent",
+    title: { text: "Real-time Monitor" },
+    tooltip: { trigger: "axis" },
+    xAxis: { type: "category", data: dataRef.current.times, boundaryGap: false },
+    yAxis: { type: "value", min: 20, max: 80 },
+    series: [
+      {
+        type: "line",
+        data: dataRef.current.values,
+        smooth: true,
+        areaStyle: { opacity: 0.2 },
+        showSymbol: false,
+      },
+    ],
+    grid: { top: 50, bottom: 30, left: 45, right: 20 },
+    animation: false,
+  });
+
+  const { setOption } = useEcharts(chartRef, { option: optionRef.current });
+
+  useEffect(() => {
+    if (!running) return;
+
+    const timer = window.setInterval(() => {
+      const { times, values } = dataRef.current;
+      times.push(formatTime(new Date()));
+      values.push(randomValue(values[values.length - 1]));
+
+      if (times.length > 60) {
+        times.shift();
+        values.shift();
+      }
+
+      setCount(times.length);
+      setOption({
+        xAxis: { data: times },
+        series: [{ data: values }],
+      });
+    }, 1000);
+
+    return () => window.clearInterval(timer);
+  }, [running, setOption]);
+
+  const handleToggle = useCallback(() => setRunning((prev) => !prev), []);
+
+  return (
+    <div>
+      <div className="controls">
+        <button type="button" className="btn" onClick={handleToggle}>
+          {running ? "Stop" : "Start"}
+        </button>
+        <span className="note-box">{count} data points</span>
+      </div>
+      <div ref={chartRef} className="chart-container" style={{ marginTop: 10 }} />
+    </div>
+  );
+};
+
+export default DynamicChart;

--- a/examples/gallery/CandlestickChart.tsx
+++ b/examples/gallery/CandlestickChart.tsx
@@ -1,0 +1,36 @@
+import React, { useRef } from "react";
+import { useEcharts } from "../../src";
+import type { EChartsOption } from "echarts";
+
+const CandlestickChart: React.FC = () => {
+  const chartRef = useRef<HTMLDivElement>(null);
+
+  const dates = ["Apr 1", "Apr 2", "Apr 3", "Apr 4", "Apr 7", "Apr 8", "Apr 9", "Apr 10"];
+  // [open, close, low, high]
+  const data = [
+    [116, 129, 112, 132],
+    [128, 133, 126, 136],
+    [132, 127, 124, 134],
+    [128, 136, 126, 140],
+    [135, 131, 128, 138],
+    [130, 142, 128, 145],
+    [141, 138, 134, 144],
+    [137, 145, 135, 148],
+  ];
+
+  const option: EChartsOption = {
+    backgroundColor: "transparent",
+    title: { text: "Stock Price" },
+    tooltip: { trigger: "axis", axisPointer: { type: "cross" } },
+    xAxis: { type: "category", data: dates, boundaryGap: true },
+    yAxis: { type: "value", scale: true, splitArea: { show: true } },
+    series: [{ type: "candlestick", data }],
+    grid: { top: 50, bottom: 30, left: 50, right: 20 },
+  };
+
+  useEcharts(chartRef, { option });
+
+  return <div ref={chartRef} className="chart-container-sm" />;
+};
+
+export default CandlestickChart;

--- a/examples/gallery/FunnelChart.tsx
+++ b/examples/gallery/FunnelChart.tsx
@@ -1,0 +1,39 @@
+import React, { useRef } from "react";
+import { useEcharts } from "../../src";
+import type { EChartsOption } from "echarts";
+
+const FunnelChart: React.FC = () => {
+  const chartRef = useRef<HTMLDivElement>(null);
+
+  const option: EChartsOption = {
+    backgroundColor: "transparent",
+    title: { text: "Conversion Funnel", left: "center" },
+    tooltip: { trigger: "item", formatter: "{b}: {c}%" },
+    series: [
+      {
+        type: "funnel",
+        left: "10%",
+        top: 50,
+        bottom: 10,
+        width: "80%",
+        sort: "descending",
+        gap: 2,
+        label: { show: true, position: "inside", formatter: "{b}\n{c}%" },
+        emphasis: { label: { fontSize: 16 } },
+        data: [
+          { value: 100, name: "Visitors" },
+          { value: 72, name: "Clicked" },
+          { value: 48, name: "Sign Up" },
+          { value: 28, name: "Trial" },
+          { value: 12, name: "Purchase" },
+        ],
+      },
+    ],
+  };
+
+  useEcharts(chartRef, { option });
+
+  return <div ref={chartRef} className="chart-container-sm" />;
+};
+
+export default FunnelChart;

--- a/examples/gallery/GaugeChart.tsx
+++ b/examples/gallery/GaugeChart.tsx
@@ -1,0 +1,40 @@
+import React, { useRef } from "react";
+import { useEcharts } from "../../src";
+import type { EChartsOption } from "echarts";
+
+const GaugeChart: React.FC = () => {
+  const chartRef = useRef<HTMLDivElement>(null);
+
+  const option: EChartsOption = {
+    backgroundColor: "transparent",
+    title: { text: "Server CPU", left: "center" },
+    series: [
+      {
+        type: "gauge",
+        startAngle: 220,
+        endAngle: -40,
+        min: 0,
+        max: 100,
+        progress: { show: true, width: 14 },
+        axisLine: { lineStyle: { width: 14 } },
+        axisTick: { show: false },
+        splitLine: { length: 8, lineStyle: { width: 2 } },
+        axisLabel: { distance: 20, fontSize: 11 },
+        pointer: { show: true, length: "55%", width: 5 },
+        detail: {
+          valueAnimation: true,
+          fontSize: 22,
+          offsetCenter: [0, "70%"],
+          formatter: "{value}%",
+        },
+        data: [{ value: 72 }],
+      },
+    ],
+  };
+
+  useEcharts(chartRef, { option });
+
+  return <div ref={chartRef} className="chart-container-sm" />;
+};
+
+export default GaugeChart;

--- a/examples/gallery/HeatmapChart.tsx
+++ b/examples/gallery/HeatmapChart.tsx
@@ -1,0 +1,60 @@
+import React, { useMemo, useRef } from "react";
+import { useEcharts } from "../../src";
+import type { EChartsOption } from "echarts";
+
+const HOURS = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
+const SLOTS = ["Morning", "Afternoon", "Evening", "Night"];
+
+function generateData() {
+  const data: [number, number, number][] = [];
+  for (let i = 0; i < HOURS.length; i++) {
+    for (let j = 0; j < SLOTS.length; j++) {
+      data.push([i, j, Math.floor(Math.random() * 10)]);
+    }
+  }
+  return data;
+}
+
+const HeatmapChart: React.FC = () => {
+  const chartRef = useRef<HTMLDivElement>(null);
+  const heatmapData = useMemo(() => generateData(), []);
+
+  const option: EChartsOption = {
+    backgroundColor: "transparent",
+    title: { text: "Activity Heatmap" },
+    tooltip: {
+      position: "top",
+      formatter: (params: unknown) => {
+        const p = params as { value: number[] };
+        return `${HOURS[p.value[0]]} ${SLOTS[p.value[1]]}: <b>${p.value[2]}</b>`;
+      },
+    },
+    xAxis: { type: "category", data: HOURS, splitArea: { show: true } },
+    yAxis: { type: "category", data: SLOTS, splitArea: { show: true } },
+    visualMap: {
+      min: 0,
+      max: 10,
+      calculable: true,
+      orient: "horizontal",
+      left: "center",
+      bottom: 0,
+      itemWidth: 12,
+      itemHeight: 80,
+    },
+    grid: { top: 50, bottom: 60, left: 80, right: 20 },
+    series: [
+      {
+        type: "heatmap",
+        data: heatmapData,
+        label: { show: true },
+        emphasis: { itemStyle: { shadowBlur: 6, shadowColor: "rgba(0,0,0,0.25)" } },
+      },
+    ],
+  };
+
+  useEcharts(chartRef, { option });
+
+  return <div ref={chartRef} className="chart-container-sm" />;
+};
+
+export default HeatmapChart;

--- a/examples/gallery/RadarChart.tsx
+++ b/examples/gallery/RadarChart.tsx
@@ -1,0 +1,40 @@
+import React, { useRef } from "react";
+import { useEcharts } from "../../src";
+import type { EChartsOption } from "echarts";
+
+const RadarChart: React.FC = () => {
+  const chartRef = useRef<HTMLDivElement>(null);
+
+  const option: EChartsOption = {
+    backgroundColor: "transparent",
+    title: { text: "Skill Assessment" },
+    tooltip: { trigger: "item" },
+    legend: { bottom: 0, data: ["Alice", "Bob"] },
+    radar: {
+      indicator: [
+        { name: "Frontend", max: 100 },
+        { name: "Backend", max: 100 },
+        { name: "DevOps", max: 100 },
+        { name: "Design", max: 100 },
+        { name: "Testing", max: 100 },
+        { name: "Communication", max: 100 },
+      ],
+    },
+    series: [
+      {
+        type: "radar",
+        data: [
+          { value: [90, 65, 50, 80, 70, 85], name: "Alice" },
+          { value: [60, 90, 85, 40, 80, 70], name: "Bob" },
+        ],
+        areaStyle: { opacity: 0.15 },
+      },
+    ],
+  };
+
+  useEcharts(chartRef, { option });
+
+  return <div ref={chartRef} className="chart-container-sm" />;
+};
+
+export default RadarChart;

--- a/examples/gallery/TreemapChart.tsx
+++ b/examples/gallery/TreemapChart.tsx
@@ -1,0 +1,56 @@
+import React, { useRef } from "react";
+import { useEcharts } from "../../src";
+import type { EChartsOption } from "echarts";
+
+const TreemapChart: React.FC = () => {
+  const chartRef = useRef<HTMLDivElement>(null);
+
+  const option: EChartsOption = {
+    backgroundColor: "transparent",
+    title: { text: "Disk Usage", left: "center" },
+    tooltip: { formatter: "{b}: {c} GB" },
+    series: [
+      {
+        type: "treemap",
+        roam: false,
+        breadcrumb: { show: false },
+        label: { show: true, formatter: "{b}\n{c} GB" },
+        data: [
+          {
+            name: "Documents",
+            value: 120,
+            children: [
+              { name: "Projects", value: 65 },
+              { name: "Archives", value: 35 },
+              { name: "Notes", value: 20 },
+            ],
+          },
+          {
+            name: "Media",
+            value: 90,
+            children: [
+              { name: "Photos", value: 45 },
+              { name: "Videos", value: 30 },
+              { name: "Music", value: 15 },
+            ],
+          },
+          {
+            name: "Applications",
+            value: 60,
+            children: [
+              { name: "Dev Tools", value: 35 },
+              { name: "Utilities", value: 25 },
+            ],
+          },
+          { name: "System", value: 40 },
+        ],
+      },
+    ],
+  };
+
+  useEcharts(chartRef, { option });
+
+  return <div ref={chartRef} className="chart-container-sm" />;
+};
+
+export default TreemapChart;

--- a/examples/renderer/RendererToggle.tsx
+++ b/examples/renderer/RendererToggle.tsx
@@ -1,0 +1,49 @@
+import React, { useRef } from "react";
+import { useEcharts } from "../../src";
+import type { EChartsOption } from "echarts";
+
+const sharedOption: EChartsOption = {
+  backgroundColor: "transparent",
+  tooltip: { trigger: "axis" },
+  xAxis: { type: "category", data: ["Jan", "Feb", "Mar", "Apr", "May", "Jun"] },
+  yAxis: { type: "value" },
+  series: [
+    { name: "Revenue", type: "bar", data: [85, 120, 95, 140, 110, 130] },
+    { name: "Profit", type: "line", smooth: true, data: [30, 55, 40, 70, 50, 65] },
+  ],
+  legend: { bottom: 0 },
+  grid: { top: 40, bottom: 40, left: 45, right: 20 },
+};
+
+const RendererToggle: React.FC = () => {
+  const canvasRef = useRef<HTMLDivElement>(null);
+  const svgRef = useRef<HTMLDivElement>(null);
+
+  const canvasOption: EChartsOption = {
+    ...sharedOption,
+    title: { text: "Canvas Renderer", textStyle: { fontSize: 14 } },
+  };
+
+  const svgOption: EChartsOption = {
+    ...sharedOption,
+    title: { text: "SVG Renderer", textStyle: { fontSize: 14 } },
+  };
+
+  useEcharts(canvasRef, { option: canvasOption, renderer: "canvas" });
+  useEcharts(svgRef, { option: svgOption, renderer: "svg" });
+
+  return (
+    <div>
+      <div className="note-box" style={{ marginBottom: 10 }}>
+        Canvas excels with large datasets; SVG is better for small charts that need crisp scaling
+        and CSS styling.
+      </div>
+      <div className="grid-2">
+        <div ref={canvasRef} className="chart-container-sm" />
+        <div ref={svgRef} className="chart-container-sm" />
+      </div>
+    </div>
+  );
+};
+
+export default RendererToggle;


### PR DESCRIPTION
## Summary
- Add **Hero** section with npm badges, install command copy button, feature tags, and Get Started CTA
- Add **Gallery** section with 6 new chart types: radar, gauge, candlestick, heatmap, funnel, treemap (2-column grid)
- Add **Dynamic Data** section with real-time monitoring demo using `setOption` + Start/Stop controls
- Add **Renderer** section comparing Canvas vs SVG renderers side by side
- Add **Footer** with npm / GitHub / API Reference links
- Tighten layout spacing (Hero, section margins, main padding) and widen content area from 960px to 1080px
- Sidebar expanded from 7 to 10 navigation items

## Test plan
- [x] `vp check` — format, lint, typecheck all pass
- [x] `vp test run` — 170/170 tests pass
- [x] Browser verified: Hero, Gallery, Dynamic Data, Renderer, Footer all render correctly
- [x] Dark mode tested — all new sections display properly
- [x] `vp build` — production build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)