### PR TITLE
Release 1.2.0: examples revamp, trimmed public API, and toolchain bump

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,7 +21,7 @@ All `useEcharts` options as props + `style` (default `{ width: '100%', height: '
 ### Other Exports
 
 - `isBuiltinTheme(name)`, `registerCustomTheme(name, config)` — from `'react-use-echarts'`
-- `registerBuiltinThemes()`, `getBuiltinTheme(name)`, `getAvailableThemes()` — from `'react-use-echarts/themes/registry'` (separate entry, ~20KB theme JSON)
+- `registerBuiltinThemes()` — from `'react-use-echarts/themes/registry'` (separate entry, ~20KB theme JSON)
 - `useLazyInit(ref, options)` — standalone lazy init hook
 
 ## Gotchas

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-use-echarts",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "private": false,
   "description": "React hooks & component for Apache ECharts — TypeScript, auto-resize, themes, lazy init",
   "keywords": [
@@ -65,9 +65,6 @@
     "typecheck": "tsc -b",
     "prepare": "vp config"
   },
-  "dependencies": {
-    "react-router-dom": "^7.14.1"
-  },
   "devDependencies": {
     "@babel/core": "^7.29.0",
     "@rolldown/plugin-babel": "^0.2.3",
@@ -84,8 +81,9 @@
     "jsdom": "^29.0.2",
     "react": "^19.2.5",
     "react-dom": "^19.2.5",
+    "react-router-dom": "^7.14.1",
     "shiki": "^4.0.2",
-    "typescript": "~6.0.2",
+    "typescript": "~6.0.3",
     "vite": "npm:@voidzero-dev/vite-plus-core@^0.1.18",
     "vite-plus": "^0.1.18",
     "vitest": "npm:@voidzero-dev/vite-plus-test@^0.1.18"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,17 +7,13 @@ settings:
 importers:
 
   .:
-    dependencies:
-      react-router-dom:
-        specifier: ^7.14.1
-        version: 7.14.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
     devDependencies:
       '@babel/core':
         specifier: ^7.29.0
         version: 7.29.0
       '@rolldown/plugin-babel':
         specifier: ^0.2.3
-        version: 0.2.3(@babel/core@7.29.0)(@babel/runtime@7.29.2)(@voidzero-dev/vite-plus-core@0.1.18(@types/node@25.6.0)(typescript@6.0.2)(yaml@2.8.2))(rolldown@1.0.0-rc.10)
+        version: 0.2.3(@babel/core@7.29.0)(@babel/runtime@7.29.2)(@voidzero-dev/vite-plus-core@0.1.18(@types/node@25.6.0)(typescript@6.0.3)(yaml@2.8.2))(rolldown@1.0.0-rc.10)
       '@shikijs/langs':
         specifier: ^4.0.2
         version: 4.0.2
@@ -38,7 +34,7 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       '@vitejs/plugin-react':
         specifier: ^6.0.1
-        version: 6.0.1(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.0)(@babel/runtime@7.29.2)(@voidzero-dev/vite-plus-core@0.1.18(@types/node@25.6.0)(typescript@6.0.2)(yaml@2.8.2))(rolldown@1.0.0-rc.10))(@voidzero-dev/vite-plus-core@0.1.18(@types/node@25.6.0)(typescript@6.0.2)(yaml@2.8.2))(babel-plugin-react-compiler@1.0.0)
+        version: 6.0.1(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.0)(@babel/runtime@7.29.2)(@voidzero-dev/vite-plus-core@0.1.18(@types/node@25.6.0)(typescript@6.0.3)(yaml@2.8.2))(rolldown@1.0.0-rc.10))(@voidzero-dev/vite-plus-core@0.1.18(@types/node@25.6.0)(typescript@6.0.3)(yaml@2.8.2))(babel-plugin-react-compiler@1.0.0)
       '@vitest/coverage-v8':
         specifier: ^4.1.4
         version: 4.1.4(@voidzero-dev/vite-plus-test@0.1.18)
@@ -57,21 +53,24 @@ importers:
       react-dom:
         specifier: ^19.2.5
         version: 19.2.5(react@19.2.5)
+      react-router-dom:
+        specifier: ^7.14.1
+        version: 7.14.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       shiki:
         specifier: ^4.0.2
         version: 4.0.2
       typescript:
-        specifier: ~6.0.2
-        version: 6.0.2
+        specifier: ~6.0.3
+        version: 6.0.3
       vite:
         specifier: npm:@voidzero-dev/vite-plus-core@^0.1.18
-        version: '@voidzero-dev/vite-plus-core@0.1.18(@types/node@25.6.0)(typescript@6.0.2)(yaml@2.8.2)'
+        version: '@voidzero-dev/vite-plus-core@0.1.18(@types/node@25.6.0)(typescript@6.0.3)(yaml@2.8.2)'
       vite-plus:
         specifier: ^0.1.18
-        version: 0.1.18(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(@voidzero-dev/vite-plus-core@0.1.18(@types/node@25.6.0)(typescript@6.0.2)(yaml@2.8.2))(jsdom@29.0.2)(typescript@6.0.2)(yaml@2.8.2)
+        version: 0.1.18(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(@voidzero-dev/vite-plus-core@0.1.18(@types/node@25.6.0)(typescript@6.0.3)(yaml@2.8.2))(jsdom@29.0.2)(typescript@6.0.3)(yaml@2.8.2)
       vitest:
         specifier: npm:@voidzero-dev/vite-plus-test@^0.1.18
-        version: '@voidzero-dev/vite-plus-test@0.1.18(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(@voidzero-dev/vite-plus-core@0.1.18(@types/node@25.6.0)(typescript@6.0.2)(yaml@2.8.2))(jsdom@29.0.2)(typescript@6.0.2)(yaml@2.8.2)'
+        version: '@voidzero-dev/vite-plus-test@0.1.18(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(@voidzero-dev/vite-plus-core@0.1.18(@types/node@25.6.0)(typescript@6.0.3)(yaml@2.8.2))(jsdom@29.0.2)(typescript@6.0.3)(yaml@2.8.2)'
 
 packages:
 
@@ -1426,8 +1425,8 @@ packages:
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
-  typescript@6.0.2:
-    resolution: {integrity: sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==}
+  typescript@6.0.3:
+    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -1900,14 +1899,14 @@ snapshots:
   '@rolldown/binding-win32-x64-msvc@1.0.0-rc.10':
     optional: true
 
-  '@rolldown/plugin-babel@0.2.3(@babel/core@7.29.0)(@babel/runtime@7.29.2)(@voidzero-dev/vite-plus-core@0.1.18(@types/node@25.6.0)(typescript@6.0.2)(yaml@2.8.2))(rolldown@1.0.0-rc.10)':
+  '@rolldown/plugin-babel@0.2.3(@babel/core@7.29.0)(@babel/runtime@7.29.2)(@voidzero-dev/vite-plus-core@0.1.18(@types/node@25.6.0)(typescript@6.0.3)(yaml@2.8.2))(rolldown@1.0.0-rc.10)':
     dependencies:
       '@babel/core': 7.29.0
       picomatch: 4.0.4
       rolldown: 1.0.0-rc.10
     optionalDependencies:
       '@babel/runtime': 7.29.2
-      vite: '@voidzero-dev/vite-plus-core@0.1.18(@types/node@25.6.0)(typescript@6.0.2)(yaml@2.8.2)'
+      vite: '@voidzero-dev/vite-plus-core@0.1.18(@types/node@25.6.0)(typescript@6.0.3)(yaml@2.8.2)'
 
   '@rolldown/pluginutils@1.0.0-rc.10': {}
 
@@ -2016,12 +2015,12 @@ snapshots:
 
   '@ungap/structured-clone@1.3.0': {}
 
-  '@vitejs/plugin-react@6.0.1(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.0)(@babel/runtime@7.29.2)(@voidzero-dev/vite-plus-core@0.1.18(@types/node@25.6.0)(typescript@6.0.2)(yaml@2.8.2))(rolldown@1.0.0-rc.10))(@voidzero-dev/vite-plus-core@0.1.18(@types/node@25.6.0)(typescript@6.0.2)(yaml@2.8.2))(babel-plugin-react-compiler@1.0.0)':
+  '@vitejs/plugin-react@6.0.1(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.0)(@babel/runtime@7.29.2)(@voidzero-dev/vite-plus-core@0.1.18(@types/node@25.6.0)(typescript@6.0.3)(yaml@2.8.2))(rolldown@1.0.0-rc.10))(@voidzero-dev/vite-plus-core@0.1.18(@types/node@25.6.0)(typescript@6.0.3)(yaml@2.8.2))(babel-plugin-react-compiler@1.0.0)':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-rc.7
-      vite: '@voidzero-dev/vite-plus-core@0.1.18(@types/node@25.6.0)(typescript@6.0.2)(yaml@2.8.2)'
+      vite: '@voidzero-dev/vite-plus-core@0.1.18(@types/node@25.6.0)(typescript@6.0.3)(yaml@2.8.2)'
     optionalDependencies:
-      '@rolldown/plugin-babel': 0.2.3(@babel/core@7.29.0)(@babel/runtime@7.29.2)(@voidzero-dev/vite-plus-core@0.1.18(@types/node@25.6.0)(typescript@6.0.2)(yaml@2.8.2))(rolldown@1.0.0-rc.10)
+      '@rolldown/plugin-babel': 0.2.3(@babel/core@7.29.0)(@babel/runtime@7.29.2)(@voidzero-dev/vite-plus-core@0.1.18(@types/node@25.6.0)(typescript@6.0.3)(yaml@2.8.2))(rolldown@1.0.0-rc.10)
       babel-plugin-react-compiler: 1.0.0
 
   '@vitest/coverage-v8@4.1.4(@voidzero-dev/vite-plus-test@0.1.18)':
@@ -2036,7 +2035,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.0.0
       tinyrainbow: 3.1.0
-      vitest: '@voidzero-dev/vite-plus-test@0.1.18(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(@voidzero-dev/vite-plus-core@0.1.18(@types/node@25.6.0)(typescript@6.0.2)(yaml@2.8.2))(jsdom@29.0.2)(typescript@6.0.2)(yaml@2.8.2)'
+      vitest: '@voidzero-dev/vite-plus-test@0.1.18(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(@voidzero-dev/vite-plus-core@0.1.18(@types/node@25.6.0)(typescript@6.0.3)(yaml@2.8.2))(jsdom@29.0.2)(typescript@6.0.3)(yaml@2.8.2)'
 
   '@vitest/pretty-format@4.1.4':
     dependencies:
@@ -2048,7 +2047,7 @@ snapshots:
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
-  '@voidzero-dev/vite-plus-core@0.1.18(@types/node@25.6.0)(typescript@6.0.2)(yaml@2.8.2)':
+  '@voidzero-dev/vite-plus-core@0.1.18(@types/node@25.6.0)(typescript@6.0.3)(yaml@2.8.2)':
     dependencies:
       '@oxc-project/runtime': 0.124.0
       '@oxc-project/types': 0.124.0
@@ -2057,7 +2056,7 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.6.0
       fsevents: 2.3.3
-      typescript: 6.0.2
+      typescript: 6.0.3
       yaml: 2.8.2
 
   '@voidzero-dev/vite-plus-darwin-arm64@0.1.18':
@@ -2078,11 +2077,11 @@ snapshots:
   '@voidzero-dev/vite-plus-linux-x64-musl@0.1.18':
     optional: true
 
-  '@voidzero-dev/vite-plus-test@0.1.18(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(@voidzero-dev/vite-plus-core@0.1.18(@types/node@25.6.0)(typescript@6.0.2)(yaml@2.8.2))(jsdom@29.0.2)(typescript@6.0.2)(yaml@2.8.2)':
+  '@voidzero-dev/vite-plus-test@0.1.18(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(@voidzero-dev/vite-plus-core@0.1.18(@types/node@25.6.0)(typescript@6.0.3)(yaml@2.8.2))(jsdom@29.0.2)(typescript@6.0.3)(yaml@2.8.2)':
     dependencies:
       '@standard-schema/spec': 1.1.0
       '@types/chai': 5.2.3
-      '@voidzero-dev/vite-plus-core': 0.1.18(@types/node@25.6.0)(typescript@6.0.2)(yaml@2.8.2)
+      '@voidzero-dev/vite-plus-core': 0.1.18(@types/node@25.6.0)(typescript@6.0.3)(yaml@2.8.2)
       es-module-lexer: 1.7.0
       obug: 2.1.1
       pixelmatch: 7.1.0
@@ -2092,7 +2091,7 @@ snapshots:
       tinybench: 2.9.0
       tinyexec: 1.0.4
       tinyglobby: 0.2.15
-      vite: '@voidzero-dev/vite-plus-core@0.1.18(@types/node@25.6.0)(typescript@6.0.2)(yaml@2.8.2)'
+      vite: '@voidzero-dev/vite-plus-core@0.1.18(@types/node@25.6.0)(typescript@6.0.3)(yaml@2.8.2)'
       ws: 8.20.0
     optionalDependencies:
       '@types/node': 25.6.0
@@ -2648,7 +2647,7 @@ snapshots:
   tslib@2.8.1:
     optional: true
 
-  typescript@6.0.2: {}
+  typescript@6.0.3: {}
 
   undici-types@7.19.2: {}
 
@@ -2693,11 +2692,11 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vite-plus@0.1.18(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(@voidzero-dev/vite-plus-core@0.1.18(@types/node@25.6.0)(typescript@6.0.2)(yaml@2.8.2))(jsdom@29.0.2)(typescript@6.0.2)(yaml@2.8.2):
+  vite-plus@0.1.18(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(@voidzero-dev/vite-plus-core@0.1.18(@types/node@25.6.0)(typescript@6.0.3)(yaml@2.8.2))(jsdom@29.0.2)(typescript@6.0.3)(yaml@2.8.2):
     dependencies:
       '@oxc-project/types': 0.124.0
-      '@voidzero-dev/vite-plus-core': 0.1.18(@types/node@25.6.0)(typescript@6.0.2)(yaml@2.8.2)
-      '@voidzero-dev/vite-plus-test': 0.1.18(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(@voidzero-dev/vite-plus-core@0.1.18(@types/node@25.6.0)(typescript@6.0.2)(yaml@2.8.2))(jsdom@29.0.2)(typescript@6.0.2)(yaml@2.8.2)
+      '@voidzero-dev/vite-plus-core': 0.1.18(@types/node@25.6.0)(typescript@6.0.3)(yaml@2.8.2)
+      '@voidzero-dev/vite-plus-test': 0.1.18(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(@voidzero-dev/vite-plus-core@0.1.18(@types/node@25.6.0)(typescript@6.0.3)(yaml@2.8.2))(jsdom@29.0.2)(typescript@6.0.3)(yaml@2.8.2)
       oxfmt: 0.45.0
       oxlint: 1.60.0(oxlint-tsgolint@0.20.0)
       oxlint-tsgolint: 0.20.0

--- a/src/__tests__/hooks/use-echarts.test.ts
+++ b/src/__tests__/hooks/use-echarts.test.ts
@@ -179,7 +179,7 @@ describe("useEcharts", () => {
       expect(mockInstance.showLoading).toHaveBeenCalledWith(loadingOption);
     });
 
-    it("should hide loading when showLoading is false", () => {
+    it("should not call hideLoading on initial mount when showLoading is false", () => {
       const element = document.createElement("div");
       const ref = { current: element };
       const mockInstance = createMockInstance(element);
@@ -187,7 +187,46 @@ describe("useEcharts", () => {
 
       renderHook(() => useEcharts(ref, { option: baseOption, showLoading: false }));
 
-      expect(mockInstance.hideLoading).toHaveBeenCalled();
+      expect(mockInstance.hideLoading).not.toHaveBeenCalled();
+      expect(mockInstance.showLoading).not.toHaveBeenCalled();
+    });
+
+    it("should hide loading when showLoading transitions from true to false", () => {
+      const element = document.createElement("div");
+      const ref = { current: element };
+      const mockInstance = createMockInstance(element);
+      (echarts.init as ReturnType<typeof vi.fn>).mockReturnValue(mockInstance);
+
+      const { rerender } = renderHook<ReturnType<typeof useEcharts>, { showLoading: boolean }>(
+        ({ showLoading }) => useEcharts(ref, { option: baseOption, showLoading }),
+        { initialProps: { showLoading: true } },
+      );
+
+      expect(mockInstance.showLoading).toHaveBeenCalledTimes(1);
+      expect(mockInstance.hideLoading).not.toHaveBeenCalled();
+
+      rerender({ showLoading: false });
+      expect(mockInstance.hideLoading).toHaveBeenCalledTimes(1);
+    });
+
+    it("should not re-call showLoading for inline loadingOption with identical content", () => {
+      const element = document.createElement("div");
+      const ref = { current: element };
+      const mockInstance = createMockInstance(element);
+      (echarts.init as ReturnType<typeof vi.fn>).mockReturnValue(mockInstance);
+
+      const { rerender } = renderHook(() =>
+        useEcharts(ref, {
+          option: baseOption,
+          showLoading: true,
+          loadingOption: { text: "Loading..." },
+        }),
+      );
+
+      expect(mockInstance.showLoading).toHaveBeenCalledTimes(1);
+      rerender();
+      rerender();
+      expect(mockInstance.showLoading).toHaveBeenCalledTimes(1);
     });
 
     it("should keep loading state after theme change", async () => {

--- a/src/__tests__/themes/registry.test.ts
+++ b/src/__tests__/themes/registry.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vite-plus/test";
 import * as echarts from "echarts";
-import { registerBuiltinThemes, getBuiltinTheme, getAvailableThemes } from "../../themes/registry";
+import { registerBuiltinThemes } from "../../themes/registry";
 
 // Mock ECharts
 vi.mock("echarts", () => ({
@@ -10,42 +10,6 @@ vi.mock("echarts", () => ({
 describe("themes registry", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-  });
-
-  describe("getBuiltinTheme", () => {
-    it("should return light theme config", () => {
-      const theme = getBuiltinTheme("light");
-      expect(theme).toBeDefined();
-      expect(theme).toHaveProperty("color");
-    });
-
-    it("should return dark theme config", () => {
-      const theme = getBuiltinTheme("dark");
-      expect(theme).toBeDefined();
-      expect(theme).toHaveProperty("color");
-    });
-
-    it("should return macarons theme config", () => {
-      const theme = getBuiltinTheme("macarons");
-      expect(theme).toBeDefined();
-      expect(theme).toHaveProperty("color");
-    });
-
-    it("should return null for unknown theme", () => {
-      // @ts-expect-error - testing invalid input
-      const theme = getBuiltinTheme("unknown");
-      expect(theme).toBeNull();
-    });
-  });
-
-  describe("getAvailableThemes", () => {
-    it("should return all builtin theme names", () => {
-      const themes = getAvailableThemes();
-      expect(themes).toContain("light");
-      expect(themes).toContain("dark");
-      expect(themes).toContain("macarons");
-      expect(themes).toHaveLength(3);
-    });
   });
 
   describe("registerBuiltinThemes", () => {

--- a/src/components/EChart.tsx
+++ b/src/components/EChart.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, useRef, useImperativeHandle } from "react";
+import { useRef, useImperativeHandle, type Ref } from "react";
 import useEcharts from "../hooks/use-echarts";
 import type { EChartProps, UseEchartsReturn } from "../types";
 
@@ -15,22 +15,23 @@ import type { EChartProps, UseEchartsReturn } from "../types";
  * <EChart option={{ series: [{ type: 'line', data: [1,2,3] }] }} />
  * ```
  */
-/* v8 ignore next 2 -- forwardRef wrapper generates false uncovered branches in v8 */
-const EChart = forwardRef<UseEchartsReturn, EChartProps>(
-  ({ style, className, ...options }, ref) => {
-    const containerRef = useRef<HTMLDivElement>(null);
-    const chart = useEcharts(containerRef, options);
-    useImperativeHandle(ref, () => chart, [chart]);
-    return (
-      <div
-        ref={containerRef}
-        style={{ width: "100%", height: "100%", minHeight: "400px", ...style }}
-        className={className}
-      />
-    );
-  },
-);
-
-EChart.displayName = "EChart";
+/* v8 ignore next -- React Compiler transforms rest-spread into an uncovered branch */
+function EChart({
+  ref,
+  style,
+  className,
+  ...options
+}: EChartProps & { ref?: Ref<UseEchartsReturn> }) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const chart = useEcharts(containerRef, options);
+  useImperativeHandle(ref, () => chart, [chart]);
+  return (
+    <div
+      ref={containerRef}
+      style={{ width: "100%", height: "100%", minHeight: "400px", ...style }}
+      className={className}
+    />
+  );
+}
 
 export default EChart;

