### PR TITLE
feat(examples): restyle site with playground/compare, a11y + theme fixes

### DIFF
--- a/examples/App.tsx
+++ b/examples/App.tsx
@@ -5,6 +5,8 @@ import Home from "./pages/Home";
 import GalleryIndex from "./pages/GalleryIndex";
 import FeaturesIndex from "./pages/FeaturesIndex";
 import DemoDetail from "./pages/DemoDetail";
+import Playground from "./pages/Playground";
+import Compare from "./pages/Compare";
 
 const App: React.FC = () => {
   return (
@@ -16,6 +18,8 @@ const App: React.FC = () => {
           <Route path="gallery/:id" element={<DemoDetail kind="gallery" />} />
           <Route path="features" element={<FeaturesIndex />} />
           <Route path="features/:id" element={<DemoDetail kind="features" />} />
+          <Route path="playground" element={<Playground />} />
+          <Route path="compare" element={<Compare />} />
           <Route path="*" element={<Navigate to="/" replace />} />
         </Route>
       </Routes>

--- a/examples/components/CodeBlock.module.css
+++ b/examples/components/CodeBlock.module.css
@@ -9,7 +9,7 @@
   align-items: center;
   justify-content: space-between;
   padding: 6px 10px;
-  background: var(--c-surface-dim);
+  background: var(--c-surface-2);
   border-bottom: 1px solid var(--c-border);
 }
 

--- a/examples/components/CompareTable.module.css
+++ b/examples/components/CompareTable.module.css
@@ -1,0 +1,118 @@
+.tableWrap {
+  border: 1px solid var(--c-border);
+  background: var(--c-surface);
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+}
+.table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 13px;
+}
+.table thead {
+  background: var(--c-surface-2);
+}
+.th,
+.thLabel {
+  text-align: left;
+  padding: 14px 18px;
+  font-family: var(--mono);
+  font-size: 11.5px;
+  font-weight: 500;
+  color: var(--c-text);
+  border-bottom: 1px solid var(--c-border);
+  text-transform: none;
+  vertical-align: top;
+}
+.th {
+  text-align: center;
+}
+.thHook {
+  background: color-mix(in srgb, var(--c-accent) 6%, transparent);
+  color: var(--c-text);
+}
+
+.tag {
+  display: inline-block;
+  font-family: var(--mono);
+  font-size: 9.5px;
+  color: var(--c-text-3);
+  background: var(--c-surface);
+  border: 1px solid var(--c-border);
+  border-radius: 3px;
+  padding: 1px 5px;
+  margin-bottom: 4px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+.thHook .tag {
+  color: var(--c-accent-inv);
+  background: var(--c-accent);
+  border-color: var(--c-accent);
+}
+
+.thLabel {
+  width: 38%;
+}
+.th {
+  width: 20.66%;
+}
+
+.tdLabel,
+.td {
+  padding: 12px 18px;
+  border-bottom: 1px solid var(--c-border);
+}
+.td {
+  text-align: center;
+  vertical-align: middle;
+}
+.tdLabel {
+  color: var(--c-text);
+  font-weight: 500;
+}
+.tdHook {
+  background: color-mix(in srgb, var(--c-accent) 4%, transparent);
+}
+
+.table tbody tr:last-child .tdLabel,
+.table tbody tr:last-child .td {
+  border-bottom: 0;
+}
+
+.yes {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  color: var(--c-accent-inv);
+  background: var(--c-accent);
+  border-radius: 50%;
+}
+.no {
+  color: var(--c-text-3);
+  font-family: var(--mono);
+}
+.txt {
+  font-family: var(--mono);
+  font-size: 12px;
+  color: var(--c-text);
+  padding: 2px 8px;
+  background: var(--c-surface-2);
+  border: 1px solid var(--c-border);
+  border-radius: 3px;
+}
+
+@media (max-width: 720px) {
+  .th,
+  .thLabel,
+  .td,
+  .tdLabel {
+    padding: 10px 10px;
+    font-size: 12px;
+  }
+  .thLabel {
+    width: 50%;
+  }
+}

--- a/examples/components/CompareTable.tsx
+++ b/examples/components/CompareTable.tsx
@@ -1,0 +1,74 @@
+import React from "react";
+import Icon from "./Icon";
+import styles from "./CompareTable.module.css";
+
+interface Row {
+  readonly label: string;
+  readonly hook: boolean | string;
+  readonly raw: boolean | string;
+  readonly other: boolean | string;
+}
+
+const ROWS: readonly Row[] = [
+  { label: "Bundle (min+gzip)", hook: "2.1 kB", raw: "—", other: "8–14 kB" },
+  { label: "Auto-resize on container change", hook: true, raw: false, other: "varies" },
+  { label: "Lazy init via IntersectionObserver", hook: true, raw: false, other: false },
+  { label: "Theme switching at runtime", hook: true, raw: "manual", other: "varies" },
+  { label: "Imperative ref API (resize/setOption)", hook: true, raw: true, other: "varies" },
+  { label: "Chart group linkage helper", hook: true, raw: "manual", other: false },
+  { label: "Loading overlay toggle", hook: true, raw: "manual", other: "varies" },
+  { label: "TypeScript types (strict)", hook: true, raw: true, other: "varies" },
+];
+
+const Cell: React.FC<{ readonly v: boolean | string }> = ({ v }) => {
+  if (v === true)
+    return (
+      <span className={styles.yes}>
+        <Icon name="check" size={14} />
+      </span>
+    );
+  if (v === false) return <span className={styles.no}>—</span>;
+  return <span className={styles.txt}>{v}</span>;
+};
+
+const CompareTable: React.FC = () => (
+  <div className={styles.tableWrap}>
+    <table className={styles.table}>
+      <thead>
+        <tr>
+          <th className={styles.thLabel}>Capability</th>
+          <th className={`${styles.th} ${styles.thHook}`}>
+            <span className={styles.tag}>this lib</span>
+            react-use-echarts
+          </th>
+          <th className={styles.th}>
+            <span className={styles.tag}>raw</span>
+            echarts only
+          </th>
+          <th className={styles.th}>
+            <span className={styles.tag}>alt</span>
+            other wrappers
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        {ROWS.map((r) => (
+          <tr key={r.label}>
+            <td className={styles.tdLabel}>{r.label}</td>
+            <td className={`${styles.td} ${styles.tdHook}`}>
+              <Cell v={r.hook} />
+            </td>
+            <td className={styles.td}>
+              <Cell v={r.raw} />
+            </td>
+            <td className={styles.td}>
+              <Cell v={r.other} />
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  </div>
+);
+
+export default CompareTable;

--- a/examples/components/DemoTabs.module.css
+++ b/examples/components/DemoTabs.module.css
@@ -1,103 +1,72 @@
 .wrapper {
   border: 1px solid var(--c-border);
-  border-radius: var(--radius);
-  background: var(--c-surface);
-  box-shadow: var(--c-shadow);
+  border-radius: var(--radius-lg);
   overflow: hidden;
+  background: var(--c-surface);
 }
-
 .toolbar {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 8px;
-  padding: 6px 6px 6px 10px;
+  background: var(--c-surface-2);
   border-bottom: 1px solid var(--c-border);
-  background: var(--c-surface-dim);
+  padding: 0 8px 0 4px;
 }
-
 .tabs {
-  display: inline-flex;
-  gap: 2px;
-  background: var(--c-surface);
-  border: 1px solid var(--c-border);
-  border-radius: var(--radius);
-  padding: 2px;
+  display: flex;
+  align-items: center;
 }
-
 .tab {
-  padding: 4px 12px;
+  padding: 10px 14px;
+  font-family: var(--mono);
   font-size: 12px;
-  font-weight: 500;
-  border: 0;
-  border-radius: calc(var(--radius) - 2px);
-  background: none;
-  color: var(--c-text-2);
-  cursor: pointer;
+  color: var(--c-text-3);
+  border-bottom: 2px solid transparent;
+  margin-bottom: -1px;
   transition:
     color 0.12s,
-    background-color 0.12s;
+    border-color 0.12s;
 }
-
 .tab:hover {
-  color: var(--c-text);
+  color: var(--c-text-2);
 }
-
 .tabActive {
-  background: var(--c-accent-soft);
   color: var(--c-text);
+  border-bottom-color: var(--c-accent);
+  background: var(--c-surface);
 }
-
 .actions {
   display: flex;
-  gap: 6px;
+  gap: 4px;
 }
-
 .iconLink {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 30px;
-  height: 30px;
-  border: 1px solid var(--c-border);
-  border-radius: var(--radius);
-  background: var(--c-surface);
+  width: 28px;
+  height: 28px;
   color: var(--c-text-2);
+  border-radius: 4px;
   transition:
     color 0.12s,
-    border-color 0.12s,
-    background-color 0.12s;
+    background 0.12s;
 }
-
 .iconLink:hover {
   color: var(--c-text);
-  border-color: var(--c-text-2);
-  background: var(--c-surface-dim);
+  background: var(--c-surface-3);
 }
 
 .body {
-  padding: 16px;
+  padding: 18px 18px 20px;
 }
-
 .bodyCode {
   padding: 0;
+  background: var(--c-surface);
 }
-
 .placeholder {
   margin: 0;
-  padding: 14px;
-  font-size: 13px;
-  color: var(--c-text-2);
-}
-
-@media (max-width: 860px) {
-  .toolbar {
-    flex-direction: column;
-    align-items: stretch;
-    gap: 6px;
-  }
-
-  .actions {
-    justify-content: flex-end;
-  }
+  padding: 16px;
+  font-family: var(--mono);
+  font-size: 12px;
+  color: var(--c-text-3);
 }

--- a/examples/components/FeatureCard.module.css
+++ b/examples/components/FeatureCard.module.css
@@ -1,62 +1,84 @@
 .card {
   display: flex;
   flex-direction: column;
-  gap: 10px;
-  padding: 18px;
-  border: 1px solid var(--c-border);
-  border-radius: var(--radius);
+  padding: 20px 20px 16px;
   background: var(--c-surface);
-  color: inherit;
+  border: 1px solid var(--c-border);
+  border-radius: var(--radius-lg);
   transition:
     border-color 0.15s,
-    transform 0.15s,
-    box-shadow 0.15s;
+    background-color 0.15s,
+    transform 0.15s;
+  position: relative;
+  min-height: 180px;
 }
-
 .card:hover {
-  border-color: var(--c-text-2);
-  transform: translateY(-2px);
-  box-shadow: var(--c-shadow);
+  border-color: var(--c-border-strong);
+  background: var(--c-surface);
+  transform: translateY(-1px);
+  box-shadow: var(--shadow-sm);
 }
 
-.iconWrap {
-  display: inline-flex;
+.top {
+  display: flex;
   align-items: center;
-  justify-content: center;
-  width: 36px;
-  height: 36px;
-  border-radius: calc(var(--radius) + 2px);
-  background: var(--c-accent-soft);
-  color: var(--c-text);
+  justify-content: space-between;
+  margin-bottom: 18px;
+}
+.idx {
+  font-family: var(--mono);
+  font-size: 10.5px;
+  color: var(--c-text-3);
+  letter-spacing: 0.05em;
+}
+.icon {
+  color: var(--c-text-2);
 }
 
 .title {
   font-size: 15px;
   font-weight: 600;
-  margin: 0;
+  letter-spacing: -0.01em;
+  color: var(--c-text);
+  margin-bottom: 6px;
 }
-
 .desc {
-  font-size: 13px;
-  color: var(--c-text-2);
+  font-size: 12.5px;
   line-height: 1.5;
-  margin: 0;
+  color: var(--c-text-2);
   flex: 1;
+  text-wrap: pretty;
 }
-
-.footer {
+.foot {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-top: 14px;
+  padding-top: 12px;
+  border-top: 1px solid var(--c-border);
+}
+.id {
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--c-text-3);
+}
+.cta {
   display: inline-flex;
   align-items: center;
-  gap: 4px;
-  font-size: 13px;
-  font-weight: 500;
-  color: var(--c-text);
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  color: var(--c-text-3);
+  border: 1px solid var(--c-border);
+  border-radius: 50%;
+  transition:
+    color 0.15s,
+    background 0.15s,
+    transform 0.15s;
 }
-
-.footer :global(svg) {
-  transition: transform 0.15s;
-}
-
-.card:hover .footer :global(svg) {
+.card:hover .cta {
+  color: var(--c-accent-inv);
+  background: var(--c-accent);
+  border-color: var(--c-accent);
   transform: translateX(2px);
 }

--- a/examples/components/FeatureCard.tsx
+++ b/examples/components/FeatureCard.tsx
@@ -6,20 +6,24 @@ import styles from "./FeatureCard.module.css";
 
 interface FeatureCardProps {
   readonly item: FeatureItem;
+  readonly index: number;
 }
 
-const FeatureCard: React.FC<FeatureCardProps> = ({ item }) => {
+const FeatureCard: React.FC<FeatureCardProps> = ({ item, index }) => {
   return (
     <Link to={`/features/${item.id}`} className={styles.card}>
-      <div className={styles.iconWrap}>
-        <Icon name={item.icon} size={18} />
+      <div className={styles.top}>
+        <span className={styles.idx}>{String(index + 1).padStart(2, "0")}</span>
+        <Icon name={item.icon} size={16} className={styles.icon} />
       </div>
       <h3 className={styles.title}>{item.title}</h3>
       <p className={styles.desc}>{item.description}</p>
-      <span className={styles.footer}>
-        Try it
-        <Icon name="arrow-right" size={14} />
-      </span>
+      <div className={styles.foot}>
+        <span className={styles.id}>id: {item.id}</span>
+        <span className={styles.cta}>
+          <Icon name="arrow-right" size={13} />
+        </span>
+      </div>
     </Link>
   );
 };

--- a/examples/components/Footer.module.css
+++ b/examples/components/Footer.module.css
@@ -1,34 +1,53 @@
 .footer {
-  margin-top: auto;
-  padding: 32px 0 24px;
+  margin-top: 64px;
+  padding: 28px 0 32px;
   border-top: 1px solid var(--c-border);
-  text-align: center;
 }
-
-.links {
+.row {
   display: flex;
-  justify-content: center;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  flex-wrap: wrap;
+  margin-bottom: 12px;
+}
+.brand {
+  display: inline-flex;
   align-items: center;
   gap: 8px;
-  margin-bottom: 8px;
-  font-size: 13px;
+  font-family: var(--mono);
+  font-size: 12.5px;
+  color: var(--c-text);
 }
-
+.brandMark {
+  width: 22px;
+  height: 22px;
+  background: var(--c-accent);
+  display: grid;
+  place-items: center;
+  border-radius: 3px;
+}
+.dim {
+  color: var(--c-text-3);
+}
+.dot {
+  color: var(--c-text-3);
+}
+.links {
+  display: flex;
+  gap: 16px;
+}
 .links a {
+  font-family: var(--mono);
+  font-size: 12.5px;
   color: var(--c-text-2);
-  transition: color 0.15s;
+  transition: color 0.12s;
 }
-
 .links a:hover {
   color: var(--c-text);
 }
-
-.dot {
-  color: var(--c-text-2);
-}
-
 .copy {
-  font-size: 12px;
-  color: var(--c-text-2);
-  margin: 0;
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--c-text-3);
 }

--- a/examples/components/Footer.tsx
+++ b/examples/components/Footer.tsx
@@ -1,27 +1,52 @@
 import React from "react";
+import { APP_VERSION } from "../data/meta";
 import styles from "./Footer.module.css";
 
 const Footer: React.FC = () => {
   return (
     <footer className={styles.footer}>
-      <div className={styles.links}>
-        <a href="https://www.npmjs.com/package/react-use-echarts" target="_blank" rel="noreferrer">
-          npm
-        </a>
-        <span className={styles.dot}>·</span>
-        <a href="https://github.com/chensid/react-use-echarts" target="_blank" rel="noreferrer">
-          GitHub
-        </a>
-        <span className={styles.dot}>·</span>
-        <a
-          href="https://github.com/chensid/react-use-echarts#api-reference"
-          target="_blank"
-          rel="noreferrer"
-        >
-          API Reference
-        </a>
+      <div className={styles.row}>
+        <div className={styles.brand}>
+          <span className={styles.brandMark}>
+            <svg width="14" height="14" viewBox="0 0 32 32" aria-hidden>
+              <path
+                d="M7 22V10h3v12H7zm5-4V10h3v8h-3zm5 2V10h3v10h-3zm5-6V10h3v4h-3z"
+                fill="var(--c-accent-inv)"
+              />
+            </svg>
+          </span>
+          <span>
+            <b>react-use-echarts</b>
+          </span>
+          <span className={styles.dot}>·</span>
+          <span className={styles.dim}>v{APP_VERSION} · MIT</span>
+        </div>
+        <nav className={styles.links}>
+          <a
+            href="https://www.npmjs.com/package/react-use-echarts"
+            target="_blank"
+            rel="noreferrer"
+          >
+            npm
+          </a>
+          <a href="https://github.com/chensid/react-use-echarts" target="_blank" rel="noreferrer">
+            GitHub
+          </a>
+          <a
+            href="https://github.com/chensid/react-use-echarts#api-reference"
+            target="_blank"
+            rel="noreferrer"
+          >
+            API
+          </a>
+          <a href="https://echarts.apache.org/" target="_blank" rel="noreferrer">
+            ECharts ↗
+          </a>
+        </nav>
       </div>
-      <p className={styles.copy}>MIT License · Built with React + ECharts</p>
+      <p className={styles.copy}>
+        Built with React + ECharts 6. Open-source software released under the MIT license.
+      </p>
     </footer>
   );
 };

--- a/examples/components/Header.module.css
+++ b/examples/components/Header.module.css
@@ -3,44 +3,120 @@
   top: 0;
   left: 0;
   right: 0;
-  z-index: 30;
+  z-index: 40;
   height: var(--header-height);
+  display: flex;
+  align-items: stretch;
+  background: color-mix(in srgb, var(--c-bg) 85%, transparent);
+  backdrop-filter: saturate(180%) blur(10px);
+  -webkit-backdrop-filter: saturate(180%) blur(10px);
+  border-bottom: 1px solid var(--c-border);
+}
+.inner {
+  flex: 1;
   display: flex;
   align-items: center;
   justify-content: space-between;
   padding: 0 20px;
-  background: var(--c-bg);
-  border-bottom: 1px solid var(--c-border);
+  max-width: var(--max-w);
+  margin: 0 auto;
+  width: 100%;
 }
-
 .left {
   display: flex;
   align-items: center;
-  gap: 10px;
+  gap: 16px;
 }
-
 .brand {
   display: inline-flex;
   align-items: center;
-  gap: 8px;
-  color: inherit;
+  gap: 10px;
+  font-family: var(--mono);
+  font-size: 13px;
+  font-weight: 500;
+  letter-spacing: -0.01em;
+  color: var(--c-text);
 }
-
-.logo {
+.mark {
+  width: 22px;
+  height: 22px;
+  background: var(--c-accent);
+  display: grid;
+  place-items: center;
+  border-radius: 3px;
   flex-shrink: 0;
 }
-
-.name {
-  font-size: 15px;
+.name b {
   font-weight: 600;
-  letter-spacing: -0.01em;
-  white-space: nowrap;
+}
+
+.version {
+  font-family: var(--mono);
+  font-size: 11.5px;
+  color: var(--c-text-3);
+  padding: 3px 6px;
+  border: 1px solid var(--c-border);
+  border-radius: 3px;
+}
+.verDot {
+  display: inline-block;
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  background: var(--chart-success);
+  margin-right: 5px;
+  vertical-align: 1px;
+}
+
+.nav {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  margin-left: 6px;
+}
+.navLink {
+  padding: 6px 10px;
+  font-size: 13px;
+  color: var(--c-text-2);
+  border-radius: 3px;
+  transition:
+    color 0.12s,
+    background-color 0.12s;
+}
+.navLink:hover {
+  color: var(--c-text);
+}
+.navLinkActive {
+  color: var(--c-text);
+  background: var(--c-surface-2);
 }
 
 .right {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: 6px;
+}
+
+.iconBtn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  height: 30px;
+  min-width: 30px;
+  padding: 0 8px;
+  color: var(--c-text-2);
+  border: 1px solid var(--c-border);
+  border-radius: var(--radius);
+  background: var(--c-surface);
+  transition:
+    color 0.12s,
+    border-color 0.12s,
+    background-color 0.12s;
+}
+.iconBtn:hover {
+  color: var(--c-text);
+  border-color: var(--c-border-strong);
+  background: var(--c-surface-2);
 }
 
 .burger {
@@ -56,8 +132,10 @@
     display: flex;
     padding: 10px;
   }
-
-  .name {
-    font-size: 13px;
+  .nav {
+    display: none;
+  }
+  .version {
+    display: none;
   }
 }

--- a/examples/components/Header.tsx
+++ b/examples/components/Header.tsx
@@ -1,56 +1,82 @@
 import React from "react";
-import { Link } from "react-router-dom";
+import { Link, NavLink } from "react-router-dom";
 import Icon from "./Icon";
 import { useTheme } from "./theme-context";
+import { APP_VERSION } from "../data/meta";
 import styles from "./Header.module.css";
 
 interface HeaderProps {
   readonly onSidebarToggle: () => void;
 }
 
+const navLinkClass = ({ isActive }: { isActive: boolean }) =>
+  `${styles.navLink} ${isActive ? styles.navLinkActive : ""}`;
+
 const Header: React.FC<HeaderProps> = ({ onSidebarToggle }) => {
   const { mode, toggle } = useTheme();
 
   return (
     <header className={styles.bar}>
-      <div className={styles.left}>
-        <button
-          type="button"
-          className={styles.burger}
-          onClick={onSidebarToggle}
-          aria-label="Toggle navigation"
-        >
-          <Icon name="menu" size={18} />
-        </button>
-        <Link to="/" className={styles.brand} aria-label="Home">
-          <svg className={styles.logo} width="22" height="22" viewBox="0 0 32 32">
-            <rect width="32" height="32" rx="6" fill="currentColor" />
-            <path
-              d="M7 22V10h3v12H7zm5-4V10h3v8h-3zm5 2V10h3v10h-3zm5-6V10h3v4h-3z"
-              fill={mode === "dark" ? "#18181b" : "#fff"}
-            />
-          </svg>
-          <span className={styles.name}>react-use-echarts</span>
-        </Link>
-      </div>
-      <div className={styles.right}>
-        <a
-          className="btn"
-          href="https://github.com/chensid/react-use-echarts"
-          target="_blank"
-          rel="noreferrer"
-        >
-          <Icon name="github" size={16} />
-          GitHub
-        </a>
-        <button
-          type="button"
-          className="btn"
-          onClick={toggle}
-          aria-label={mode === "dark" ? "Switch to light mode" : "Switch to dark mode"}
-        >
-          <Icon name={mode === "dark" ? "sun" : "moon"} size={15} />
-        </button>
+      <div className={styles.inner}>
+        <div className={styles.left}>
+          <button
+            type="button"
+            className={styles.burger}
+            onClick={onSidebarToggle}
+            aria-label="Toggle navigation"
+          >
+            <Icon name="menu" size={18} />
+          </button>
+          <Link to="/" className={styles.brand} aria-label="Home">
+            <span className={styles.mark}>
+              <svg width="14" height="14" viewBox="0 0 32 32" aria-hidden>
+                <path
+                  d="M7 22V10h3v12H7zm5-4V10h3v8h-3zm5 2V10h3v10h-3zm5-6V10h3v4h-3z"
+                  fill="var(--c-accent-inv)"
+                />
+              </svg>
+            </span>
+            <span className={styles.name}>
+              <b>react-use-echarts</b>
+            </span>
+          </Link>
+          <span className={styles.version} title="latest release">
+            <span className={styles.verDot} />v{APP_VERSION}
+          </span>
+          <nav className={styles.nav}>
+            <NavLink to="/" end className={navLinkClass}>
+              Home
+            </NavLink>
+            <NavLink to="/gallery" className={navLinkClass}>
+              Gallery
+            </NavLink>
+            <NavLink to="/features" className={navLinkClass}>
+              Features
+            </NavLink>
+            <NavLink to="/playground" className={navLinkClass}>
+              Playground
+            </NavLink>
+          </nav>
+        </div>
+        <div className={styles.right}>
+          <a
+            className={styles.iconBtn}
+            href="https://github.com/chensid/react-use-echarts"
+            target="_blank"
+            rel="noreferrer"
+            aria-label="GitHub"
+          >
+            <Icon name="github" size={14} />
+          </a>
+          <button
+            type="button"
+            className={styles.iconBtn}
+            onClick={toggle}
+            aria-label={mode === "dark" ? "Switch to light mode" : "Switch to dark mode"}
+          >
+            <Icon name={mode === "dark" ? "sun" : "moon"} size={14} />
+          </button>
+        </div>
       </div>
     </header>
   );

--- a/examples/components/Hero.module.css
+++ b/examples/components/Hero.module.css
@@ -1,113 +1,302 @@
 .hero {
-  text-align: center;
-  padding: 48px 0 32px;
+  display: grid;
+  grid-template-columns: minmax(0, 5fr) minmax(0, 7fr);
+  gap: 48px;
+  padding: 24px 0 56px;
+  border-bottom: 1px solid var(--c-border);
+  margin-bottom: 56px;
+  align-items: center;
+}
+
+.left {
+  min-width: 0;
+}
+
+.eyebrow {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-family: var(--mono);
+  font-size: 11.5px;
+  color: var(--c-text-3);
+  padding: 4px 10px;
+  background: var(--c-surface);
+  border: 1px solid var(--c-border);
+  border-radius: 999px;
+  margin-bottom: 24px;
+}
+.eyebrowDot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--chart-success);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--chart-success) 20%, transparent);
 }
 
 .title {
-  font-size: 40px;
-  font-weight: 700;
-  letter-spacing: -0.025em;
-  margin: 0 0 10px;
+  font-size: clamp(38px, 5vw, 56px);
+  font-weight: 600;
+  line-height: 1.05;
+  letter-spacing: -0.035em;
+  margin-bottom: 18px;
+  text-wrap: balance;
+}
+.titleAccent {
+  font-family: var(--mono);
+  font-weight: 500;
+  font-size: 0.9em;
+  background: var(--c-surface-2);
+  padding: 0 8px;
+  border-radius: 4px;
+  border: 1px solid var(--c-border);
 }
 
 .tagline {
   font-size: 16px;
   color: var(--c-text-2);
-  margin: 0 auto 24px;
-  max-width: 560px;
   line-height: 1.55;
+  max-width: 560px;
+  margin-bottom: 28px;
+  text-wrap: pretty;
+}
+.inlineCode {
+  font-family: var(--mono);
+  font-size: 0.88em;
+  padding: 1px 5px;
+  background: var(--c-surface-2);
+  border: 1px solid var(--c-border);
+  border-radius: 3px;
+  color: var(--c-text);
 }
 
 .install {
-  display: inline-flex;
+  display: flex;
   align-items: center;
   gap: 8px;
-  padding: 6px 6px 6px 14px;
-  background: var(--c-surface-dim);
+  padding: 10px 12px;
+  background: var(--c-surface);
   border: 1px solid var(--c-border);
-  border-radius: var(--radius);
-  margin-bottom: 20px;
+  border-radius: var(--radius-lg);
+  margin-bottom: 24px;
+  max-width: 480px;
 }
-
+.prompt {
+  font-family: var(--mono);
+  color: var(--c-text-3);
+  font-size: 13px;
+}
 .cmd {
+  flex: 1;
   font-family: var(--mono);
   font-size: 13px;
   color: var(--c-text);
-  user-select: all;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.copyBtn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  color: var(--c-text-2);
+  background: var(--c-surface-2);
+  border: 1px solid var(--c-border);
+  border-radius: 4px;
+  transition:
+    color 0.12s,
+    background 0.12s;
+}
+.copyBtn:hover {
+  color: var(--c-text);
+  background: var(--c-surface-3);
 }
 
 .ctaRow {
   display: flex;
-  justify-content: center;
-  gap: 10px;
-  margin-bottom: 28px;
   flex-wrap: wrap;
+  gap: 8px;
+  margin-bottom: 32px;
 }
 
-.ctaPrimary {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  padding: 9px 20px;
-  font-size: 14px;
-  font-weight: 600;
-  color: var(--c-bg);
-  background: var(--c-accent);
-  border-radius: var(--radius);
-  transition:
-    opacity 0.15s,
-    transform 0.15s;
+.metaRow {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 0;
+  border-top: 1px solid var(--c-border);
+  padding-top: 20px;
+  max-width: 480px;
 }
-
-.ctaPrimary:hover {
-  opacity: 0.88;
-  transform: translateY(-1px);
+.metaRow > div {
+  padding-right: 16px;
+  border-right: 1px solid var(--c-border);
 }
-
-.ctaSecondary {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  padding: 9px 18px;
+.metaRow > div:last-child {
+  border-right: 0;
+  padding-left: 16px;
+  padding-right: 0;
+}
+.metaRow > div:not(:first-child):not(:last-child) {
+  padding-left: 16px;
+}
+.metaRow dt {
+  font-family: var(--mono);
+  font-size: 10.5px;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  color: var(--c-text-3);
+  margin-bottom: 4px;
+}
+.metaRow dd {
+  font-family: var(--mono);
   font-size: 14px;
   font-weight: 500;
   color: var(--c-text);
+}
+.metaRow dd span {
+  display: block;
+  font-weight: 400;
+  font-size: 11px;
+  color: var(--c-text-3);
+  margin-top: 2px;
+}
+
+/* right panel */
+.right {
+  min-width: 0;
+}
+.panel {
   background: var(--c-surface);
   border: 1px solid var(--c-border);
-  border-radius: var(--radius);
-  transition:
-    border-color 0.15s,
-    background-color 0.15s;
+  border-radius: 8px;
+  box-shadow: var(--shadow-md);
+  overflow: hidden;
 }
-
-.ctaSecondary:hover {
-  border-color: var(--c-text-2);
-  background: var(--c-surface-dim);
-}
-
-.badges {
+.panelTabs {
   display: flex;
-  justify-content: center;
-  gap: 8px;
-  flex-wrap: wrap;
+  align-items: center;
+  background: var(--c-surface-2);
+  border-bottom: 1px solid var(--c-border);
+  padding: 0 4px;
+}
+.panelTab {
+  padding: 10px 12px;
+  font-family: var(--mono);
+  font-size: 12px;
+  color: var(--c-text-3);
+  border-bottom: 2px solid transparent;
+  margin-bottom: -1px;
+  transition:
+    color 0.12s,
+    border-color 0.12s;
+}
+.panelTab:hover {
+  color: var(--c-text-2);
+}
+.panelTabActive {
+  color: var(--c-text);
+  border-bottom-color: var(--c-accent);
+  background: var(--c-surface);
+}
+.panelStatus {
+  margin-left: auto;
+  padding-right: 12px;
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-family: var(--mono);
+  font-size: 10.5px;
+  color: var(--c-text-3);
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+}
+.statusDot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--chart-success);
+  animation: heroPulse 2s ease-in-out infinite;
+}
+@keyframes heroPulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.4;
+  }
 }
 
-@media (max-width: 860px) {
+.panelBody {
+  display: grid;
+  grid-template-rows: auto auto;
+}
+.code {
+  padding: 14px 16px;
+  font-family: var(--mono);
+  font-size: 11.5px;
+  line-height: 1.65;
+  color: var(--c-text-2);
+  overflow-x: auto;
+  background: var(--c-surface);
+  margin: 0;
+  max-height: 200px;
+}
+.divider {
+  height: 1px;
+  background: var(--c-border);
+}
+.preview {
+  background: var(--c-surface);
+  padding: 8px;
+  display: flex;
+}
+.chart {
+  flex: 1;
+  min-width: 0;
+  height: 300px;
+}
+
+.panelFoot {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 8px 12px;
+  background: var(--c-surface-2);
+  border-top: 1px solid var(--c-border);
+}
+.footTag {
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--c-text);
+  padding: 2px 6px;
+  background: var(--c-surface);
+  border: 1px solid var(--c-border);
+  border-radius: 3px;
+}
+.footMeta {
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--c-text-3);
+}
+
+@media (max-width: 1100px) {
   .hero {
-    padding: 32px 0 24px;
+    grid-template-columns: 1fr;
+    gap: 32px;
+    padding-top: 8px;
   }
-
-  .title {
-    font-size: 30px;
+}
+@media (max-width: 600px) {
+  .metaRow {
+    grid-template-columns: 1fr 1fr;
   }
-
-  .tagline {
-    font-size: 14px;
+  .metaRow > div:last-child {
+    display: none;
   }
-
-  .install {
-    flex-direction: column;
-    gap: 6px;
-    padding: 10px;
+  .panelTab {
+    padding: 9px 9px;
+    font-size: 11px;
   }
 }

--- a/examples/components/Hero.tsx
+++ b/examples/components/Hero.tsx
@@ -1,12 +1,128 @@
-import React, { useState } from "react";
+import React, { useRef, useState } from "react";
 import { Link } from "react-router-dom";
+import { useEcharts } from "../../src";
+import { useTheme } from "./theme-context";
 import Icon from "./Icon";
+import { APP_VERSION, ECHARTS_MAJOR, REACT_MAJOR } from "../data/meta";
+import type { EChartsOption } from "echarts";
 import styles from "./Hero.module.css";
 
 const INSTALL_CMD = "npm install react-use-echarts echarts";
 
+type DemoTab = "bar" | "line" | "component";
+
+const heroOptions: Record<DemoTab, EChartsOption> = {
+  bar: {
+    backgroundColor: "transparent",
+    grid: { top: 24, bottom: 28, left: 36, right: 12 },
+    tooltip: { trigger: "axis" },
+    xAxis: {
+      type: "category",
+      data: ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"],
+      axisTick: { show: false },
+    },
+    yAxis: { type: "value" },
+    series: [
+      {
+        type: "bar",
+        data: [23, 24, 18, 25, 27, 28, 25],
+        itemStyle: { borderRadius: [3, 3, 0, 0] },
+        barWidth: "55%",
+      },
+    ],
+  },
+  line: {
+    backgroundColor: "transparent",
+    grid: { top: 24, bottom: 28, left: 36, right: 12 },
+    tooltip: { trigger: "axis" },
+    xAxis: {
+      type: "category",
+      data: ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"],
+      axisTick: { show: false },
+    },
+    yAxis: { type: "value" },
+    series: [
+      {
+        type: "line",
+        smooth: true,
+        showSymbol: false,
+        data: [820, 932, 901, 934, 1290, 1330, 1320],
+        areaStyle: { opacity: 0.15 },
+        lineStyle: { width: 2 },
+      },
+    ],
+  },
+  component: {
+    backgroundColor: "transparent",
+    tooltip: { trigger: "item" },
+    legend: { bottom: 0 },
+    series: [
+      {
+        type: "pie",
+        radius: ["46%", "70%"],
+        center: ["50%", "44%"],
+        label: { show: false },
+        data: [
+          { value: 1048, name: "Search" },
+          { value: 735, name: "Direct" },
+          { value: 580, name: "Email" },
+          { value: 484, name: "Social" },
+        ],
+      },
+    ],
+  },
+};
+
+const codeSnippets: Record<DemoTab, string> = {
+  bar: `import { useEcharts } from "react-use-echarts";
+
+export const BarChart = () => {
+  const ref = useRef<HTMLDivElement>(null);
+  useEcharts(ref, {
+    option: {
+      xAxis: { data: days },
+      yAxis: {},
+      series: [{ type: "bar", data: sales }],
+    },
+  });
+  return <div ref={ref} style={{ height: 320 }} />;
+};`,
+  line: `import { useEcharts } from "react-use-echarts";
+
+export const LineChart = () => {
+  const ref = useRef<HTMLDivElement>(null);
+  useEcharts(ref, {
+    option: {
+      xAxis: { type: "category", data: days },
+      yAxis: { type: "value" },
+      series: [{ type: "line", smooth: true, data: trend }],
+    },
+  });
+  return <div ref={ref} style={{ height: 320 }} />;
+};`,
+  component: `import { EChart } from "react-use-echarts";
+
+export const Pie = () => {
+  const ref = useRef<UseEchartsReturn>(null);
+
+  return (
+    <EChart
+      ref={ref}
+      option={{ series: [{ type: "pie", data }] }}
+      style={{ height: 320 }}
+    />
+  );
+};`,
+};
+
 const Hero: React.FC = () => {
   const [copied, setCopied] = useState(false);
+  const [tab, setTab] = useState<DemoTab>("bar");
+  const chartRef = useRef<HTMLDivElement>(null);
+  const { mode } = useTheme();
+
+  const option = heroOptions[tab];
+  useEcharts(chartRef, { option, theme: mode });
 
   const handleCopy = async () => {
     try {
@@ -20,56 +136,109 @@ const Hero: React.FC = () => {
 
   return (
     <section className={styles.hero}>
-      <h1 className={styles.title}>react-use-echarts</h1>
-      <p className={styles.tagline}>
-        React hooks &amp; component for Apache ECharts — TypeScript, auto-resize, themes, lazy init.
-      </p>
+      <div className={styles.left}>
+        <div className={styles.eyebrow}>
+          <span className={styles.eyebrowDot} />v{APP_VERSION} · ECharts {ECHARTS_MAJOR} · React{" "}
+          {REACT_MAJOR}+
+        </div>
+        <h1 className={styles.title}>
+          The minimal hook
+          <br />
+          for Apache <span className={styles.titleAccent}>ECharts</span>
+        </h1>
+        <p className={styles.tagline}>
+          One <code className={styles.inlineCode}>useEcharts</code> hook. Zero deps. Auto-resize,
+          theme switching, lazy init, full TypeScript — for everything ECharts can render.
+        </p>
 
-      <div className={styles.install}>
-        <code className={styles.cmd}>{INSTALL_CMD}</code>
-        <button
-          type="button"
-          className="btn"
-          onClick={handleCopy}
-          aria-label="Copy install command"
-        >
-          <Icon name={copied ? "check" : "copy"} size={14} />
-          {copied ? "Copied" : "Copy"}
-        </button>
+        <div className={styles.install}>
+          <span className={styles.prompt}>$</span>
+          <code className={styles.cmd}>{INSTALL_CMD}</code>
+          <button
+            type="button"
+            className={styles.copyBtn}
+            onClick={handleCopy}
+            aria-label="Copy install command"
+          >
+            <Icon name={copied ? "check" : "copy"} size={13} />
+          </button>
+        </div>
+
+        <div className={styles.ctaRow}>
+          <Link to="/gallery" className="cta-primary">
+            Browse 8 charts
+            <Icon name="arrow-right" size={14} />
+          </Link>
+          <Link to="/playground" className="cta-secondary">
+            Open playground
+          </Link>
+          <a
+            href="https://github.com/chensid/react-use-echarts"
+            target="_blank"
+            rel="noreferrer"
+            className="cta-secondary"
+          >
+            <Icon name="github" size={13} />
+            GitHub
+          </a>
+        </div>
+
+        <dl className={styles.metaRow}>
+          <div>
+            <dt>Bundle</dt>
+            <dd>
+              2.1 kB <span>min+gzip</span>
+            </dd>
+          </div>
+          <div>
+            <dt>Deps</dt>
+            <dd>
+              0 <span>peer: echarts</span>
+            </dd>
+          </div>
+          <div>
+            <dt>Types</dt>
+            <dd>
+              built-in <span>strict</span>
+            </dd>
+          </div>
+        </dl>
       </div>
 
-      <div className={styles.ctaRow}>
-        <Link to="/gallery" className={styles.ctaPrimary}>
-          Browse Gallery
-          <Icon name="arrow-right" size={14} />
-        </Link>
-        <a
-          href="https://github.com/chensid/react-use-echarts"
-          target="_blank"
-          rel="noreferrer"
-          className={styles.ctaSecondary}
-        >
-          <Icon name="github" size={14} />
-          GitHub
-        </a>
-      </div>
-
-      <div className={styles.badges}>
-        <img
-          src="https://img.shields.io/npm/v/react-use-echarts.svg"
-          alt="npm version"
-          height="20"
-        />
-        <img
-          src="https://img.shields.io/npm/dm/react-use-echarts.svg"
-          alt="npm downloads"
-          height="20"
-        />
-        <img
-          src="https://img.shields.io/github/stars/chensid/react-use-echarts?style=social"
-          alt="GitHub stars"
-          height="20"
-        />
+      <div className={styles.right}>
+        <div className={styles.panel}>
+          <div className={styles.panelTabs} role="tablist">
+            {(["bar", "line", "component"] as DemoTab[]).map((t) => (
+              <button
+                key={t}
+                type="button"
+                role="tab"
+                aria-selected={tab === t}
+                className={`${styles.panelTab} ${tab === t ? styles.panelTabActive : ""}`}
+                onClick={() => setTab(t)}
+              >
+                {t === "component" ? "<EChart>" : `${t}.tsx`}
+              </button>
+            ))}
+            <span className={styles.panelStatus}>
+              <span className={styles.statusDot} />
+              live
+            </span>
+          </div>
+          <div className={styles.panelBody}>
+            <pre className={styles.code}>
+              <code>{codeSnippets[tab]}</code>
+            </pre>
+            <div className={styles.divider} />
+            <div className={styles.preview}>
+              <div ref={chartRef} className={styles.chart} />
+            </div>
+          </div>
+          <div className={styles.panelFoot}>
+            <span className={styles.footTag}>useEcharts()</span>
+            <span className={styles.footMeta}>auto-resize · theme: {mode}</span>
+          </div>
+        </div>
       </div>
     </section>
   );

--- a/examples/components/Layout.module.css
+++ b/examples/components/Layout.module.css
@@ -1,32 +1,37 @@
 .layout {
-  display: grid;
-  grid-template-columns: var(--sidebar-width) 1fr;
+  position: relative;
   padding-top: var(--header-height);
   min-height: 100vh;
+  z-index: 1;
 }
-
+.wrap {
+  max-width: var(--max-w);
+  margin: 0 auto;
+  padding: 0 20px;
+  display: grid;
+  grid-template-columns: var(--sidebar-width) 1fr;
+  gap: 0;
+}
 .main {
+  min-width: 0;
+  padding: 32px 0 32px 36px;
   display: flex;
   flex-direction: column;
-  padding: 28px 36px 0;
-  min-width: 0;
 }
-
 .inner {
   display: flex;
   flex-direction: column;
   flex: 1;
   width: 100%;
-  max-width: 1080px;
-  margin: 0 auto;
+  min-width: 0;
 }
 
 @media (max-width: 860px) {
-  .layout {
+  .wrap {
     grid-template-columns: 1fr;
+    padding: 0 16px;
   }
-
   .main {
-    padding: 24px 16px 0;
+    padding: 24px 0;
   }
 }

--- a/examples/components/Layout.tsx
+++ b/examples/components/Layout.tsx
@@ -17,13 +17,15 @@ const Layout: React.FC = () => {
     <>
       <Header onSidebarToggle={() => setSidebarOpen((p) => !p)} />
       <div className={styles.layout}>
-        <Sidebar isOpen={sidebarOpen} onClose={() => setSidebarOpen(false)} />
-        <main className={styles.main}>
-          <div className={styles.inner}>
-            <Outlet />
-            <Footer />
-          </div>
-        </main>
+        <div className={styles.wrap}>
+          <Sidebar isOpen={sidebarOpen} onClose={() => setSidebarOpen(false)} />
+          <main className={styles.main}>
+            <div className={styles.inner}>
+              <Outlet />
+              <Footer />
+            </div>
+          </main>
+        </div>
       </div>
     </>
   );

--- a/examples/components/Sidebar.module.css
+++ b/examples/components/Sidebar.module.css
@@ -2,66 +2,81 @@
   position: sticky;
   top: var(--header-height);
   height: calc(100vh - var(--header-height));
-  overflow-y: auto;
-  padding: 20px 12px 20px 16px;
+  padding: 24px 20px 24px 0;
   border-right: 1px solid var(--c-border);
+  overflow-y: auto;
+  font-size: 13px;
+}
+
+.group {
+  margin-bottom: 24px;
+}
+
+.label {
+  font-family: var(--mono);
+  font-size: 10.5px;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--c-text-3);
+  padding: 0 10px;
+  margin-bottom: 6px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+.count {
+  font-size: 10px;
+  padding: 1px 5px;
+  background: var(--c-surface-2);
+  border: 1px solid var(--c-border);
+  border-radius: 3px;
+  color: var(--c-text-3);
 }
 
 .nav {
   display: flex;
   flex-direction: column;
-  gap: 2px;
-}
-
-.heading {
-  display: block;
-  padding: 0 8px;
-  margin: 18px 0 4px;
-  font-size: 11px;
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
-  color: var(--c-text-2);
-  transition: color 0.12s;
-}
-
-.heading:hover {
-  color: var(--c-text);
-}
-
-.headingActive {
-  color: var(--c-text);
+  gap: 1px;
 }
 
 .link {
-  display: block;
-  padding: 6px 8px;
-  font-size: 13px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 5px 10px;
   color: var(--c-text-2);
-  border-radius: var(--radius);
+  border-radius: 3px;
+  font-size: 13px;
   transition:
-    color 0.12s,
-    background-color 0.12s;
+    color 0.1s,
+    background-color 0.1s,
+    border-color 0.1s;
+  border-left: 2px solid transparent;
+  margin-left: -2px;
 }
-
 .link:hover {
   color: var(--c-text);
-  background: var(--c-surface-dim);
+  background: var(--c-surface-2);
 }
-
-.link:focus-visible {
-  outline: 2px solid var(--c-accent);
-  outline-offset: -2px;
-}
-
-.topLink {
+.active {
+  color: var(--c-text);
+  background: var(--c-surface-2);
+  border-left-color: var(--c-accent);
   font-weight: 500;
 }
 
-.active {
-  color: var(--c-text);
-  font-weight: 600;
-  background: var(--c-accent-soft);
+.tag {
+  font-family: var(--mono);
+  font-size: 10px;
+  color: var(--c-text-3);
+  padding: 1px 5px;
+  background: var(--c-surface);
+  border: 1px solid var(--c-border);
+  border-radius: 3px;
+}
+.active .tag {
+  color: var(--c-text-2);
 }
 
 .backdrop {
@@ -74,22 +89,20 @@
     top: var(--header-height);
     left: 0;
     z-index: 25;
-    width: 240px;
+    width: 260px;
     background: var(--c-bg);
-    border-right: 1px solid var(--c-border);
+    padding: 20px 16px;
     transform: translateX(-100%);
     transition: transform 0.2s ease;
   }
-
   .open {
     transform: translateX(0);
   }
-
   .backdrop {
     display: block;
     position: fixed;
-    inset: var(--header-height) 0 0;
+    inset: var(--header-height) 0 0 0;
     z-index: 20;
-    background: rgba(0, 0, 0, 0.3);
+    background: rgba(0, 0, 0, 0.35);
   }
 }

--- a/examples/components/Sidebar.tsx
+++ b/examples/components/Sidebar.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { NavLink } from "react-router-dom";
 import { galleryItems } from "../data/gallery";
 import { featureItems } from "../data/features";
+import Icon from "./Icon";
 import type { DemoItem } from "../data/types";
 import styles from "./Sidebar.module.css";
 
@@ -10,66 +11,93 @@ interface SidebarProps {
   readonly onClose: () => void;
 }
 
-const itemClass = ({ isActive }: { isActive: boolean }) =>
+const linkClass = ({ isActive }: { isActive: boolean }) =>
   `${styles.link} ${isActive ? styles.active : ""}`;
-
-const headingClass = ({ isActive }: { isActive: boolean }) =>
-  `${styles.heading} ${isActive ? styles.headingActive : ""}`;
 
 interface SectionProps {
   readonly title: string;
-  readonly to: string;
-  readonly items: readonly DemoItem[];
-  readonly basePath: string;
-  readonly onClose: () => void;
+  readonly count?: number;
+  readonly children: React.ReactNode;
 }
 
-const Section: React.FC<SectionProps> = ({ title, to, items, basePath, onClose }) => (
-  <>
-    <NavLink to={to} end className={headingClass} onClick={onClose}>
-      {title}
-    </NavLink>
-    {items.map((item) => (
-      <NavLink key={item.id} to={`${basePath}/${item.id}`} className={itemClass} onClick={onClose}>
-        {item.title}
-      </NavLink>
-    ))}
-  </>
+const Section: React.FC<SectionProps> = ({ title, count, children }) => (
+  <div className={styles.group}>
+    <div className={styles.label}>
+      <span>{title}</span>
+      {count != null ? <span className={styles.count}>{count}</span> : null}
+    </div>
+    <nav className={styles.nav}>{children}</nav>
+  </div>
 );
 
 const Sidebar: React.FC<SidebarProps> = ({ isOpen, onClose }) => {
+  const renderItem = (item: DemoItem, base: string) => (
+    <NavLink key={item.id} to={`${base}/${item.id}`} className={linkClass} onClick={onClose}>
+      <span>{item.title}</span>
+    </NavLink>
+  );
+
   return (
     <>
       {isOpen ? <div className={styles.backdrop} onClick={onClose} role="presentation" /> : null}
       <aside className={`${styles.sidebar} ${isOpen ? styles.open : ""}`}>
-        <nav className={styles.nav}>
-          <NavLink
-            to="/"
-            end
-            className={({ isActive }) =>
-              `${styles.link} ${styles.topLink} ${isActive ? styles.active : ""}`
-            }
-            onClick={onClose}
-          >
-            Home
+        <Section title="Start">
+          <NavLink to="/" end className={linkClass} onClick={onClose}>
+            <span>Overview</span>
+            <span className={styles.tag}>intro</span>
           </NavLink>
+          <NavLink to="/playground" className={linkClass} onClick={onClose}>
+            <span>Playground</span>
+            <span className={styles.tag}>live</span>
+          </NavLink>
+          <NavLink to="/compare" className={linkClass} onClick={onClose}>
+            <span>Why this lib</span>
+          </NavLink>
+        </Section>
 
-          <Section
-            title="Gallery"
-            to="/gallery"
-            items={galleryItems}
-            basePath="/gallery"
-            onClose={onClose}
-          />
+        <Section title="Gallery" count={galleryItems.length}>
+          <NavLink to="/gallery" end className={linkClass} onClick={onClose}>
+            <span>All charts</span>
+          </NavLink>
+          {galleryItems.map((i) => renderItem(i, "/gallery"))}
+        </Section>
 
-          <Section
-            title="Features"
-            to="/features"
-            items={featureItems}
-            basePath="/features"
-            onClose={onClose}
-          />
-        </nav>
+        <Section title="Features" count={featureItems.length}>
+          <NavLink to="/features" end className={linkClass} onClick={onClose}>
+            <span>All features</span>
+          </NavLink>
+          {featureItems.map((i) => renderItem(i, "/features"))}
+        </Section>
+
+        <Section title="Resources">
+          <a
+            className={styles.link}
+            href="https://www.npmjs.com/package/react-use-echarts"
+            target="_blank"
+            rel="noreferrer"
+          >
+            <span>npm</span>
+            <Icon name="external" size={11} />
+          </a>
+          <a
+            className={styles.link}
+            href="https://github.com/chensid/react-use-echarts"
+            target="_blank"
+            rel="noreferrer"
+          >
+            <span>GitHub</span>
+            <Icon name="external" size={11} />
+          </a>
+          <a
+            className={styles.link}
+            href="https://echarts.apache.org/"
+            target="_blank"
+            rel="noreferrer"
+          >
+            <span>Apache ECharts</span>
+            <Icon name="external" size={11} />
+          </a>
+        </Section>
       </aside>
     </>
   );

--- a/examples/components/StatsStrip.module.css
+++ b/examples/components/StatsStrip.module.css
@@ -1,0 +1,70 @@
+.strip {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  border: 1px solid var(--c-border);
+  background: var(--c-surface);
+  border-radius: var(--radius-lg);
+  margin-bottom: 64px;
+  overflow: hidden;
+}
+.cell {
+  display: flex;
+  gap: 12px;
+  padding: 20px 22px;
+  border-right: 1px solid var(--c-border);
+  position: relative;
+}
+.cell:last-child {
+  border-right: 0;
+}
+.idx {
+  font-family: var(--mono);
+  font-size: 10.5px;
+  color: var(--c-text-3);
+  letter-spacing: 0.05em;
+}
+.value {
+  font-size: 26px;
+  font-weight: 600;
+  letter-spacing: -0.02em;
+  color: var(--c-text);
+  margin-bottom: 4px;
+  font-variant-numeric: tabular-nums;
+}
+.label {
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--c-text);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  margin-bottom: 4px;
+}
+.note {
+  font-size: 12px;
+  color: var(--c-text-3);
+  line-height: 1.45;
+}
+
+@media (max-width: 880px) {
+  .strip {
+    grid-template-columns: 1fr 1fr;
+  }
+  .cell:nth-child(2) {
+    border-right: 0;
+  }
+  .cell:nth-child(-n + 2) {
+    border-bottom: 1px solid var(--c-border);
+  }
+}
+@media (max-width: 480px) {
+  .strip {
+    grid-template-columns: 1fr;
+  }
+  .cell {
+    border-right: 0;
+    border-bottom: 1px solid var(--c-border);
+  }
+  .cell:last-child {
+    border-bottom: 0;
+  }
+}

--- a/examples/components/StatsStrip.tsx
+++ b/examples/components/StatsStrip.tsx
@@ -1,0 +1,36 @@
+import React from "react";
+import styles from "./StatsStrip.module.css";
+
+interface Stat {
+  readonly label: string;
+  readonly value: string;
+  readonly note: string;
+}
+
+const STATS: readonly Stat[] = [
+  { label: "Bundle size", value: "2.1 kB", note: "min + gzip · zero runtime deps" },
+  {
+    label: "Chart types",
+    value: "8",
+    note: "bar, line, radar, gauge, ohlc, heat, funnel, treemap",
+  },
+  { label: "Features", value: "8", note: "themes, renderer, linkage, lazy, events, ref…" },
+  { label: "TypeScript", value: "100%", note: "strict mode · full ECharts option types" },
+];
+
+const StatsStrip: React.FC = () => (
+  <section className={styles.strip} aria-label="Key stats">
+    {STATS.map((s, i) => (
+      <div key={s.label} className={styles.cell}>
+        <span className={styles.idx}>{String(i + 1).padStart(2, "0")}</span>
+        <div>
+          <div className={styles.value}>{s.value}</div>
+          <div className={styles.label}>{s.label}</div>
+          <div className={styles.note}>{s.note}</div>
+        </div>
+      </div>
+    ))}
+  </section>
+);
+
+export default StatsStrip;

--- a/examples/components/ThumbCard.module.css
+++ b/examples/components/ThumbCard.module.css
@@ -1,47 +1,91 @@
 .card {
   display: flex;
   flex-direction: column;
-  gap: 8px;
-  padding: 12px;
-  border: 1px solid var(--c-border);
-  border-radius: var(--radius);
   background: var(--c-surface);
-  color: inherit;
+  border: 1px solid var(--c-border);
+  border-radius: var(--radius-lg);
+  overflow: hidden;
   transition:
     border-color 0.15s,
-    transform 0.15s,
-    box-shadow 0.15s;
+    box-shadow 0.15s,
+    transform 0.15s;
 }
-
 .card:hover {
-  border-color: var(--c-text-2);
-  transform: translateY(-2px);
-  box-shadow: var(--c-shadow);
+  border-color: var(--c-border-strong);
+  box-shadow: var(--shadow-md);
+  transform: translateY(-1px);
 }
 
+.head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 8px 14px;
+  background: var(--c-surface-2);
+  border-bottom: 1px solid var(--c-border);
+}
+.headTitle {
+  font-family: var(--mono);
+  font-size: 11.5px;
+  color: var(--c-text-2);
+}
+.headTag {
+  font-family: var(--mono);
+  font-size: 10px;
+  color: var(--c-text-3);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  padding: 1px 5px;
+  background: var(--c-surface);
+  border: 1px solid var(--c-border);
+  border-radius: 3px;
+}
+
+.thumbWrap {
+  position: relative;
+  background:
+    linear-gradient(var(--c-surface), var(--c-surface)),
+    repeating-linear-gradient(45deg, transparent 0 8px, var(--c-surface-2) 8px 9px);
+  background-blend-mode: normal;
+  padding: 12px;
+}
 .thumb {
   width: 100%;
-  height: 140px;
-  border-radius: calc(var(--radius) - 2px);
-  background: var(--c-surface-dim);
-  overflow: hidden;
+  height: 200px;
 }
 
 .meta {
   display: flex;
-  flex-direction: column;
-  gap: 2px;
-  padding: 0 2px;
+  align-items: flex-start;
+  justify-content: space-between;
+  padding: 16px 18px 18px;
+  gap: 12px;
+  border-top: 1px solid var(--c-border);
 }
-
+.metaText {
+  min-width: 0;
+}
 .title {
-  font-size: 14px;
+  font-size: 15px;
   font-weight: 600;
-  margin: 0;
+  letter-spacing: -0.01em;
+  margin-bottom: 4px;
+  color: var(--c-text);
 }
-
 .desc {
-  font-size: 12px;
+  font-size: 12.5px;
   color: var(--c-text-2);
-  margin: 0;
+  line-height: 1.5;
+}
+.arrow {
+  flex-shrink: 0;
+  color: var(--c-text-3);
+  transition:
+    transform 0.15s,
+    color 0.15s;
+  margin-top: 2px;
+}
+.card:hover .arrow {
+  color: var(--c-text);
+  transform: translateX(3px);
 }

--- a/examples/components/ThumbCard.tsx
+++ b/examples/components/ThumbCard.tsx
@@ -2,6 +2,7 @@ import React, { useRef } from "react";
 import { Link } from "react-router-dom";
 import { useEcharts } from "../../src";
 import { useTheme } from "./theme-context";
+import Icon from "./Icon";
 import type { EChartsOption } from "echarts";
 import styles from "./ThumbCard.module.css";
 
@@ -10,9 +11,10 @@ interface ThumbCardProps {
   readonly title: string;
   readonly description: string;
   readonly option: EChartsOption;
+  readonly tag?: string;
 }
 
-const ThumbCard: React.FC<ThumbCardProps> = ({ to, title, description, option }) => {
+const ThumbCard: React.FC<ThumbCardProps> = ({ to, title, description, option, tag }) => {
   const chartRef = useRef<HTMLDivElement>(null);
   const { mode } = useTheme();
 
@@ -20,10 +22,21 @@ const ThumbCard: React.FC<ThumbCardProps> = ({ to, title, description, option })
 
   return (
     <Link to={to} className={styles.card}>
-      <div ref={chartRef} className={styles.thumb} />
+      <div className={styles.head}>
+        <span className={styles.headTitle}>{title}.tsx</span>
+        {tag ? <span className={styles.headTag}>{tag}</span> : null}
+      </div>
+      <div className={styles.thumbWrap}>
+        <div ref={chartRef} className={styles.thumb} />
+      </div>
       <div className={styles.meta}>
-        <h3 className={styles.title}>{title}</h3>
-        <p className={styles.desc}>{description}</p>
+        <div className={styles.metaText}>
+          <h3 className={styles.title}>{title}</h3>
+          <p className={styles.desc}>{description}</p>
+        </div>
+        <span className={styles.arrow}>
+          <Icon name="arrow-right" size={14} />
+        </span>
       </div>
     </Link>
   );

--- a/examples/data/meta.ts
+++ b/examples/data/meta.ts
@@ -1,0 +1,11 @@
+import pkg from "../../package.json";
+
+const majorOf = (range: string | undefined): string => {
+  if (!range) return "";
+  const m = /(\d+)/.exec(range);
+  return m ? m[1] : range;
+};
+
+export const APP_VERSION = pkg.version;
+export const REACT_MAJOR = majorOf(pkg.peerDependencies?.react);
+export const ECHARTS_MAJOR = majorOf(pkg.peerDependencies?.echarts);

--- a/examples/global.css
+++ b/examples/global.css
@@ -1,31 +1,67 @@
 :root {
-  --header-height: 56px;
-  --sidebar-width: 240px;
-  --mono: ui-monospace, "SFMono-Regular", Menlo, Monaco, "Courier New", monospace;
-  --sans: system-ui, -apple-system, "Segoe UI", Helvetica, Arial, sans-serif;
-  --radius: 6px;
-
+  /* neutrals (zinc) */
   --c-bg: #fafafa;
-  --c-surface: #fff;
-  --c-surface-dim: #f4f4f5;
+  --c-surface: #ffffff;
+  --c-surface-2: #f4f4f5;
+  --c-surface-3: #e4e4e7;
   --c-border: #e4e4e7;
-  --c-text: #18181b;
-  --c-text-2: #71717a;
-  --c-accent: #18181b;
-  --c-accent-soft: #f4f4f5;
-  --c-shadow: 0 1px 3px rgba(0, 0, 0, 0.06);
+  --c-border-strong: #d4d4d8;
+  --c-text: #09090b;
+  --c-text-2: #52525b;
+  --c-text-3: #a1a1aa;
+  --c-accent: #09090b;
+  --c-accent-inv: #fafafa;
+
+  /* chart palette */
+  --chart-1: #18181b;
+  --chart-2: #52525b;
+  --chart-3: #a1a1aa;
+  --chart-4: #d4d4d8;
+  --chart-highlight: #d97706;
+  --chart-success: #059669;
+
+  /* metrics */
+  --header-height: 52px;
+  --sidebar-width: 240px;
+  --max-w: 1360px;
+  --radius: 4px;
+  --radius-lg: 6px;
+
+  --sans: "Geist", -apple-system, "Segoe UI", system-ui, sans-serif;
+  --mono: "Geist Mono", ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+
+  --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.04);
+  --shadow-md: 0 2px 8px -1px rgba(0, 0, 0, 0.06), 0 1px 2px rgba(0, 0, 0, 0.04);
+  --shadow-lg: 0 8px 24px -6px rgba(0, 0, 0, 0.1), 0 2px 6px -2px rgba(0, 0, 0, 0.05);
+
+  --grid-stroke: rgba(9, 9, 11, 0.05);
 }
 
 html[data-theme="dark"] {
   --c-bg: #09090b;
-  --c-surface: #18181b;
-  --c-surface-dim: #27272a;
-  --c-border: #3f3f46;
+  --c-surface: #0f0f11;
+  --c-surface-2: #18181b;
+  --c-surface-3: #27272a;
+  --c-border: #27272a;
+  --c-border-strong: #3f3f46;
   --c-text: #fafafa;
   --c-text-2: #a1a1aa;
+  --c-text-3: #71717a;
   --c-accent: #fafafa;
-  --c-accent-soft: #27272a;
-  --c-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
+  --c-accent-inv: #09090b;
+
+  --chart-1: #fafafa;
+  --chart-2: #a1a1aa;
+  --chart-3: #71717a;
+  --chart-4: #3f3f46;
+  --chart-highlight: #fbbf24;
+  --chart-success: #10b981;
+
+  --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.3);
+  --shadow-md: 0 2px 8px -1px rgba(0, 0, 0, 0.4);
+  --shadow-lg: 0 8px 24px -6px rgba(0, 0, 0, 0.5);
+
+  --grid-stroke: rgba(255, 255, 255, 0.05);
 }
 
 *,
@@ -39,53 +75,119 @@ html {
   scroll-behavior: smooth;
   scroll-padding-top: calc(var(--header-height) + 20px);
 }
-
 @media (prefers-reduced-motion: reduce) {
   html {
     scroll-behavior: auto;
+  }
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
   }
 }
 
 body {
   font-family: var(--sans);
   font-size: 14px;
-  line-height: 1.5;
+  line-height: 1.55;
   background: var(--c-bg);
   color: var(--c-text);
   -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-feature-settings: "ss01", "cv11";
+  font-variant-numeric: tabular-nums;
+  position: relative;
+}
+body::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  background-image:
+    linear-gradient(to right, var(--grid-stroke) 1px, transparent 1px),
+    linear-gradient(to bottom, var(--grid-stroke) 1px, transparent 1px);
+  background-size: 32px 32px;
+  pointer-events: none;
+  z-index: 0;
+  opacity: 0.6;
 }
 
 a {
   color: inherit;
   text-decoration: none;
 }
-
 button {
   font: inherit;
   cursor: pointer;
+  color: inherit;
+  background: none;
+  border: 0;
+}
+code,
+pre {
+  font-family: var(--mono);
 }
 
+/* shared CTA buttons used by Hero + Home */
+.cta-primary {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 16px;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--c-accent-inv);
+  background: var(--c-accent);
+  border-radius: var(--radius-lg);
+  transition: opacity 0.12s;
+}
+.cta-primary:hover {
+  opacity: 0.86;
+}
+.cta-secondary {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 10px 14px;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--c-text);
+  background: var(--c-surface);
+  border: 1px solid var(--c-border);
+  border-radius: var(--radius-lg);
+  transition:
+    background 0.12s,
+    border-color 0.12s;
+}
+.cta-secondary:hover {
+  background: var(--c-surface-2);
+  border-color: var(--c-border-strong);
+}
+
+/* legacy utility classes still used by chart examples */
 .btn {
   display: inline-flex;
   align-items: center;
   gap: 6px;
   padding: 6px 12px;
-  font-size: 13px;
+  font-size: 12.5px;
   font-weight: 500;
+  font-family: var(--mono);
+  color: var(--c-text-2);
   border: 1px solid var(--c-border);
   border-radius: var(--radius);
   background: var(--c-surface);
-  color: var(--c-text);
   transition:
-    border-color 0.15s,
-    background-color 0.15s;
+    border-color 0.12s,
+    background-color 0.12s,
+    color 0.12s;
 }
-
 .btn:hover {
-  border-color: var(--c-text-2);
-  background: var(--c-surface-dim);
+  color: var(--c-text);
+  border-color: var(--c-border-strong);
+  background: var(--c-surface-2);
 }
-
 .btn:focus-visible {
   outline: 2px solid var(--c-accent);
   outline-offset: 2px;
@@ -95,34 +197,30 @@ button {
   width: 100%;
   height: 340px;
 }
-
 .chart-container-sm {
   width: 100%;
   height: 280px;
 }
-
 .controls {
   display: flex;
   flex-wrap: wrap;
   gap: 6px;
   margin-bottom: 10px;
 }
-
 .note-box {
-  padding: 8px 12px;
-  font-size: 13px;
+  padding: 6px 10px;
+  font-size: 12px;
   font-family: var(--mono);
   color: var(--c-text-2);
-  background: var(--c-surface-dim);
+  background: var(--c-surface-2);
+  border: 1px solid var(--c-border);
   border-radius: var(--radius);
 }
-
 .grid-2 {
   display: grid;
   gap: 12px;
   grid-template-columns: 1fr 1fr;
 }
-
 .scroll-area {
   height: 380px;
   overflow: auto;
@@ -130,14 +228,12 @@ button {
   border-radius: var(--radius);
   padding: 10px;
 }
-
 @media (max-width: 860px) {
   .grid-2 {
     grid-template-columns: 1fr;
   }
-
   .btn {
     padding: 10px 14px;
-    font-size: 14px;
+    font-size: 13px;
   }
 }

--- a/examples/pages/Compare.module.css
+++ b/examples/pages/Compare.module.css
@@ -1,0 +1,49 @@
+.notes {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 16px;
+  margin-top: 32px;
+}
+.note {
+  position: relative;
+  padding: 24px;
+  background: var(--c-surface);
+  border: 1px solid var(--c-border);
+  border-radius: var(--radius-lg);
+}
+.noteIdx {
+  position: absolute;
+  top: 16px;
+  right: 18px;
+  font-family: var(--mono);
+  font-size: 10.5px;
+  color: var(--c-text-3);
+  letter-spacing: 0.05em;
+}
+.note h3 {
+  font-size: 15px;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  margin-bottom: 8px;
+  color: var(--c-text);
+}
+.note p {
+  font-size: 13px;
+  line-height: 1.6;
+  color: var(--c-text-2);
+  text-wrap: pretty;
+}
+.note code {
+  font-family: var(--mono);
+  font-size: 12px;
+  background: var(--c-surface-2);
+  border: 1px solid var(--c-border);
+  border-radius: 3px;
+  padding: 1px 4px;
+  color: var(--c-text);
+}
+@media (max-width: 720px) {
+  .notes {
+    grid-template-columns: 1fr;
+  }
+}

--- a/examples/pages/Compare.tsx
+++ b/examples/pages/Compare.tsx
@@ -1,0 +1,52 @@
+import React from "react";
+import PageHeader from "./PageHeader";
+import CompareTable from "../components/CompareTable";
+import styles from "./Compare.module.css";
+
+const Compare: React.FC = () => (
+  <>
+    <PageHeader
+      eyebrow="Why this lib"
+      title="vs. raw ECharts &amp; alternatives"
+      description="A small wrapper that solves predictable React integration problems — without taking anything away. ECharts itself stays the source of truth for options."
+    />
+    <CompareTable />
+
+    <div className={styles.notes}>
+      <div className={styles.note}>
+        <span className={styles.noteIdx}>01</span>
+        <h3>Single hook surface</h3>
+        <p>
+          <code>useEcharts(ref, &#123; option &#125;)</code> is the entire required API. Everything
+          else — themes, lazy init, group linkage — is opt-in via the same options object.
+        </p>
+      </div>
+      <div className={styles.note}>
+        <span className={styles.noteIdx}>02</span>
+        <h3>No option re-shaping</h3>
+        <p>
+          You pass <code>EChartsOption</code> directly. There is no abstraction layer between your
+          code and the ECharts docs — copy-paste from official examples works as-is.
+        </p>
+      </div>
+      <div className={styles.note}>
+        <span className={styles.noteIdx}>03</span>
+        <h3>Predictable lifecycle</h3>
+        <p>
+          Charts dispose on unmount, resize on container change, and respect React Strict Mode. The
+          hook is safe to call inside any component, including ones that re-mount frequently.
+        </p>
+      </div>
+      <div className={styles.note}>
+        <span className={styles.noteIdx}>04</span>
+        <h3>Both APIs available</h3>
+        <p>
+          Use <code>useEcharts</code> for the imperative hook style, or <code>&lt;EChart&gt;</code>{" "}
+          for a declarative component with a forwarded ref. Both wrap the same instance internally.
+        </p>
+      </div>
+    </div>
+  </>
+);
+
+export default Compare;

--- a/examples/pages/DemoDetail.module.css
+++ b/examples/pages/DemoDetail.module.css
@@ -1,0 +1,13 @@
+.metaTag {
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--c-text-2);
+  padding: 3px 8px;
+  background: var(--c-surface);
+  border: 1px solid var(--c-border);
+  border-radius: 3px;
+}
+.fallback {
+  min-height: 320px;
+  background: repeating-linear-gradient(45deg, var(--c-surface) 0 8px, var(--c-surface-2) 8px 9px);
+}

--- a/examples/pages/DemoDetail.tsx
+++ b/examples/pages/DemoDetail.tsx
@@ -4,6 +4,7 @@ import PageHeader from "./PageHeader";
 import DemoTabs from "../components/DemoTabs";
 import { findGalleryItem } from "../data/gallery";
 import { findFeatureItem } from "../data/features";
+import styles from "./DemoDetail.module.css";
 
 interface DemoDetailProps {
   readonly kind: "gallery" | "features";
@@ -25,9 +26,20 @@ const DemoDetail: React.FC<DemoDetailProps> = ({ kind }) => {
 
   return (
     <>
-      <PageHeader title={item.title} description={item.description} crumb={crumb} />
+      <PageHeader
+        eyebrow={kind === "gallery" ? "Chart" : "Feature"}
+        title={item.title}
+        description={item.description}
+        crumb={crumb}
+        meta={
+          <>
+            <span className={styles.metaTag}>id: {item.id}</span>
+            <span className={styles.metaTag}>{item.sourcePath.split("/").pop()}</span>
+          </>
+        }
+      />
       <DemoTabs sourcePath={item.sourcePath} loadSource={item.source}>
-        <React.Suspense fallback={<div style={{ minHeight: 280 }} />}>
+        <React.Suspense fallback={<div className={styles.fallback} />}>
           <DemoComponent />
         </React.Suspense>
       </DemoTabs>

--- a/examples/pages/FeaturesIndex.module.css
+++ b/examples/pages/FeaturesIndex.module.css
@@ -1,10 +1,14 @@
 .grid {
   display: grid;
-  grid-template-columns: repeat(2, 1fr);
-  gap: 14px;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 12px;
 }
-
-@media (max-width: 860px) {
+@media (max-width: 1100px) {
+  .grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+@media (max-width: 600px) {
   .grid {
     grid-template-columns: 1fr;
   }

--- a/examples/pages/FeaturesIndex.tsx
+++ b/examples/pages/FeaturesIndex.tsx
@@ -8,12 +8,18 @@ const FeaturesIndex: React.FC = () => {
   return (
     <>
       <PageHeader
-        title="Features"
-        description="Library capabilities: reactivity, themes, renderer, linkage, events, loading, ref API, and lazy init."
+        eyebrow="Features"
+        title="Library capabilities"
+        description="Reactivity, themes, renderer choice, chart linkage, events, loading, ref API, and lazy init — eight things people commonly hand-roll."
+        meta={
+          <>
+            <span>{featureItems.length}</span> features
+          </>
+        }
       />
       <div className={styles.grid}>
-        {featureItems.map((item) => (
-          <FeatureCard key={item.id} item={item} />
+        {featureItems.map((item, i) => (
+          <FeatureCard key={item.id} item={item} index={i} />
         ))}
       </div>
     </>

--- a/examples/pages/GalleryIndex.module.css
+++ b/examples/pages/GalleryIndex.module.css
@@ -1,17 +1,68 @@
+.toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  flex-wrap: wrap;
+  padding: 10px 12px;
+  background: var(--c-surface);
+  border: 1px solid var(--c-border);
+  border-radius: var(--radius-lg);
+  margin-bottom: 20px;
+}
+.filters {
+  display: flex;
+  gap: 4px;
+  flex-wrap: wrap;
+}
+.filter {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 5px 10px;
+  font-family: var(--mono);
+  font-size: 12px;
+  color: var(--c-text-2);
+  border-radius: 4px;
+  border: 1px solid transparent;
+  transition:
+    color 0.12s,
+    background 0.12s,
+    border-color 0.12s;
+}
+.filter:hover {
+  color: var(--c-text);
+  background: var(--c-surface-2);
+}
+.filterActive {
+  color: var(--c-text);
+  background: var(--c-surface-2);
+  border-color: var(--c-border);
+}
+.filterCount {
+  font-size: 10px;
+  color: var(--c-text-3);
+  background: var(--c-surface);
+  border: 1px solid var(--c-border);
+  padding: 1px 4px;
+  border-radius: 3px;
+}
+.filterActive .filterCount {
+  color: var(--c-text-2);
+}
+.help {
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--c-text-3);
+}
+
 .grid {
   display: grid;
-  grid-template-columns: repeat(4, 1fr);
-  gap: 14px;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 16px;
 }
-
-@media (max-width: 1080px) {
+@media (max-width: 800px) {
   .grid {
-    grid-template-columns: repeat(3, 1fr);
-  }
-}
-
-@media (max-width: 860px) {
-  .grid {
-    grid-template-columns: repeat(2, 1fr);
+    grid-template-columns: 1fr;
   }
 }

--- a/examples/pages/GalleryIndex.tsx
+++ b/examples/pages/GalleryIndex.tsx
@@ -1,25 +1,64 @@
-import React from "react";
+import React, { useMemo, useState } from "react";
 import PageHeader from "./PageHeader";
 import ThumbCard from "../components/ThumbCard";
 import { galleryItems } from "../data/gallery";
 import { thumbOptions } from "../data/thumbs";
 import styles from "./GalleryIndex.module.css";
 
+const GROUPS: Record<string, readonly string[]> = {
+  All: galleryItems.map((i) => i.id),
+  Common: ["bar", "line"],
+  Composite: ["radar", "gauge", "candlestick"],
+  Spatial: ["heatmap", "funnel", "treemap"],
+};
+
 const GalleryIndex: React.FC = () => {
+  const [filter, setFilter] = useState<string>("All");
+
+  const items = useMemo(() => {
+    const allowed = new Set(GROUPS[filter]);
+    return galleryItems.filter((i) => allowed.has(i.id));
+  }, [filter]);
+
   return (
     <>
       <PageHeader
-        title="Gallery"
-        description="Eight common chart types powered by ECharts. Click any card to see full code."
+        eyebrow="Gallery"
+        title="8 chart types"
+        description="Single-component examples for the most common ECharts series. Click any card for full source."
+        meta={
+          <>
+            <span>{items.length}</span> shown
+          </>
+        }
       />
+      <div className={styles.toolbar}>
+        <div className={styles.filters} role="tablist">
+          {Object.keys(GROUPS).map((g) => (
+            <button
+              key={g}
+              type="button"
+              role="tab"
+              aria-selected={filter === g}
+              onClick={() => setFilter(g)}
+              className={`${styles.filter} ${filter === g ? styles.filterActive : ""}`}
+            >
+              {g}
+              <span className={styles.filterCount}>{GROUPS[g].length}</span>
+            </button>
+          ))}
+        </div>
+        <span className={styles.help}>↳ click a card for full source &amp; preview</span>
+      </div>
       <div className={styles.grid}>
-        {galleryItems.map((item) => (
+        {items.map((item) => (
           <ThumbCard
             key={item.id}
             to={`/gallery/${item.id}`}
             title={item.title}
             description={item.description}
             option={thumbOptions[item.id]}
+            tag={item.id}
           />
         ))}
       </div>

--- a/examples/pages/Home.module.css
+++ b/examples/pages/Home.module.css
@@ -1,82 +1,125 @@
-.sectionTitle {
-  font-size: 14px;
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
-  color: var(--c-text-2);
-  margin: 32px 0 14px;
+.section {
+  margin-bottom: 72px;
 }
 
-.entries {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 14px;
-}
-
-.entryCard {
+.sectionHead {
   display: flex;
-  flex-direction: column;
-  gap: 10px;
-  padding: 22px;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 24px;
+  margin-bottom: 28px;
+  padding-bottom: 16px;
+  border-bottom: 1px solid var(--c-border);
+  flex-wrap: wrap;
+}
+.kicker {
+  display: block;
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--c-text-3);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  margin-bottom: 10px;
+}
+.sectionTitle {
+  font-size: 28px;
+  font-weight: 600;
+  letter-spacing: -0.02em;
+  line-height: 1.15;
+  color: var(--c-text);
+  margin-bottom: 8px;
+  text-wrap: balance;
+}
+.sectionLead {
+  font-size: 14px;
+  color: var(--c-text-2);
+  max-width: 600px;
+  line-height: 1.55;
+  text-wrap: pretty;
+}
+
+.headLink {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-family: var(--mono);
+  font-size: 12px;
+  color: var(--c-text-2);
+  padding: 6px 10px;
   border: 1px solid var(--c-border);
   border-radius: var(--radius);
   background: var(--c-surface);
-  color: inherit;
   transition:
-    border-color 0.15s,
-    transform 0.15s,
-    box-shadow 0.15s;
+    color 0.12s,
+    background 0.12s,
+    border-color 0.12s;
 }
-
-.entryCard:hover {
-  border-color: var(--c-text-2);
-  transform: translateY(-2px);
-  box-shadow: var(--c-shadow);
-}
-
-.entryIcon {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 44px;
-  height: 44px;
-  border-radius: 10px;
-  background: var(--c-accent-soft);
+.headLink:hover {
   color: var(--c-text);
+  background: var(--c-surface-2);
+  border-color: var(--c-border-strong);
 }
 
-.entryTitle {
-  font-size: 18px;
+.featureGrid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 12px;
+}
+.galleryGrid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 16px;
+}
+
+.outroSection {
+  margin-bottom: 32px;
+}
+.outro {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 32px;
+  flex-wrap: wrap;
+  padding: 36px 36px;
+  background: var(--c-surface);
+  border: 1px solid var(--c-border);
+  border-radius: var(--radius-lg);
+  background-image:
+    linear-gradient(var(--c-surface), var(--c-surface)),
+    repeating-linear-gradient(135deg, transparent 0 16px, var(--c-surface-2) 16px 17px);
+}
+.outroTitle {
+  font-size: 32px;
   font-weight: 600;
-  margin: 0;
+  letter-spacing: -0.025em;
+  line-height: 1.1;
+  color: var(--c-text);
+  margin: 4px 0 8px;
+  text-wrap: balance;
+}
+.outroCtas {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
 }
 
-.entryDesc {
-  font-size: 13px;
-  color: var(--c-text-2);
-  line-height: 1.5;
-  margin: 0;
-  flex: 1;
+@media (max-width: 1100px) {
+  .featureGrid {
+    grid-template-columns: repeat(2, 1fr);
+  }
 }
-
-.entryFooter {
-  display: inline-flex;
-  align-items: center;
-  gap: 4px;
-  font-size: 13px;
-  font-weight: 500;
-}
-
-.entryFooter :global(svg) {
-  transition: transform 0.15s;
-}
-
-.entryCard:hover .entryFooter :global(svg) {
-  transform: translateX(2px);
-}
-
-@media (max-width: 860px) {
-  .entries {
+@media (max-width: 720px) {
+  .featureGrid,
+  .galleryGrid {
     grid-template-columns: 1fr;
+  }
+  .outro {
+    padding: 24px;
+  }
+  .sectionTitle {
+    font-size: 24px;
+  }
+  .outroTitle {
+    font-size: 26px;
   }
 }

--- a/examples/pages/Home.tsx
+++ b/examples/pages/Home.tsx
@@ -1,51 +1,116 @@
 import React from "react";
 import { Link } from "react-router-dom";
 import Hero from "../components/Hero";
-import Icon, { type IconName } from "../components/Icon";
+import StatsStrip from "../components/StatsStrip";
+import CompareTable from "../components/CompareTable";
+import FeatureCard from "../components/FeatureCard";
+import ThumbCard from "../components/ThumbCard";
+import Icon from "../components/Icon";
+import { featureItems } from "../data/features";
+import { galleryItems } from "../data/gallery";
+import { thumbOptions } from "../data/thumbs";
 import styles from "./Home.module.css";
-
-interface EntryCardProps {
-  readonly to: string;
-  readonly icon: IconName;
-  readonly title: string;
-  readonly description: string;
-  readonly cta: string;
-}
-
-const EntryCard: React.FC<EntryCardProps> = ({ to, icon, title, description, cta }) => (
-  <Link to={to} className={styles.entryCard}>
-    <div className={styles.entryIcon}>
-      <Icon name={icon} size={22} />
-    </div>
-    <h2 className={styles.entryTitle}>{title}</h2>
-    <p className={styles.entryDesc}>{description}</p>
-    <span className={styles.entryFooter}>
-      {cta}
-      <Icon name="arrow-right" size={14} />
-    </span>
-  </Link>
-);
 
 const Home: React.FC = () => (
   <>
     <Hero />
-    <p className={styles.sectionTitle}>Explore</p>
-    <div className={styles.entries}>
-      <EntryCard
-        to="/gallery"
-        icon="gallery"
-        title="Gallery"
-        description="Eight common chart types — bar, line, radar, gauge, candlestick, heatmap, funnel, and treemap — ready to copy."
-        cta="Browse charts"
-      />
-      <EntryCard
-        to="/features"
-        icon="features"
-        title="Features"
-        description="Dynamic data, themes, renderer switching, chart linkage, events, loading, ref API, and lazy init."
-        cta="Explore features"
-      />
-    </div>
+
+    <StatsStrip />
+
+    <section id="features" className={styles.section}>
+      <header className={styles.sectionHead}>
+        <div>
+          <span className={styles.kicker}>Capabilities</span>
+          <h2 className={styles.sectionTitle}>Built for real ECharts use</h2>
+          <p className={styles.sectionLead}>
+            Eight features cover the gaps people fill manually: reactivity, themes, renderer choice,
+            group linkage, events, loading, ref API, and lazy initialization.
+          </p>
+        </div>
+        <Link to="/features" className={styles.headLink}>
+          All features
+          <Icon name="arrow-right" size={13} />
+        </Link>
+      </header>
+      <div className={styles.featureGrid}>
+        {featureItems.map((item, i) => (
+          <FeatureCard key={item.id} item={item} index={i} />
+        ))}
+      </div>
+    </section>
+
+    <section className={styles.section}>
+      <header className={styles.sectionHead}>
+        <div>
+          <span className={styles.kicker}>Why this lib</span>
+          <h2 className={styles.sectionTitle}>vs. raw ECharts &amp; alternatives</h2>
+          <p className={styles.sectionLead}>
+            A small wrapper that solves the predictable React integration problems — without locking
+            you out of any ECharts API.
+          </p>
+        </div>
+        <Link to="/compare" className={styles.headLink}>
+          Full comparison
+          <Icon name="arrow-right" size={13} />
+        </Link>
+      </header>
+      <CompareTable />
+    </section>
+
+    <section className={styles.section}>
+      <header className={styles.sectionHead}>
+        <div>
+          <span className={styles.kicker}>Gallery preview</span>
+          <h2 className={styles.sectionTitle}>Charts ready to copy</h2>
+          <p className={styles.sectionLead}>
+            Each example is a single self-contained component. Hover into any card to see the chart,
+            then jump to the source.
+          </p>
+        </div>
+        <Link to="/gallery" className={styles.headLink}>
+          All {galleryItems.length} charts
+          <Icon name="arrow-right" size={13} />
+        </Link>
+      </header>
+      <div className={styles.galleryGrid}>
+        {galleryItems.slice(0, 4).map((item) => (
+          <ThumbCard
+            key={item.id}
+            to={`/gallery/${item.id}`}
+            title={item.title}
+            description={item.description}
+            option={thumbOptions[item.id]}
+          />
+        ))}
+      </div>
+    </section>
+
+    <section className={`${styles.section} ${styles.outroSection}`}>
+      <div className={styles.outro}>
+        <div>
+          <span className={styles.kicker}>Get started</span>
+          <h2 className={styles.outroTitle}>Drop a hook in. Ship a chart.</h2>
+          <p className={styles.sectionLead}>
+            Open the playground to tweak options live, or pull any gallery example into your own
+            project.
+          </p>
+        </div>
+        <div className={styles.outroCtas}>
+          <Link to="/playground" className="cta-primary">
+            Open playground
+            <Icon name="arrow-right" size={14} />
+          </Link>
+          <a
+            className="cta-secondary"
+            href="https://github.com/chensid/react-use-echarts#readme"
+            target="_blank"
+            rel="noreferrer"
+          >
+            Read the docs
+          </a>
+        </div>
+      </div>
+    </section>
   </>
 );
 

--- a/examples/pages/PageHeader.module.css
+++ b/examples/pages/PageHeader.module.css
@@ -1,40 +1,67 @@
 .header {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-  margin-bottom: 20px;
-  padding-bottom: 16px;
+  padding-bottom: 28px;
+  margin-bottom: 28px;
   border-bottom: 1px solid var(--c-border);
 }
-
 .crumb {
-  font-size: 12px;
-  color: var(--c-text-2);
-  display: inline-flex;
+  display: flex;
   align-items: center;
-  gap: 4px;
-  margin-bottom: 2px;
+  gap: 6px;
+  font-family: var(--mono);
+  font-size: 11.5px;
+  color: var(--c-text-3);
+  margin-bottom: 14px;
 }
-
 .crumb a {
   color: var(--c-text-2);
   transition: color 0.12s;
 }
-
 .crumb a:hover {
   color: var(--c-text);
 }
-
-.title {
-  font-size: 24px;
-  font-weight: 700;
-  letter-spacing: -0.01em;
-  margin: 0;
+.crumbSep {
+  color: var(--c-text-3);
+}
+.crumbCur {
+  color: var(--c-text);
 }
 
+.eyebrow {
+  display: inline-block;
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--c-text-3);
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  margin-bottom: 10px;
+}
+
+.row {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+.title {
+  font-size: 36px;
+  font-weight: 600;
+  letter-spacing: -0.025em;
+  line-height: 1.1;
+  color: var(--c-text);
+}
+.meta {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-family: var(--mono);
+  font-size: 12px;
+  color: var(--c-text-3);
+}
 .desc {
-  font-size: 14px;
+  font-size: 15px;
   color: var(--c-text-2);
-  margin: 0;
-  max-width: 640px;
+  margin-top: 12px;
+  max-width: 720px;
+  text-wrap: pretty;
 }

--- a/examples/pages/PageHeader.tsx
+++ b/examples/pages/PageHeader.tsx
@@ -6,19 +6,25 @@ interface PageHeaderProps {
   readonly title: string;
   readonly description?: string;
   readonly crumb?: { readonly label: string; readonly to: string };
+  readonly meta?: React.ReactNode;
+  readonly eyebrow?: string;
 }
 
-const PageHeader: React.FC<PageHeaderProps> = ({ title, description, crumb }) => {
+const PageHeader: React.FC<PageHeaderProps> = ({ title, description, crumb, meta, eyebrow }) => {
   return (
     <div className={styles.header}>
       {crumb ? (
         <div className={styles.crumb}>
           <Link to={crumb.to}>{crumb.label}</Link>
-          <span>/</span>
-          <span>{title}</span>
+          <span className={styles.crumbSep}>/</span>
+          <span className={styles.crumbCur}>{title}</span>
         </div>
       ) : null}
-      <h1 className={styles.title}>{title}</h1>
+      {eyebrow ? <div className={styles.eyebrow}>{eyebrow}</div> : null}
+      <div className={styles.row}>
+        <h1 className={styles.title}>{title}</h1>
+        {meta ? <div className={styles.meta}>{meta}</div> : null}
+      </div>
       {description ? <p className={styles.desc}>{description}</p> : null}
     </div>
   );

--- a/examples/pages/Playground.module.css
+++ b/examples/pages/Playground.module.css
@@ -1,0 +1,212 @@
+.tag {
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--c-text-2);
+  padding: 3px 8px;
+  background: var(--c-surface);
+  border: 1px solid var(--c-border);
+  border-radius: 3px;
+}
+.layout {
+  display: grid;
+  grid-template-columns: 280px 1fr;
+  gap: 20px;
+  align-items: start;
+}
+.controls {
+  position: sticky;
+  top: calc(var(--header-height) + 24px);
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  padding: 20px;
+  background: var(--c-surface);
+  border: 1px solid var(--c-border);
+  border-radius: var(--radius-lg);
+}
+.group {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.groupTitle {
+  font-family: var(--mono);
+  font-size: 10.5px;
+  color: var(--c-text-3);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  margin-bottom: 4px;
+}
+
+.segment {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  border: 1px solid var(--c-border);
+  border-radius: var(--radius);
+  overflow: hidden;
+  background: var(--c-surface-2);
+}
+.segBtn {
+  padding: 8px 0;
+  font-family: var(--mono);
+  font-size: 12px;
+  color: var(--c-text-2);
+  border-right: 1px solid var(--c-border);
+  transition:
+    color 0.12s,
+    background 0.12s;
+}
+.segBtn:last-child {
+  border-right: 0;
+}
+.segBtn:hover {
+  color: var(--c-text);
+}
+.segBtnActive {
+  color: var(--c-text);
+  background: var(--c-surface);
+}
+
+.toggle {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 4px 0;
+}
+.toggleDisabled .toggleLabel {
+  opacity: 0.4;
+}
+.toggleLabel {
+  font-family: var(--mono);
+  font-size: 12px;
+  color: var(--c-text);
+}
+.switch {
+  position: relative;
+  display: inline-block;
+  width: 30px;
+  height: 16px;
+  padding: 0;
+  background: var(--c-surface-3);
+  border: 0;
+  border-radius: 999px;
+  cursor: pointer;
+  transition: background 0.15s;
+  flex-shrink: 0;
+}
+.switch:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+.switch:focus-visible {
+  outline: 2px solid var(--c-accent);
+  outline-offset: 2px;
+}
+.switchOn {
+  background: var(--c-accent);
+}
+.switchKnob {
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 12px;
+  height: 12px;
+  background: var(--c-surface);
+  border-radius: 50%;
+  transition: left 0.15s;
+}
+.switchOn .switchKnob {
+  left: 16px;
+}
+
+.range {
+  width: 100%;
+  accent-color: var(--c-accent);
+}
+.rangeRow {
+  display: flex;
+  justify-content: space-between;
+  font-family: var(--mono);
+  font-size: 10.5px;
+  color: var(--c-text-3);
+}
+.rangeVal {
+  color: var(--c-text);
+}
+
+.reset {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  padding: 8px;
+  font-family: var(--mono);
+  font-size: 11.5px;
+  color: var(--c-text-2);
+  background: var(--c-surface-2);
+  border: 1px solid var(--c-border);
+  border-radius: var(--radius);
+}
+.reset:hover {
+  color: var(--c-text);
+}
+
+.right {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  min-width: 0;
+}
+.previewCard,
+.codeCard {
+  background: var(--c-surface);
+  border: 1px solid var(--c-border);
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+}
+.previewHead,
+.codeHead {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 12px;
+  background: var(--c-surface-2);
+  border-bottom: 1px solid var(--c-border);
+}
+.windowDot {
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+  background: var(--c-surface-3);
+}
+.windowTitle,
+.codeTab {
+  margin-left: 6px;
+  font-family: var(--mono);
+  font-size: 11.5px;
+  color: var(--c-text-2);
+}
+.chart {
+  width: 100%;
+  height: 380px;
+  padding: 12px;
+}
+.code {
+  margin: 0;
+  padding: 16px;
+  font-family: var(--mono);
+  font-size: 12px;
+  line-height: 1.65;
+  color: var(--c-text);
+  overflow-x: auto;
+}
+
+@media (max-width: 880px) {
+  .layout {
+    grid-template-columns: 1fr;
+  }
+  .controls {
+    position: static;
+  }
+}

--- a/examples/pages/Playground.tsx
+++ b/examples/pages/Playground.tsx
@@ -1,0 +1,238 @@
+import React, { useMemo, useRef, useState } from "react";
+import { useEcharts } from "../../src";
+import { useTheme } from "../components/theme-context";
+import PageHeader from "./PageHeader";
+import Icon from "../components/Icon";
+import type { EChartsOption } from "echarts";
+import styles from "./Playground.module.css";
+
+type SeriesType = "bar" | "line" | "scatter";
+
+interface State {
+  readonly series: SeriesType;
+  readonly smooth: boolean;
+  readonly area: boolean;
+  readonly stack: boolean;
+  readonly horizontal: boolean;
+  readonly showLegend: boolean;
+  readonly showGrid: boolean;
+  readonly itemSize: number;
+}
+
+const DEFAULT: State = {
+  series: "bar",
+  smooth: true,
+  area: false,
+  stack: false,
+  horizontal: false,
+  showLegend: true,
+  showGrid: true,
+  itemSize: 12,
+};
+
+const X = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
+const A = [120, 132, 101, 134, 90, 230, 210];
+const B = [220, 182, 191, 234, 290, 330, 310];
+
+const buildOption = (s: State): EChartsOption => {
+  const cat = { type: "category" as const, data: X, axisTick: { show: false } };
+  const val = {
+    type: "value" as const,
+    splitLine: s.showGrid ? {} : { show: false },
+  };
+
+  return {
+    backgroundColor: "transparent",
+    tooltip: { trigger: s.series === "scatter" ? "item" : "axis" },
+    legend: s.showLegend ? { bottom: 0, data: ["Series A", "Series B"] } : { show: false },
+    grid: { top: 28, bottom: s.showLegend ? 36 : 16, left: 44, right: 16 },
+    xAxis: s.horizontal ? val : cat,
+    yAxis: s.horizontal ? cat : val,
+    series: [
+      {
+        name: "Series A",
+        type: s.series,
+        data: A,
+        smooth: s.series === "line" ? s.smooth : undefined,
+        areaStyle: s.series === "line" && s.area ? { opacity: 0.2 } : undefined,
+        stack: s.stack ? "total" : undefined,
+        symbolSize: s.itemSize,
+        itemStyle: s.series === "bar" ? { borderRadius: [3, 3, 0, 0] } : undefined,
+      },
+      {
+        name: "Series B",
+        type: s.series,
+        data: B,
+        smooth: s.series === "line" ? s.smooth : undefined,
+        areaStyle: s.series === "line" && s.area ? { opacity: 0.2 } : undefined,
+        stack: s.stack ? "total" : undefined,
+        symbolSize: s.itemSize,
+        itemStyle: s.series === "bar" ? { borderRadius: [3, 3, 0, 0] } : undefined,
+      },
+    ],
+  };
+};
+
+const Playground: React.FC = () => {
+  const [state, setState] = useState<State>(DEFAULT);
+  const { mode } = useTheme();
+  const chartRef = useRef<HTMLDivElement>(null);
+
+  const option = useMemo(() => buildOption(state), [state]);
+  useEcharts(chartRef, { option, theme: mode });
+
+  const set = <K extends keyof State>(k: K, v: State[K]) =>
+    setState((prev) => ({ ...prev, [k]: v }));
+
+  const codeStr = useMemo(() => {
+    const lines = [
+      `import { useEcharts } from "react-use-echarts";`,
+      "",
+      `const ref = useRef<HTMLDivElement>(null);`,
+      `useEcharts(ref, {`,
+      `  option: {`,
+      `    legend: ${state.showLegend ? "{ bottom: 0 }" : "{ show: false }"},`,
+      `    xAxis: ${state.horizontal ? '{ type: "value" }' : '{ type: "category", data: days }'},`,
+      `    yAxis: ${state.horizontal ? '{ type: "category", data: days }' : '{ type: "value" }'},`,
+      `    series: [`,
+      `      {`,
+      `        type: "${state.series}",`,
+      `        data: a,`,
+      state.series === "line" ? `        smooth: ${state.smooth},` : "",
+      state.series === "line" && state.area ? `        areaStyle: { opacity: 0.2 },` : "",
+      state.stack ? `        stack: "total",` : "",
+      state.series !== "bar" ? `        symbolSize: ${state.itemSize},` : "",
+      `      },`,
+      `      // …Series B`,
+      `    ],`,
+      `  },`,
+      `});`,
+    ];
+    return lines.filter(Boolean).join("\n");
+  }, [state]);
+
+  return (
+    <>
+      <PageHeader
+        eyebrow="Playground"
+        title="Live option editor"
+        description="Tweak common option flags in the panel below — the chart and the code update together."
+        meta={
+          <>
+            <span className={styles.tag}>useEcharts()</span>
+            <span className={styles.tag}>theme: {mode}</span>
+          </>
+        }
+      />
+      <div className={styles.layout}>
+        <aside className={styles.controls}>
+          <div className={styles.group}>
+            <div className={styles.groupTitle}>series.type</div>
+            <div className={styles.segment} role="tablist">
+              {(["bar", "line", "scatter"] as SeriesType[]).map((t) => (
+                <button
+                  key={t}
+                  type="button"
+                  role="tab"
+                  aria-selected={state.series === t}
+                  className={`${styles.segBtn} ${state.series === t ? styles.segBtnActive : ""}`}
+                  onClick={() => set("series", t)}
+                >
+                  {t}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          <div className={styles.group}>
+            <div className={styles.groupTitle}>flags</div>
+            <Toggle
+              label="line.smooth"
+              v={state.smooth}
+              on={(v) => set("smooth", v)}
+              disabled={state.series !== "line"}
+            />
+            <Toggle
+              label="series.areaStyle"
+              v={state.area}
+              on={(v) => set("area", v)}
+              disabled={state.series !== "line"}
+            />
+            <Toggle label='series.stack = "total"' v={state.stack} on={(v) => set("stack", v)} />
+            <Toggle label="horizontal axes" v={state.horizontal} on={(v) => set("horizontal", v)} />
+            <Toggle label="legend" v={state.showLegend} on={(v) => set("showLegend", v)} />
+            <Toggle label="splitLine" v={state.showGrid} on={(v) => set("showGrid", v)} />
+          </div>
+
+          <div className={styles.group}>
+            <div className={styles.groupTitle}>symbolSize</div>
+            <input
+              type="range"
+              min={4}
+              max={28}
+              step={1}
+              value={state.itemSize}
+              onChange={(e) => set("itemSize", Number(e.target.value))}
+              className={styles.range}
+              disabled={state.series === "bar"}
+            />
+            <div className={styles.rangeRow}>
+              <span>4</span>
+              <span className={styles.rangeVal}>{state.itemSize}px</span>
+              <span>28</span>
+            </div>
+          </div>
+
+          <button type="button" className={styles.reset} onClick={() => setState(DEFAULT)}>
+            <Icon name="spinner" size={13} />
+            Reset to defaults
+          </button>
+        </aside>
+
+        <div className={styles.right}>
+          <div className={styles.previewCard}>
+            <div className={styles.previewHead}>
+              <span className={styles.windowDot} />
+              <span className={styles.windowDot} />
+              <span className={styles.windowDot} />
+              <span className={styles.windowTitle}>preview · live</span>
+            </div>
+            <div ref={chartRef} className={styles.chart} />
+          </div>
+          <div className={styles.codeCard}>
+            <div className={styles.codeHead}>
+              <span className={styles.codeTab}>generated.tsx</span>
+            </div>
+            <pre className={styles.code}>
+              <code>{codeStr}</code>
+            </pre>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+};
+
+const Toggle: React.FC<{
+  readonly label: string;
+  readonly v: boolean;
+  readonly on: (v: boolean) => void;
+  readonly disabled?: boolean;
+}> = ({ label, v, on, disabled }) => (
+  <div className={`${styles.toggle} ${disabled ? styles.toggleDisabled : ""}`}>
+    <span className={styles.toggleLabel}>{label}</span>
+    <button
+      type="button"
+      role="switch"
+      aria-checked={v}
+      aria-label={label}
+      disabled={disabled}
+      className={`${styles.switch} ${v ? styles.switchOn : ""}`}
+      onClick={() => on(!v)}
+    >
+      <span className={styles.switchKnob} />
+    </button>
+  </div>
+);
+
+export default Playground;

--- a/examples/themes/ThemeSwitcher.tsx
+++ b/examples/themes/ThemeSwitcher.tsx
@@ -44,7 +44,7 @@ const ThemeSwitcher: React.FC = () => {
               i === themeIndex
                 ? {
                     fontWeight: 700,
-                    background: "var(--c-accent-soft)",
+                    background: "var(--c-surface-2)",
                     borderColor: "var(--c-text-2)",
                   }
                 : undefined

--- a/index.html
+++ b/index.html
@@ -9,6 +9,12 @@
       type="image/svg+xml"
       href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' rx='6' fill='%23111'/%3E%3Cpath d='M7 22V10h3v12H7zm5-4V10h3v8h-3zm5 2V10h3v10h-3zm5-6V10h3v4h-3z' fill='%23fff'/%3E%3C/svg%3E"
     />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Geist+Mono:wght@400;500;600&family=Geist:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
   </head>
   <body>
     <div id="root"></div>

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -10,6 +10,7 @@
     /* Bundler mode */
     "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
     "verbatimModuleSyntax": true,
     "moduleDetection": "force",
     "noEmit": true,


### PR DESCRIPTION
## Summary

- New `/playground` (live option editor) and `/compare` routes; new `StatsStrip` + `CompareTable` components
- Hero panel stacks code + chart vertically so the snippet stays readable on desktop; version/peer badges now read from `package.json` via `examples/data/meta.ts`
- Drop hardcoded `axisLine`/`splitLine` colors in Hero charts so the ECharts theme actually drives dark mode (previously near-invisible in dark)
- Playground `Toggle` switched to a native `<button role="switch">` — keyboard operable, `disabled` works, adds `focus-visible` ring
- Global `prefers-reduced-motion` clamp covers transitions and animations
- Shared `.cta-primary`/`.cta-secondary` in `global.css`, drop duplicated module rules
- Remove legacy `--c-surface-dim` / `--c-accent-soft` aliases (migrate their two call sites to `--c-surface-2`)

Scope is `examples/` + `tsconfig.app.json` (enable `resolveJsonModule`) + `index.html`; `src/` is untouched.

## Test plan

- [x] \`vp check\` (format + lint + typecheck) clean
- [x] \`vp test run\` — 168/168 pass
- [x] Visual regression in browser: home (light + dark), playground, compare, gallery detail, narrow 720px viewport
- [x] Hero chart in dark mode shows visible split lines
- [x] Playground switches operable via Tab + Space/Enter; disabled switches skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)