### PR TITLE
ci: enable pnpm via corepack for publint/attw

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,9 @@ jobs:
           node-version: "24"
           cache: true
 
+      - name: Enable pnpm via corepack
+        run: corepack enable
+
       - name: Install dependencies
         run: vp install --frozen-lockfile
 

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -29,6 +29,9 @@ jobs:
           node-version: "24"
           cache: true
 
+      - name: Enable pnpm via corepack
+        run: corepack enable
+
       - name: Install dependencies
         run: vp install --frozen-lockfile
 


### PR DESCRIPTION
## Summary

Follow-up to #366. The ESM-only release adds \`publint\` + \`attw\` to \`vp pack\`, and those tools \`spawn("pnpm")\` directly to inspect the package. The GitHub runner had \`vp\` on PATH but not \`pnpm\`, producing \`spawn pnpm ENOENT\` in the "Build library" step on main.

Enabling \`corepack\` reads the \`packageManager\` field from \`package.json\` and puts pnpm 10 on PATH for every later step. Applied to both \`ci.yml\` and \`npm-publish.yml\`.

## Test plan

- [ ] CI green on this PR (this is what the change is fixing)
- [ ] Main branch CI becomes green after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)