### PR TITLE
refactor(hooks): extract stable-key and dev-warnings utilities

### DIFF
--- a/src/__tests__/hooks/use-echarts.test.ts
+++ b/src/__tests__/hooks/use-echarts.test.ts
@@ -115,6 +115,32 @@ describe("useEcharts", () => {
       }
     });
 
+    it("should skip the zero-size warning if getBoundingClientRect throws", () => {
+      const previousNodeEnv = process.env.NODE_ENV;
+      process.env.NODE_ENV = "development";
+
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      try {
+        const element = document.createElement("div");
+        Object.defineProperty(element, "getBoundingClientRect", {
+          value: vi.fn(() => {
+            throw new Error("detached element");
+          }),
+        });
+        const ref = { current: element };
+        const mockInstance = createMockInstance(element);
+        (echarts.init as ReturnType<typeof vi.fn>).mockReturnValue(mockInstance);
+
+        expect(() => renderHook(() => useEcharts(ref, { option: baseOption }))).not.toThrow();
+        expect(warnSpy).not.toHaveBeenCalledWith(
+          expect.stringContaining("chart container has zero width or height during initialization"),
+        );
+      } finally {
+        warnSpy.mockRestore();
+        process.env.NODE_ENV = previousNodeEnv;
+      }
+    });
+
     it("should use svg renderer when specified", () => {
       const element = document.createElement("div");
       const ref = { current: element };

--- a/src/hooks/internal/use-chart-core.ts
+++ b/src/hooks/internal/use-chart-core.ts
@@ -10,58 +10,16 @@ import {
 import { updateGroup, getInstanceGroup } from "../../utils/connect";
 import { getOrRegisterCustomTheme, isKnownTheme } from "../../themes";
 import { shallowEqual } from "../../utils/shallow-equal";
+import { computeStableKey, isCircularFallbackKey } from "../../utils/stable-key";
+import { warnedThemeNames, warnedZeroSizeContainers } from "../../utils/dev-warnings";
 import { bindEvents, unbindEvents, eventsEqual } from "./event-utils";
-
-// --- Module-level helpers ---
-
-// Stable IDs for objects that cannot be JSON-serialized (e.g. circular references).
-// Each object gets a unique string via crypto.randomUUID (Math.random fallback),
-// stored in a WeakMap so the same object consistently maps to the same id.
-const CIRCULAR_PREFIX = "__circular_";
-const circularObjectIds = new WeakMap<object, string>();
-
-function getCircularObjectId(obj: object): string {
-  let id = circularObjectIds.get(obj);
-  if (!id) {
-    const rand =
-      typeof crypto !== "undefined" && typeof crypto.randomUUID === "function"
-        ? crypto.randomUUID()
-        : `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
-    id = `${CIRCULAR_PREFIX}${rand}`;
-    circularObjectIds.set(obj, id);
-  }
-  return id;
-}
-
-/**
- * Compute a stable identity key for theme.
- * Falls back to a WeakMap-based ID for circular-reference objects.
- * 计算主题的稳定标识键。对循环引用对象回退到 WeakMap 分配的 ID。
- */
-function computeThemeKey(theme: string | object | null | undefined): string | null {
-  if (theme == null) return null;
-  if (typeof theme === "string") return theme;
-  if (typeof theme !== "object") return null;
-  try {
-    return JSON.stringify(theme);
-  } catch {
-    return getCircularObjectId(theme);
-  }
-}
-
-/**
- * Names already warned about in dev to prevent log spam.
- * dev 模式下已警告过的名称，避免重复输出。
- */
-const warnedThemeNames: Set<string> = new Set();
-const warnedZeroSizeContainers = new WeakSet<HTMLElement>();
 
 /**
  * Resolve theme to a registered ECharts theme name (has side effects).
  * Must only be called inside effects, not during render.
  * 将主题解析为已注册的 ECharts 主题名称（有副作用，仅可在 effect 内调用）。
  *
- * @param themeKey Pre-computed key from computeThemeKey — passed as contentHash
+ * @param themeKey Pre-computed key from computeStableKey — passed as contentHash
  *   to avoid redundant JSON.stringify inside getOrRegisterCustomTheme.
  */
 function resolveThemeName(
@@ -85,7 +43,7 @@ function resolveThemeName(
     return theme;
   }
   if (typeof theme !== "object") return null;
-  const contentHash = themeKey && !themeKey.startsWith(CIRCULAR_PREFIX) ? themeKey : undefined;
+  const contentHash = themeKey && !isCircularFallbackKey(themeKey) ? themeKey : undefined;
   return getOrRegisterCustomTheme(theme, contentHash);
 }
 
@@ -110,7 +68,17 @@ function warnZeroSizeContainer(element: HTMLElement): void {
     return;
   }
 
-  const { width, height } = element.getBoundingClientRect();
+  let width = 0;
+  let height = 0;
+  try {
+    const rect = element.getBoundingClientRect();
+    width = rect.width;
+    height = rect.height;
+  } catch {
+    // getBoundingClientRect is highly reliable on mounted elements but can throw in
+    // exotic environments (detached SVG, cross-realm nodes); skip warning in those cases.
+    return;
+  }
   if (width > 0 && height > 0) return;
 
   warnedZeroSizeContainers.add(element);
@@ -207,15 +175,8 @@ export function useChartCore(
   const lastLoadingRef = useRef<LastLoading | null>(null);
 
   // --- Stable dependency keys ---
-  const themeKey = useMemo(() => computeThemeKey(theme), [theme]);
-  const initOptsKey = useMemo(() => {
-    if (!initOpts) return null;
-    try {
-      return JSON.stringify(initOpts);
-    } catch {
-      return getCircularObjectId(initOpts);
-    }
-  }, [initOpts]);
+  const themeKey = useMemo(() => computeStableKey(theme), [theme]);
+  const initOptsKey = useMemo(() => computeStableKey(initOpts), [initOpts]);
 
   // --- Public API ---
 

--- a/src/hooks/internal/use-resize-observer.ts
+++ b/src/hooks/internal/use-resize-observer.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef, type RefObject } from "react";
+import { useEffect, useLayoutEffect, useRef, type RefObject } from "react";
 import { getCachedInstance } from "../../utils/instance-cache";
 
 /**
@@ -11,7 +11,9 @@ export function useResizeObserver(
   onError?: (error: unknown) => void,
 ): void {
   const onErrorRef = useRef(onError);
-  onErrorRef.current = onError;
+  useLayoutEffect(() => {
+    onErrorRef.current = onError;
+  });
 
   useEffect(() => {
     if (!autoResize) return;

--- a/src/themes/index.ts
+++ b/src/themes/index.ts
@@ -1,5 +1,6 @@
 import * as echarts from "echarts";
 import type { BuiltinTheme } from "../types";
+import { resetDevWarnings } from "../utils/dev-warnings";
 
 /**
  * Hardcoded set of built-in theme names (no JSON dependency)
@@ -143,4 +144,5 @@ export function clearThemeCache(): void {
   contentHashCache.clear();
   knownThemeNames.clear();
   customThemeCounter = 0;
+  resetDevWarnings();
 }

--- a/src/utils/dev-warnings.ts
+++ b/src/utils/dev-warnings.ts
@@ -1,0 +1,16 @@
+/**
+ * Dev-only warning dedup sets.
+ * Module-level singletons so repeated renders / recreated instances only warn once.
+ * dev-only 警告去重集合：跨渲染共享的 module 级单例，保证同一情况只警告一次。
+ */
+
+export const warnedThemeNames = new Set<string>();
+export const warnedZeroSizeContainers = new WeakSet<HTMLElement>();
+
+/**
+ * Reset dev warning state (for testing).
+ * WeakSet has no .clear(); its entries are collected with the element.
+ */
+export function resetDevWarnings(): void {
+  warnedThemeNames.clear();
+}

--- a/src/utils/stable-key.ts
+++ b/src/utils/stable-key.ts
@@ -1,0 +1,51 @@
+/**
+ * Stable identity keys for values used as effect dependencies.
+ * Produces a string that is equal across renders for equivalent values,
+ * so inline objects do not spuriously re-trigger effects.
+ * 为 effect 依赖生成稳定标识键：对相同内容的对象在多次渲染间返回同一字符串，
+ * 避免内联对象触发不必要的 effect 重跑。
+ */
+
+const CIRCULAR_PREFIX = "__circular_";
+
+// Stable IDs for objects that cannot be JSON-serialized (e.g. circular references).
+// Each object gets a unique string via crypto.randomUUID (Math.random fallback),
+// stored in a WeakMap so the same object consistently maps to the same id.
+const circularObjectIds = new WeakMap<object, string>();
+
+function getCircularObjectId(obj: object): string {
+  let id = circularObjectIds.get(obj);
+  if (!id) {
+    const rand =
+      typeof crypto !== "undefined" && typeof crypto.randomUUID === "function"
+        ? crypto.randomUUID()
+        : `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
+    id = `${CIRCULAR_PREFIX}${rand}`;
+    circularObjectIds.set(obj, id);
+  }
+  return id;
+}
+
+/**
+ * Compute a stable identity key for a value.
+ * Strings are returned as-is; objects are JSON-serialized; circular objects
+ * fall back to a WeakMap-assigned id; nullish returns null.
+ */
+export function computeStableKey(value: unknown): string | null {
+  if (value == null) return null;
+  if (typeof value === "string") return value;
+  if (typeof value !== "object") return null;
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return getCircularObjectId(value as object);
+  }
+}
+
+/**
+ * Whether `key` is a WeakMap-assigned fallback id produced for a circular object.
+ * Callers use this to decide whether the key carries serializable content.
+ */
+export function isCircularFallbackKey(key: string): boolean {
+  return key.startsWith(CIRCULAR_PREFIX);
+}


### PR DESCRIPTION
## Summary
- Extract JSON+circular-id fallback into `utils/stable-key` so `themeKey` and `initOptsKey` share one implementation in `useChartCore`
- Extract dev-mode warning sets into `utils/dev-warnings`; `clearThemeCache` now resets them so tests get clean state
- Harden `warnZeroSizeContainer` against `getBoundingClientRect` throwing in detached / cross-realm elements
- Align `useResizeObserver` ref sync with `useChartCore` by wrapping in `useLayoutEffect` instead of writing during render (avoids render-phase side effects under concurrent rendering)

Public API unchanged. Core file `use-chart-core.ts` nets −38 lines.

## Test plan
- [x] `vp check` — format + lint + typecheck all green
- [x] `vp test run --coverage` — 175 tests pass, 100% coverage (stmts / branches / funcs / lines)
- [x] New test covers the `getBoundingClientRect` throw path

🤖 Generated with [Claude Code](https://claude.com/claude-code)