### PR TITLE
ci: matrix on Node 22/24, concurrency, enable Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,34 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "08:00"
+      timezone: Asia/Shanghai
+    open-pull-requests-limit: 5
+    groups:
+      dev-dependencies:
+        dependency-type: development
+        update-types: [minor, patch]
+    labels:
+      - dependencies
+    commit-message:
+      prefix: chore
+      include: scope
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "08:00"
+      timezone: Asia/Shanghai
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - github-actions
+    commit-message:
+      prefix: chore
+      include: scope

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,15 +6,23 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node: ["22", "24"]
     steps:
       - uses: actions/checkout@v5
 
       - uses: voidzero-dev/setup-vp@v1
         with:
-          node-version: "24"
+          node-version: ${{ matrix.node }}
           cache: true
 
       - name: Enable pnpm via corepack
@@ -33,6 +41,7 @@ jobs:
         run: vp test run --coverage
 
       - name: Upload coverage to Codecov
+        if: matrix.node == '24'
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
## Summary
- Run CI `test` job as a matrix across Node **22** and **24** — `engines.node` claims `>=22` but CI only ran 24
- Add workflow-level `concurrency` to cancel superseded runs on the same ref
- Upload coverage to Codecov only from the Node 24 run (avoid duplicate reports)
- Enable Dependabot for `npm` (dev deps grouped, weekly) and `github-actions` (weekly)

## Notes
- After this merges, branch protection required checks need updating from `test` → `test (22)` + `test (24)`. Will do that once PR CI confirms the exact check names.

## Test plan
- [ ] CI green on both Node 22 and Node 24
- [ ] Concurrency cancels a superseded run (will be observed on next push/PR)
- [ ] Dependabot picks up config on Monday

🤖 Generated with [Claude Code](https://claude.com/claude-code)