### PR TITLE
develop → main: examples overhaul + API polish

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,11 +16,11 @@ Options: `option` (required), `theme`, `renderer` (`'canvas'`|`'svg'`), `lazyIni
 
 ### `<EChart />` Component
 
-All `useEcharts` options as props + `style` (default `{ width: '100%', height: '100%', minHeight: '400px' }`), `className`, `ref` (exposes `{ setOption, getInstance, resize }`)
+All `useEcharts` options as props + `style` (default `{ width: '100%', height: '100%' }`), `className`, `ref` (exposes `{ setOption, getInstance, resize }`)
 
 ### Other Exports
 
-- `isBuiltinTheme(name)`, `registerCustomTheme(name, config)` — from `'react-use-echarts'`
+- `isBuiltinTheme(name)`, `isKnownTheme(name)`, `registerCustomTheme(name, config)` — from `'react-use-echarts'`
 - `registerBuiltinThemes()` — from `'react-use-echarts/themes/registry'` (separate entry, ~20KB theme JSON)
 - `useLazyInit(ref, options)` — standalone lazy init hook
 

--- a/README-zh_CN.md
+++ b/README-zh_CN.md
@@ -161,11 +161,11 @@ useEcharts(chartRef, {
 
 封装了 `useEcharts` 的声明式组件。接受所有 Hook 选项作为 props，另外支持：
 
-| Prop        | 类型                    | 默认值                                                  | 说明                                      |
-| ----------- | ----------------------- | ------------------------------------------------------- | ----------------------------------------- |
-| `style`     | `React.CSSProperties`   | `{ width: '100%', height: '100%', minHeight: '400px' }` | 容器样式（与默认样式合并）                |
-| `className` | `string`                | —                                                       | 容器 CSS 类名                             |
-| `ref`       | `Ref<UseEchartsReturn>` | —                                                       | 暴露 `{ setOption, getInstance, resize }` |
+| Prop        | 类型                    | 默认值                              | 说明                                      |
+| ----------- | ----------------------- | ----------------------------------- | ----------------------------------------- |
+| `style`     | `React.CSSProperties`   | `{ width: '100%', height: '100%' }` | 容器样式（与默认样式合并）                |
+| `className` | `string`                | —                                   | 容器 CSS 类名                             |
+| `ref`       | `Ref<UseEchartsReturn>` | —                                   | 暴露 `{ setOption, getInstance, resize }` |
 
 ### `useEcharts(ref, options)`
 

--- a/README.md
+++ b/README.md
@@ -161,11 +161,11 @@ useEcharts(chartRef, {
 
 Declarative component wrapping `useEcharts`. Accepts all hook options as props plus:
 
-| Prop        | Type                    | Default                                                 | Description                                  |
-| ----------- | ----------------------- | ------------------------------------------------------- | -------------------------------------------- |
-| `style`     | `React.CSSProperties`   | `{ width: '100%', height: '100%', minHeight: '400px' }` | Container style (merged with defaults)       |
-| `className` | `string`                | —                                                       | Container CSS class                          |
-| `ref`       | `Ref<UseEchartsReturn>` | —                                                       | Exposes `{ setOption, getInstance, resize }` |
+| Prop        | Type                    | Default                             | Description                                  |
+| ----------- | ----------------------- | ----------------------------------- | -------------------------------------------- |
+| `style`     | `React.CSSProperties`   | `{ width: '100%', height: '100%' }` | Container style (merged with defaults)       |
+| `className` | `string`                | —                                   | Container CSS class                          |
+| `ref`       | `Ref<UseEchartsReturn>` | —                                   | Exposes `{ setOption, getInstance, resize }` |
 
 ### `useEcharts(ref, options)`
 

--- a/src/__tests__/components/EChart.test.tsx
+++ b/src/__tests__/components/EChart.test.tsx
@@ -41,7 +41,7 @@ describe("EChart component", () => {
     expect(echarts.init).toHaveBeenCalled();
   });
 
-  it("should apply default style (width 100%, height 100%, minHeight 400px)", () => {
+  it("should apply default style (width 100%, height 100%)", () => {
     (echarts.init as ReturnType<typeof vi.fn>).mockImplementation((el: HTMLElement) =>
       createMockInstance(el),
     );
@@ -53,7 +53,7 @@ describe("EChart component", () => {
     const div = container.firstChild as HTMLDivElement;
     expect(div.style.width).toBe("100%");
     expect(div.style.height).toBe("100%");
-    expect(div.style.minHeight).toBe("400px");
+    expect(div.style.minHeight).toBe("");
   });
 
   it("should merge custom style with defaults", () => {

--- a/src/components/EChart.tsx
+++ b/src/components/EChart.tsx
@@ -6,9 +6,8 @@ import type { EChartProps, UseEchartsReturn } from "../types";
  * Declarative EChart component — thin wrapper around useEcharts
  * 声明式 EChart 组件 — useEcharts 的薄封装
  *
- * Default container style: `{ width: '100%', height: '100%', minHeight: '400px' }`.
- * `height: 100%` requires the parent to have an explicit height; `minHeight: 400px`
- * acts as a fallback so the chart is always visible. Override via the `style` prop.
+ * Default container style: `{ width: '100%', height: '100%' }`.
+ * The parent must have an explicit height; override either via the `style` prop.
  *
  * @example
  * ```tsx