--- a/src/hooks/internal/use-chart-core.ts
+++ b/src/hooks/internal/use-chart-core.ts
@@ -82,6 +82,11 @@ interface LastApplied {
   opts: SetOptionOpts | undefined;
 }
 
+interface LastLoading {
+  showLoading: boolean;
+  loadingOption: LoadingOption | undefined;
+}
+
 interface ChartCoreConfig {
   option: EChartsOption;
   theme?: UseEchartsOptions["theme"];
@@ -153,6 +158,7 @@ export function useChartCore(
   // --- Internal shared state ---
   const boundEventsRef = useRef<EChartsEvents | undefined>(undefined);
   const lastAppliedRef = useRef<LastApplied | null>(null);
+  const lastLoadingRef = useRef<LastLoading | null>(null);
 
   // --- Stable dependency keys ---
   const themeKey = useMemo(() => computeThemeKey(theme), [theme]);
@@ -244,6 +250,10 @@ export function useChartCore(
     if (showLoadingRef.current) {
       instance.showLoading(loadingOptionRef.current);
     }
+    lastLoadingRef.current = {
+      showLoading: showLoadingRef.current,
+      loadingOption: loadingOptionRef.current,
+    };
 
     bindEvents(instance, onEventsRef.current);
     boundEventsRef.current = onEventsRef.current;
@@ -255,6 +265,7 @@ export function useChartCore(
 
     return () => {
       lastAppliedRef.current = null;
+      lastLoadingRef.current = null;
 
       const inst = getCachedInstance(element);
       if (!inst) return;
@@ -315,17 +326,24 @@ export function useChartCore(
   // Effect 4: LOADING STATE
   //
   // Toggles showLoading / hideLoading on dynamic changes.
-  // Init effect handles initial application on instance creation.
+  // Init effect handles initial application on instance creation;
+  // lastLoadingRef + shallowEqual skips redundant calls for inline
+  // loadingOption objects with identical content.
   // =====================================================================
   useEffect(() => {
     const instance = getInstance();
     if (!instance) return;
+
+    const last = lastLoadingRef.current;
+    if (last && last.showLoading === showLoading && shallowEqual(last.loadingOption, loadingOption))
+      return;
 
     if (showLoading) {
       instance.showLoading(loadingOption);
     } else {
       instance.hideLoading();
     }
+    lastLoadingRef.current = { showLoading, loadingOption };
   }, [getInstance, showLoading, loadingOption]);
 
   // =====================================================================

--- a/src/themes/registry.ts
+++ b/src/themes/registry.ts
@@ -1,25 +1,16 @@
 import * as echarts from "echarts";
-import type { BuiltinTheme } from "../types";
 
 // Import theme presets (heavy — ~20KB JSON)
 import lightTheme from "./presets/light.json";
 import darkTheme from "./presets/dark.json";
 import macaronsTheme from "./presets/macarons.json";
 
-/**
- * Theme registry for built-in themes
- * 内置主题注册表
- */
-const themeRegistry = new Map<string, object>([
+const builtinThemes: ReadonlyArray<readonly [string, object]> = [
   ["light", lightTheme],
   ["dark", darkTheme],
   ["macarons", macaronsTheme],
-]);
+];
 
-/**
- * Flag for idempotent registration
- * 幂等注册标志
- */
 let builtinThemesRegistered = false;
 
 /**
@@ -29,27 +20,8 @@ let builtinThemesRegistered = false;
  */
 export function registerBuiltinThemes(): void {
   if (builtinThemesRegistered) return;
-  for (const [themeName, themeConfig] of themeRegistry.entries()) {
+  for (const [themeName, themeConfig] of builtinThemes) {
     echarts.registerTheme(themeName, themeConfig);
   }
   builtinThemesRegistered = true;
-}
-
-/**
- * Get built-in theme configuration
- * 获取内置主题配置
- * @param themeName Theme name
- * @returns Theme configuration object or null if not found
- */
-export function getBuiltinTheme(themeName: BuiltinTheme): object | null {
-  return themeRegistry.get(themeName) || null;
-}
-
-/**
- * Get all available built-in theme names
- * 获取所有可用的内置主题名称
- * @returns Array of built-in theme names
- */
-export function getAvailableThemes(): BuiltinTheme[] {
-  return Array.from(themeRegistry.keys()) as BuiltinTheme[];
 }


### PR DESCRIPTION
## Summary

Rolls up four commits on `develop` into `main` for the **1.2.0** release.

### Library changes (`refactor: trim public API...`)
- **Fix:** move `react-router-dom` from `dependencies` to `devDependencies` — it's only used in `examples/`, so it was leaking into every consumer install as a runtime dep.
- **Cleanup:** drop unused `getBuiltinTheme` / `getAvailableThemes` exports from the `themes/registry` subpath; only `registerBuiltinThemes` is consumed externally.
- **Modernize:** replace `forwardRef` wrapper in `EChart` with React 19 native `ref` prop (peer dep is already `react >=19`).
- **Optimize:** add `lastLoadingRef` + `shallowEqual` dedup to Effect 4 so inline `loadingOption` objects and initial `showLoading=false` mounts stop triggering redundant `showLoading` / `hideLoading` calls. Mirrors the dedup pattern already used for `option` and events.

### Examples revamp (`feat: restructure examples...`, `feat: enrich examples...`)
- Routing-based layout (Home / Gallery / Features / demo detail pages)
- Richer showcase: hero, dynamic data, renderer toggle, candlestick / funnel / gauge / heatmap / radar / treemap galleries
- Dark-mode fixes, accessibility polish, themed code blocks, footer

### Toolchain (`chore: bump vite-plus`)
- `vite-plus` / `@voidzero-dev/vite-plus-*` `^0.1.16 → ^0.1.18`
- `typescript` `~6.0.2 → ~6.0.3`

## Verification

- `vp check` — 100 files formatted / 67 files no lint/type errors
- `vp test run --coverage` — 167 tests passing, 100% statements/branches/functions/lines
- `vp pack` — ESM 24.09 KB / UMD 26.94 KB / `themes/registry` 17.67 KB

## Test plan

- [ ] Smoke-test the deployed examples page (Home / Gallery / Features navigation, dark-mode toggle, renderer toggle)
- [ ] Install tarball (`pnpm pack` output) in a downstream project, verify `react-router-dom` is no longer pulled in as a transitive dep
- [ ] Verify `import { registerBuiltinThemes } from 'react-use-echarts/themes/registry'` still works after removing the two unused exports

🤖 Generated with [Claude Code](https://claude.com/claude-code)