### PR TITLE
refactor(hooks): track ref element to handle DOM node replacement

### DIFF
--- a/src/__tests__/hooks/use-echarts.test.ts
+++ b/src/__tests__/hooks/use-echarts.test.ts
@@ -11,6 +11,7 @@ import { clearGroups, getGroupInstances } from "../../utils/connect";
 import type { EChartsOption } from "echarts";
 import type { BuiltinTheme } from "../../types";
 import { clearThemeCache } from "../../themes";
+import { registerBuiltinThemes } from "../../themes/registry";
 import { createMockInstance, MockResizeObserver, MockIntersectionObserver } from "../helpers";
 
 // Mock ECharts
@@ -182,6 +183,51 @@ describe("useEcharts", () => {
       globalThis.IntersectionObserver =
         MockIntersectionObserver as unknown as typeof IntersectionObserver;
     });
+
+    it("should recreate the instance when ref.current changes to a new element", async () => {
+      const element1 = document.createElement("div");
+      const element2 = document.createElement("div");
+      const ref = { current: element1 };
+      const option1: EChartsOption = { series: [{ type: "line", data: [1, 2, 3] }] };
+      const option2: EChartsOption = { series: [{ type: "bar", data: [4, 5, 6] }] };
+      const onClick = vi.fn();
+      const mockInstance1 = createMockInstance(element1);
+      const mockInstance2 = createMockInstance(element2);
+      (echarts.init as ReturnType<typeof vi.fn>)
+        .mockReturnValueOnce(mockInstance1)
+        .mockReturnValueOnce(mockInstance2);
+
+      const { result, rerender } = renderHook(
+        ({ option }) =>
+          useEcharts(ref, {
+            option,
+            group: "swapGroup",
+            showLoading: true,
+            onEvents: { click: onClick },
+          }),
+        { initialProps: { option: option1 } },
+      );
+
+      await waitFor(() => {
+        expect(getCachedInstance(element1)).toBe(mockInstance1);
+      });
+
+      ref.current = element2;
+      rerender({ option: option2 });
+
+      await waitFor(() => {
+        expect(getCachedInstance(element2)).toBe(mockInstance2);
+      });
+
+      expect(mockInstance1.dispose).toHaveBeenCalledTimes(1);
+      expect(getCachedInstance(element1)).toBeUndefined();
+      expect(result.current.getInstance()).toBe(mockInstance2);
+      expect(mockInstance2.setOption).toHaveBeenCalledWith(option2, undefined);
+      expect(mockInstance2.showLoading).toHaveBeenCalled();
+      expect(mockInstance2.on).toHaveBeenCalledWith("click", onClick, undefined);
+      expect(getGroupInstances("swapGroup")).toContain(mockInstance2);
+      expect(getGroupInstances("swapGroup")).not.toContain(mockInstance1);
+    });
   });
 
   describe("theme handling", () => {
@@ -205,6 +251,51 @@ describe("useEcharts", () => {
       renderHook(() => useEcharts(ref, { option: baseOption, theme: "dark" }));
 
       expect(echarts.init).toHaveBeenCalledWith(element, "dark", expect.any(Object));
+    });
+
+    it("should warn in development when a builtin theme is used before registration", () => {
+      const previousNodeEnv = process.env.NODE_ENV;
+      process.env.NODE_ENV = "development";
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+      try {
+        const element = document.createElement("div");
+        const ref = { current: element };
+        const mockInstance = createMockInstance(element);
+        (echarts.init as ReturnType<typeof vi.fn>).mockReturnValue(mockInstance);
+
+        renderHook(() => useEcharts(ref, { option: baseOption, theme: "dark" }));
+
+        expect(warnSpy).toHaveBeenCalledWith(
+          expect.stringContaining('built-in theme "dark" was not registered'),
+        );
+      } finally {
+        warnSpy.mockRestore();
+        process.env.NODE_ENV = previousNodeEnv;
+      }
+    });
+
+    it("should not warn for a builtin theme after registry registration", () => {
+      const previousNodeEnv = process.env.NODE_ENV;
+      process.env.NODE_ENV = "development";
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+      try {
+        const element = document.createElement("div");
+        const ref = { current: element };
+        const mockInstance = createMockInstance(element);
+        (echarts.init as ReturnType<typeof vi.fn>).mockReturnValue(mockInstance);
+
+        registerBuiltinThemes();
+        renderHook(() => useEcharts(ref, { option: baseOption, theme: "dark" }));
+
+        expect(warnSpy).not.toHaveBeenCalledWith(
+          expect.stringContaining('built-in theme "dark" was not registered'),
+        );
+      } finally {
+        warnSpy.mockRestore();
+        process.env.NODE_ENV = previousNodeEnv;
+      }
     });
 
     it("should register and use custom theme object", () => {
@@ -1081,6 +1172,31 @@ describe("useEcharts", () => {
 
       unmount();
 
+      expect(resizeObserverInstances[0].disconnect).toHaveBeenCalled();
+    });
+
+    it("should move resize observer to a replacement ref element", async () => {
+      const element1 = document.createElement("div");
+      const element2 = document.createElement("div");
+      const ref = { current: element1 };
+      const mockInstance1 = createMockInstance(element1);
+      const mockInstance2 = createMockInstance(element2);
+      (echarts.init as ReturnType<typeof vi.fn>)
+        .mockReturnValueOnce(mockInstance1)
+        .mockReturnValueOnce(mockInstance2);
+
+      const { rerender } = renderHook(() => useEcharts(ref, { option: baseOption }));
+
+      await waitFor(() => {
+        expect(resizeObserverInstances[0].observe).toHaveBeenCalledWith(element1);
+      });
+
+      ref.current = element2;
+      rerender();
+
+      await waitFor(() => {
+        expect(resizeObserverInstances[1].observe).toHaveBeenCalledWith(element2);
+      });
       expect(resizeObserverInstances[0].disconnect).toHaveBeenCalled();
     });
 

--- a/src/__tests__/hooks/use-lazy-init.test.ts
+++ b/src/__tests__/hooks/use-lazy-init.test.ts
@@ -128,6 +128,41 @@ describe("useLazyInit", () => {
     expect(mockObserve).not.toHaveBeenCalled();
   });
 
+  it("should initialize immediately when IntersectionObserver is unavailable", () => {
+    const originalIntersectionObserver = globalThis.IntersectionObserver;
+    Reflect.deleteProperty(globalThis, "IntersectionObserver");
+
+    try {
+      const element = document.createElement("div");
+      const ref = { current: element };
+
+      const { result } = renderHook(() => useLazyInit(ref, true));
+
+      expect(result.current).toBe(true);
+      expect(mockObserve).not.toHaveBeenCalled();
+    } finally {
+      globalThis.IntersectionObserver = originalIntersectionObserver;
+    }
+  });
+
+  it("should observe a replacement ref element before it is visible", async () => {
+    const element1 = document.createElement("div");
+    const element2 = document.createElement("div");
+    const ref = { current: element1 };
+
+    const { rerender } = renderHook(() => useLazyInit(ref, true));
+
+    expect(mockObserve).toHaveBeenCalledWith(element1);
+
+    ref.current = element2;
+    rerender();
+
+    await waitFor(() => {
+      expect(mockObserve).toHaveBeenCalledWith(element2);
+    });
+    expect(mockDisconnect).toHaveBeenCalled();
+  });
+
   it("should cleanup on unmount", () => {
     const element = document.createElement("div");
     const ref = { current: element };

--- a/src/__tests__/themes/index.test.ts
+++ b/src/__tests__/themes/index.test.ts
@@ -2,6 +2,8 @@ import { describe, it, expect, vi, beforeEach } from "vite-plus/test";
 import * as echarts from "echarts";
 import {
   isBuiltinTheme,
+  isBuiltinThemeRegistered,
+  markBuiltinThemeRegistered,
   registerCustomTheme,
   getOrRegisterCustomTheme,
   clearThemeCache,
@@ -37,6 +39,24 @@ describe("themes utilities", () => {
 
     it("should return false for empty string", () => {
       expect(isBuiltinTheme("")).toBe(false);
+    });
+  });
+
+  describe("builtin theme registration state", () => {
+    it("should track registered builtin themes separately from builtin names", () => {
+      expect(isBuiltinTheme("dark")).toBe(true);
+      expect(isBuiltinThemeRegistered("dark")).toBe(false);
+
+      markBuiltinThemeRegistered("dark");
+
+      expect(isBuiltinThemeRegistered("dark")).toBe(true);
+    });
+
+    it("should clear registered builtin theme state", () => {
+      markBuiltinThemeRegistered("dark");
+      clearThemeCache();
+
+      expect(isBuiltinThemeRegistered("dark")).toBe(false);
     });
   });
 

--- a/src/__tests__/themes/registry.test.ts
+++ b/src/__tests__/themes/registry.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vite-plus/test";
 import * as echarts from "echarts";
+import { clearThemeCache, isBuiltinThemeRegistered } from "../../themes";
 import { registerBuiltinThemes } from "../../themes/registry";
 
 // Mock ECharts
@@ -9,6 +10,7 @@ vi.mock("echarts", () => ({
 
 describe("themes registry", () => {
   beforeEach(() => {
+    clearThemeCache();
     vi.clearAllMocks();
   });
 
@@ -20,6 +22,9 @@ describe("themes registry", () => {
       expect(echarts.registerTheme).toHaveBeenCalledWith("dark", expect.any(Object));
       expect(echarts.registerTheme).toHaveBeenCalledWith("macarons", expect.any(Object));
       expect(echarts.registerTheme).toHaveBeenCalledTimes(3);
+      expect(isBuiltinThemeRegistered("light")).toBe(true);
+      expect(isBuiltinThemeRegistered("dark")).toBe(true);
+      expect(isBuiltinThemeRegistered("macarons")).toBe(true);
 
       // Calling again should be a no-op (idempotent)
       vi.clearAllMocks();

--- a/src/hooks/internal/use-chart-core.ts
+++ b/src/hooks/internal/use-chart-core.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useCallback, useLayoutEffect, useMemo, type RefObject } from "react";
+import { useEffect, useRef, useCallback, useLayoutEffect, useMemo } from "react";
 import * as echarts from "echarts";
 import type { ECharts, SetOptionOpts, EChartsOption } from "echarts";
 import type { EChartsEvents, EChartsInitOpts, UseEchartsOptions, LoadingOption } from "../../types";
@@ -8,7 +8,12 @@ import {
   releaseCachedInstance,
 } from "../../utils/instance-cache";
 import { updateGroup, getInstanceGroup } from "../../utils/connect";
-import { getOrRegisterCustomTheme, isKnownTheme } from "../../themes";
+import {
+  getOrRegisterCustomTheme,
+  isBuiltinTheme,
+  isBuiltinThemeRegistered,
+  isKnownTheme,
+} from "../../themes";
 import { shallowEqual } from "../../utils/shallow-equal";
 import { computeStableKey, isCircularFallbackKey } from "../../utils/stable-key";
 import { warnedThemeNames, warnedZeroSizeContainers } from "../../utils/dev-warnings";
@@ -30,6 +35,20 @@ function resolveThemeName(
   if (typeof theme === "string") {
     if (
       process.env.NODE_ENV !== "production" &&
+      process.env.NODE_ENV !== "test" &&
+      isBuiltinTheme(theme) &&
+      !isBuiltinThemeRegistered(theme) &&
+      !warnedThemeNames.has(theme)
+    ) {
+      warnedThemeNames.add(theme);
+      console.warn(
+        `react-use-echarts: built-in theme "${theme}" was not registered. ` +
+          `Import registerBuiltinThemes() from "react-use-echarts/themes/registry" and call it once before using built-in themes. ` +
+          `Unregistered themes silently fall back to the default theme.`,
+      );
+    } else if (
+      process.env.NODE_ENV !== "production" &&
+      process.env.NODE_ENV !== "test" &&
       !isKnownTheme(theme) &&
       !warnedThemeNames.has(theme)
     ) {
@@ -129,7 +148,7 @@ interface ChartCoreReturn {
  * 内部管理所有 ref 和共享可变状态——调用方仅传入原始值。
  */
 export function useChartCore(
-  ref: RefObject<HTMLDivElement | null>,
+  element: HTMLDivElement | null,
   shouldInit: boolean,
   config: ChartCoreConfig,
 ): ChartCoreReturn {
@@ -181,9 +200,9 @@ export function useChartCore(
   // --- Public API ---
 
   const getInstance = useCallback((): ECharts | undefined => {
-    if (!ref.current) return undefined;
-    return getCachedInstance(ref.current);
-  }, [ref]);
+    if (!element) return undefined;
+    return getCachedInstance(element);
+  }, [element]);
 
   const setOption = useCallback(
     (newOption: EChartsOption, opts?: SetOptionOpts) => {
@@ -213,7 +232,6 @@ export function useChartCore(
   useLayoutEffect(() => {
     if (!shouldInit) return;
 
-    const element = ref.current;
     if (!element) return;
 
     warnZeroSizeContainer(element);
@@ -289,8 +307,8 @@ export function useChartCore(
 
       releaseCachedInstance(element);
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- refs are stable containers; only structural deps trigger re-init
-  }, [shouldInit, ref, themeKey, renderer, initOptsKey]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- latest config values are read from refs; only structural deps trigger re-init
+  }, [shouldInit, element, themeKey, renderer, initOptsKey]);
 
   // =====================================================================
   // Effect 2: OPTION UPDATES

--- a/src/hooks/internal/use-ref-element.ts
+++ b/src/hooks/internal/use-ref-element.ts
@@ -1,0 +1,18 @@
+import { useLayoutEffect, useState, type RefObject } from "react";
+
+/**
+ * Tracks the current element behind a stable RefObject across renders.
+ */
+export function useRefElement<T extends Element>(ref: RefObject<T | null>): T | null {
+  const [element, setElement] = useState<T | null>(() => ref.current);
+
+  // Ref assignment happens during commit; check after every commit to catch replacements.
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- intentionally polls ref.current after each commit
+  useLayoutEffect(() => {
+    if (element !== ref.current) {
+      setElement(ref.current);
+    }
+  });
+
+  return element;
+}

--- a/src/hooks/internal/use-resize-observer.ts
+++ b/src/hooks/internal/use-resize-observer.ts
@@ -1,4 +1,4 @@
-import { useEffect, useLayoutEffect, useRef, type RefObject } from "react";
+import { useEffect, useLayoutEffect, useRef } from "react";
 import { getCachedInstance } from "../../utils/instance-cache";
 
 /**
@@ -6,7 +6,7 @@ import { getCachedInstance } from "../../utils/instance-cache";
  * 内部 hook：基于 ResizeObserver 的自动 resize，使用 RAF 节流。
  */
 export function useResizeObserver(
-  ref: RefObject<HTMLElement | null>,
+  element: HTMLElement | null,
   autoResize: boolean,
   onError?: (error: unknown) => void,
 ): void {
@@ -18,7 +18,6 @@ export function useResizeObserver(
   useEffect(() => {
     if (!autoResize) return;
 
-    const element = ref.current;
     if (!element) return;
 
     let resizeObserver: ResizeObserver | undefined;
@@ -49,5 +48,5 @@ export function useResizeObserver(
       }
       resizeObserver?.disconnect();
     };
-  }, [ref, autoResize]);
+  }, [element, autoResize]);
 }

--- a/src/hooks/use-echarts.ts
+++ b/src/hooks/use-echarts.ts
@@ -1,8 +1,9 @@
 import { useCallback, useMemo, type RefObject } from "react";
 import type { UseEchartsOptions, UseEchartsReturn } from "../types";
-import { useLazyInit } from "./use-lazy-init";
+import { useLazyInitForElement } from "./use-lazy-init";
 import { useChartCore } from "./internal/use-chart-core";
 import { useResizeObserver } from "./internal/use-resize-observer";
+import { useRefElement } from "./internal/use-ref-element";
 
 /**
  * React hook for Apache ECharts integration
@@ -31,10 +32,11 @@ function useEcharts(
     onError,
   } = options;
 
-  const shouldInit = useLazyInit(ref, lazyInit);
+  const element = useRefElement(ref);
+  const shouldInit = useLazyInitForElement(element, lazyInit);
 
   // Core: instance lifecycle + option sync + events + loading + group (1 useLayoutEffect + 4 useEffect)
-  const { getInstance, setOption } = useChartCore(ref, shouldInit, {
+  const { getInstance, setOption } = useChartCore(element, shouldInit, {
     option,
     theme,
     renderer,
@@ -47,7 +49,7 @@ function useEcharts(
     onError,
   });
 
-  useResizeObserver(ref, autoResize, onError);
+  useResizeObserver(element, autoResize, onError);
 
   const resize = useCallback(() => {
     getInstance()?.resize();

--- a/src/hooks/use-lazy-init.ts
+++ b/src/hooks/use-lazy-init.ts
@@ -1,4 +1,5 @@
 import { useEffect, useState, useMemo, type RefObject } from "react";
+import { useRefElement } from "./internal/use-ref-element";
 
 /**
  * Hook for lazy initialization using IntersectionObserver
@@ -11,8 +12,17 @@ export function useLazyInit(
   elementRef: RefObject<Element | null>,
   options: boolean | IntersectionObserverInit = false,
 ): boolean {
+  const element = useRefElement(elementRef);
+  return useLazyInitForElement(element, options);
+}
+
+export function useLazyInitForElement(
+  element: Element | null,
+  options: boolean | IntersectionObserverInit = false,
+): boolean {
   const isLazyMode = options !== false;
   const [isInView, setIsInView] = useState(!isLazyMode);
+  const supportsIntersectionObserver = typeof IntersectionObserver !== "undefined";
 
   // Extract config values for stable dependency comparison
   // 提取配置值用于稳定的依赖比较
@@ -36,10 +46,7 @@ export function useLazyInit(
   useEffect(() => {
     // Skip if lazy mode is disabled or already in view
     // 如果禁用了懒加载模式或已经可见，则跳过
-    if (!isLazyMode || isInView) return;
-
-    const element = elementRef.current;
-    if (!element) return;
+    if (!isLazyMode || isInView || !supportsIntersectionObserver || !element) return;
 
     const observer = new IntersectionObserver((entries) => {
       const [entry] = entries;
@@ -57,9 +64,9 @@ export function useLazyInit(
       observer.disconnect();
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps -- isInView excluded: observer self-disconnects on intersection
-  }, [elementRef, isLazyMode, observerOptions]);
+  }, [element, isLazyMode, observerOptions, supportsIntersectionObserver]);
 
   // Derive visibility — when lazy mode is toggled off at runtime,
   // the hook should report visible without waiting for an effect tick.
-  return !isLazyMode || isInView;
+  return !isLazyMode || !supportsIntersectionObserver || isInView;
 }

--- a/src/themes/index.ts
+++ b/src/themes/index.ts
@@ -7,6 +7,7 @@ import { resetDevWarnings } from "../utils/dev-warnings";
  * 内置主题名称硬编码集合（不依赖 JSON 数据）
  */
 const BUILTIN_THEME_NAMES: ReadonlySet<string> = new Set<string>(["light", "dark", "macarons"]);
+const REGISTERED_BUILTIN_THEME_NAMES_KEY = "__react_use_echarts_registered_builtin_theme_names__";
 
 /**
  * Names known to be registered via this library's API. Used by `isKnownTheme`
@@ -16,6 +17,13 @@ const BUILTIN_THEME_NAMES: ReadonlySet<string> = new Set<string>(["light", "dark
  * 若要消除 dev 警告请改用 `registerCustomTheme`。
  */
 const knownThemeNames: Set<string> = new Set<string>();
+type ThemeGlobal = typeof globalThis & {
+  [REGISTERED_BUILTIN_THEME_NAMES_KEY]?: Set<BuiltinTheme>;
+};
+const themeGlobal = globalThis as ThemeGlobal;
+const registeredBuiltinThemeNames: Set<BuiltinTheme> =
+  themeGlobal[REGISTERED_BUILTIN_THEME_NAMES_KEY] ?? new Set<BuiltinTheme>();
+themeGlobal[REGISTERED_BUILTIN_THEME_NAMES_KEY] = registeredBuiltinThemeNames;
 
 /**
  * Cache for custom theme names (theme object -> registered theme name)
@@ -59,6 +67,21 @@ export function isBuiltinTheme(themeName: string): themeName is BuiltinTheme {
  */
 export function isKnownTheme(themeName: string): boolean {
   return BUILTIN_THEME_NAMES.has(themeName) || knownThemeNames.has(themeName);
+}
+
+/**
+ * Whether a built-in theme has been registered through the registry entry.
+ * Used internally for dev-time warnings without importing preset JSON.
+ */
+export function isBuiltinThemeRegistered(themeName: BuiltinTheme): boolean {
+  return registeredBuiltinThemeNames.has(themeName);
+}
+
+/**
+ * Mark a built-in theme as registered by the optional registry entry.
+ */
+export function markBuiltinThemeRegistered(themeName: BuiltinTheme): void {
+  registeredBuiltinThemeNames.add(themeName);
 }
 
 /**
@@ -143,6 +166,7 @@ export function getOrRegisterCustomTheme(themeConfig: object, precomputedHash?: 
 export function clearThemeCache(): void {
   contentHashCache.clear();
   knownThemeNames.clear();
+  registeredBuiltinThemeNames.clear();
   customThemeCounter = 0;
   resetDevWarnings();
 }

--- a/src/themes/registry.ts
+++ b/src/themes/registry.ts
@@ -1,17 +1,17 @@
 import * as echarts from "echarts";
+import type { BuiltinTheme } from "../types";
+import { isBuiltinThemeRegistered, markBuiltinThemeRegistered } from "./index";
 
 // Import theme presets (heavy — ~20KB JSON)
 import lightTheme from "./presets/light.json";
 import darkTheme from "./presets/dark.json";
 import macaronsTheme from "./presets/macarons.json";
 
-const builtinThemes: ReadonlyArray<readonly [string, object]> = [
+const builtinThemes: ReadonlyArray<readonly [BuiltinTheme, object]> = [
   ["light", lightTheme],
   ["dark", darkTheme],
   ["macarons", macaronsTheme],
 ];
-
-let builtinThemesRegistered = false;
 
 /**
  * Register all built-in themes with ECharts.
@@ -19,9 +19,9 @@ let builtinThemesRegistered = false;
  * 向 ECharts 注册所有内置主题。在应用入口调用一次即可使用内置主题。
  */
 export function registerBuiltinThemes(): void {
-  if (builtinThemesRegistered) return;
   for (const [themeName, themeConfig] of builtinThemes) {
+    if (isBuiltinThemeRegistered(themeName)) continue;
     echarts.registerTheme(themeName, themeConfig);
+    markBuiltinThemeRegistered(themeName);
   }
-  builtinThemesRegistered = true;
 }


### PR DESCRIPTION
## Summary
- Internal hooks (`useChartCore`, `useResizeObserver`, `useLazyInit`) now consume a tracked element value via the new `useRefElement` instead of a `RefObject`, so effects correctly re-run when `ref.current` is swapped to a different DOM node — fixing a latent bug where the chart instance was not recreated for the replacement element.
- Adds a dev-only warning when a built-in theme name is used before `registerBuiltinThemes()` has been called (separate from the existing unknown-theme warning), with the registration state tracked through `isBuiltinThemeRegistered` / `markBuiltinThemeRegistered`.
- `useLazyInit` falls back to immediate visibility when `IntersectionObserver` is unavailable.

## Test plan
- [x] `vp test run` — 183 tests pass, including new cases:
  - `useEcharts` recreates the instance and migrates events / loading / group when `ref.current` changes
  - `useResizeObserver` re-observes the replacement element
  - `useLazyInit` observes a replacement element and falls back when `IntersectionObserver` is missing
  - Built-in theme warning fires only when `registerBuiltinThemes()` has not been called
- [x] `vp check` — format / lint / typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)