@@ -28,7 +27,7 @@ function EChart({
   return (
     <div
       ref={containerRef}
-      style={{ width: "100%", height: "100%", minHeight: "400px", ...style }}
+      style={{ width: "100%", height: "100%", ...style }}
       className={className}
     />
   );

--- a/src/hooks/internal/event-utils.ts
+++ b/src/hooks/internal/event-utils.ts
@@ -1,12 +1,12 @@
 import type { ECharts } from "echarts";
-import type { EChartsEvents, EChartsEventConfig } from "../../types";
+import type { EChartsEvents, EChartsEventConfig, EChartsEventHandler } from "../../types";
 
 /**
  * Normalize event config to full object form
  * 将事件配置标准化为完整对象形式
  */
 function normalizeEventConfig(config: EChartsEventConfig): {
-  handler: (params: unknown) => void;
+  handler: EChartsEventHandler;
   query?: string | object;
   context?: object;
 } {

--- a/src/hooks/internal/use-chart-core.ts
+++ b/src/hooks/internal/use-chart-core.ts
@@ -8,7 +8,7 @@ import {
   releaseCachedInstance,
 } from "../../utils/instance-cache";
 import { updateGroup, getInstanceGroup } from "../../utils/connect";
-import { getOrRegisterCustomTheme } from "../../themes";
+import { getOrRegisterCustomTheme, isKnownTheme } from "../../themes";
 import { shallowEqual } from "../../utils/shallow-equal";
 import { bindEvents, unbindEvents, eventsEqual } from "./event-utils";
 
@@ -45,6 +45,12 @@ function computeThemeKey(theme: string | object | null | undefined): string | nu
 }
 
 /**
+ * Names already warned about in dev to prevent log spam.
+ * dev 模式下已警告过的名称，避免重复输出。
+ */
+const warnedThemeNames: Set<string> = new Set();
+
+/**
  * Resolve theme to a registered ECharts theme name (has side effects).
  * Must only be called inside effects, not during render.
  * 将主题解析为已注册的 ECharts 主题名称（有副作用，仅可在 effect 内调用）。
@@ -57,7 +63,21 @@ function resolveThemeName(
   themeKey: string | null,
 ): string | null {
   if (theme == null) return null;
-  if (typeof theme === "string") return theme;
+  if (typeof theme === "string") {
+    if (
+      process.env.NODE_ENV !== "production" &&
+      !isKnownTheme(theme) &&
+      !warnedThemeNames.has(theme)
+    ) {
+      warnedThemeNames.add(theme);
+      console.warn(
+        `react-use-echarts: theme "${theme}" is not built-in and was not registered via registerCustomTheme(). ` +
+          `If you registered it directly with echarts.registerTheme(), switch to registerCustomTheme() to silence this warning. ` +
+          `Unknown names silently fall back to the default theme.`,
+      );
+    }
+    return theme;
+  }
   if (typeof theme !== "object") return null;
   const contentHash = themeKey && !themeKey.startsWith(CIRCULAR_PREFIX) ? themeKey : undefined;
   return getOrRegisterCustomTheme(theme, contentHash);
@@ -295,7 +315,7 @@ export function useChartCore(
     if (!instance) return;
 
     const last = lastAppliedRef.current;
-    if (last && shallowEqual(last.option, option) && last.opts === setOptionOpts) return;
+    if (last && shallowEqual(last.option, option) && shallowEqual(last.opts, setOptionOpts)) return;
 
     try {
       instance.setOption(option, setOptionOpts);

--- a/src/hooks/internal/use-resize-observer.ts
+++ b/src/hooks/internal/use-resize-observer.ts
@@ -1,11 +1,18 @@
-import { useEffect, type RefObject } from "react";
+import { useEffect, useRef, type RefObject } from "react";
 import { getCachedInstance } from "../../utils/instance-cache";
 
 /**
  * Internal hook: ResizeObserver-based auto-resize with RAF throttle.
  * 内部 hook：基于 ResizeObserver 的自动 resize，使用 RAF 节流。
  */
-export function useResizeObserver(ref: RefObject<HTMLElement | null>, autoResize: boolean): void {
+export function useResizeObserver(
+  ref: RefObject<HTMLElement | null>,
+  autoResize: boolean,
+  onError?: (error: unknown) => void,
+): void {
+  const onErrorRef = useRef(onError);
+  onErrorRef.current = onError;
+
   useEffect(() => {
     if (!autoResize) return;
 
@@ -27,7 +34,11 @@ export function useResizeObserver(ref: RefObject<HTMLElement | null>, autoResize
       });
       resizeObserver.observe(element);
     } catch (error) {
-      console.warn("ResizeObserver not available:", error);
+      if (onErrorRef.current) {
+        onErrorRef.current(error);
+      } else {
+        console.warn("ResizeObserver not available:", error);
+      }
     }
 
     return () => {

--- a/src/hooks/use-echarts.ts
+++ b/src/hooks/use-echarts.ts
@@ -47,7 +47,7 @@ function useEcharts(
     onError,
   });
 
-  useResizeObserver(ref, autoResize);
+  useResizeObserver(ref, autoResize, onError);
 
   const resize = useCallback(() => {
     getInstance()?.resize();

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,6 +33,7 @@ export type {
   UseEchartsReturn,
   EChartsEvents,
   EChartsEventConfig,
+  EChartsEventHandler,
   EChartsInitOpts,
   EChartProps,
   BuiltinTheme,
@@ -43,4 +44,4 @@ export type {
  * Theme utilities (lightweight, no JSON bundled)
  * 主题工具函数（轻量，不含 JSON）
  */
-export { isBuiltinTheme, registerCustomTheme } from "./themes";
+export { isBuiltinTheme, isKnownTheme, registerCustomTheme } from "./themes";

--- a/src/themes/index.ts
+++ b/src/themes/index.ts
@@ -8,6 +8,15 @@ import type { BuiltinTheme } from "../types";
 const BUILTIN_THEME_NAMES: ReadonlySet<string> = new Set<string>(["light", "dark", "macarons"]);
 
 /**
+ * Names known to be registered via this library's API. Used by `isKnownTheme`
+ * for dev-time validation. External `echarts.registerTheme(...)` calls are
+ * invisible here — route through `registerCustomTheme` to suppress warnings.
+ * 通过本库 API 注册过的主题名。外部直接调用 `echarts.registerTheme` 的名字不会被记录，
+ * 若要消除 dev 警告请改用 `registerCustomTheme`。
+ */
+const knownThemeNames: Set<string> = new Set<string>();
+
+/**
  * Cache for custom theme names (theme object -> registered theme name)
  * 自定义主题名称缓存（主题对象 -> 已注册的主题名称）
  * Uses WeakMap to allow garbage collection of theme objects
@@ -41,6 +50,17 @@ export function isBuiltinTheme(themeName: string): themeName is BuiltinTheme {
 }
 
 /**
+ * Whether a theme name is either built-in or has been registered through this
+ * library's API (`registerCustomTheme` / `getOrRegisterCustomTheme`).
+ * Names registered directly via `echarts.registerTheme` will return `false`.
+ * 判断主题名是否为内置主题或通过本库 API 注册过。外部直接通过
+ * `echarts.registerTheme` 注册的名称会返回 `false`。
+ */
+export function isKnownTheme(themeName: string): boolean {
+  return BUILTIN_THEME_NAMES.has(themeName) || knownThemeNames.has(themeName);
+}
+
+/**
  * Register a custom theme
  * 注册自定义主题
  * @param themeName Theme name
@@ -48,6 +68,7 @@ export function isBuiltinTheme(themeName: string): themeName is BuiltinTheme {
  */
 export function registerCustomTheme(themeName: string, themeConfig: object): void {
   echarts.registerTheme(themeName, themeConfig);
+  knownThemeNames.add(themeName);
 }
 
 /**
@@ -97,6 +118,7 @@ export function getOrRegisterCustomTheme(themeConfig: object, precomputedHash?: 
   // Register new theme
   const themeName = `__custom_theme_${customThemeCounter++}`;
   echarts.registerTheme(themeName, themeConfig);
+  knownThemeNames.add(themeName);
   customThemeCache.set(themeConfig, themeName);
   if (contentHash) {
     if (contentHashCache.size >= MAX_CONTENT_CACHE_SIZE) {
@@ -119,5 +141,6 @@ export function getOrRegisterCustomTheme(themeConfig: object, precomputedHash?: 
  */
 export function clearThemeCache(): void {
   contentHashCache.clear();
+  knownThemeNames.clear();
   customThemeCounter = 0;
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -13,20 +13,30 @@ import type { CSSProperties } from "react";
 export type BuiltinTheme = "light" | "dark" | "macarons";
 
 /**
+ * Event handler signature. Params defaults to `any` so consumers can annotate
+ * concrete ECharts event types (e.g. `ECElementEvent`) without casting.
+ * 事件处理函数签名。参数默认为 `any`，便于使用方直接标注具体的 ECharts 事件类型。
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- see docstring
+export type EChartsEventHandler<TParams = any> = (params: TParams) => void;
+
+/**
  * Event configuration: shorthand function or full config object
  * 事件配置：简写函数或完整配置对象
  * @example
  * ```typescript
  * // Shorthand 简写
  * onEvents={{ click: (params) => console.log(params) }}
+ * // Typed params 明确参数类型
+ * onEvents={{ click: (params: ECElementEvent) => console.log(params.data) }}
  * // Full config 完整写法
  * onEvents={{ click: { handler: fn, query: 'series' } }}
  * ```
  */
 export type EChartsEventConfig =
-  | ((params: unknown) => void)
+  | EChartsEventHandler
   | {
-      handler: (params: unknown) => void;
+      handler: EChartsEventHandler;
       query?: string | object;
       context?: object;
     };
@@ -111,8 +121,19 @@ export interface UseEchartsOptions {
   option: EChartsOption;
 
   /**
-   * Theme: any registered theme name | custom object | null
-   * 主题：任意已注册主题名 | 自定义对象 | null
+   * Theme. Accepts one of:
+   * - a built-in name: `"light" | "dark" | "macarons"`
+   * - any theme name already registered via `registerCustomTheme()` or `echarts.registerTheme()`
+   *   — unknown strings silently fall back to the default theme (typos are NOT detected at runtime)
+   * - a custom theme config object (auto-deduplicated by content hash)
+   * - `null` / `undefined` for the default theme
+   *
+   * 主题。可为：
+   * - 内置主题名：`"light" | "dark" | "macarons"`
+   * - 已通过 `registerCustomTheme()` 或 `echarts.registerTheme()` 注册过的任意主题名
+   *   —— 未知字符串会静默回退到默认主题（运行时不会检测拼写错误）
+   * - 自定义主题配置对象（按内容哈希自动去重）
+   * - `null` / `undefined` 表示默认主题
    */
   theme?: BuiltinTheme | (string & {}) | object | null;
 


### PR DESCRIPTION
## Summary

- **API polish** — route ResizeObserver init failures through `onError`, shallow-compare `setOptionOpts` to skip redundant `setOption`, warn once in dev for unknown theme names (new `isKnownTheme` helper), drop hardcoded 400px `minHeight` from `EChart`, loosen event handler params via `EChartsEventHandler` so consumers can type concrete event objects without casting.
- **Examples overhaul** — restructure examples site with routing, Gallery/Features split, theme sync, hero/footer, dynamic data, renderer toggle, and expanded demo set.
- **Internals** — trim public API, relocate misplaced dep, and dedup loading effect.
- **Toolchain** — bump `vite-plus` to ^0.1.18.

## Test plan

- [x] `vp check` — lint + format + typecheck pass
- [x] `vp test run` — 167/167 tests pass
- [ ] Smoke-test examples site (`vp dev`) in reviewer's browser
- [ ] Verify built artifacts (`vp pack`) before publishing

🤖 Generated with [Claude Code](https://claude.com/claude-code)