### PR TITLE
test: cover onError path for ResizeObserver constructor failure

### DIFF
--- a/src/__tests__/hooks/use-echarts.test.ts
+++ b/src/__tests__/hooks/use-echarts.test.ts
@@ -931,6 +931,32 @@ describe("useEcharts", () => {
       globalThis.ResizeObserver = originalResizeObserver;
     });
 
+    it("should route ResizeObserver constructor failure to onError when provided", () => {
+      const originalResizeObserver = globalThis.ResizeObserver;
+      const thrown = new Error("ResizeObserver not supported");
+      globalThis.ResizeObserver = class {
+        constructor() {
+          throw thrown;
+        }
+      } as unknown as typeof ResizeObserver;
+
+      const onError = vi.fn();
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+      const element = document.createElement("div");
+      const ref = { current: element };
+      const mockInstance = createMockInstance(element);
+      (echarts.init as ReturnType<typeof vi.fn>).mockReturnValue(mockInstance);
+
+      renderHook(() => useEcharts(ref, { option: baseOption, onError }));
+
+      expect(onError).toHaveBeenCalledWith(thrown);
+      expect(warnSpy).not.toHaveBeenCalled();
+
+      warnSpy.mockRestore();
+      globalThis.ResizeObserver = originalResizeObserver;
+    });
+
     it("should disconnect resize observer on unmount", () => {
       const element = document.createElement("div");
       const ref = { current: element };


### PR DESCRIPTION
## Summary
- Adds a test case that exercises the `onError` branch in `useResizeObserver` when the `ResizeObserver` constructor throws, asserting the error is routed to the caller callback and not `console.warn`.
- Restores 100% coverage (statements/branches/functions/lines) after the earlier error-routing refactor.

## Test plan
- [x] `vp test run --coverage` — 168/168 passing, 100% coverage
- [x] `vp check` — format + lint + typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)