### PR TITLE
fix(hooks): drop redundant test-env guard on unknown-theme warning

### DIFF
--- a/src/hooks/internal/use-chart-core.ts
+++ b/src/hooks/internal/use-chart-core.ts
@@ -48,7 +48,6 @@ function resolveThemeName(
       );
     } else if (
       process.env.NODE_ENV !== "production" &&
-      process.env.NODE_ENV !== "test" &&
       !isKnownTheme(theme) &&
       !warnedThemeNames.has(theme)
     ) {


### PR DESCRIPTION
## Summary
Follow-up to #375. The previous PR extended the new `process.env.NODE_ENV !== "test"` guard (added for the built-in-not-registered warning) to the existing unknown-theme branch as well, which silenced a path that the existing `non-builtin string theme` test relied on for coverage. Codecov flagged a 0.58% project drop.

This restores the original `production`-only guard on the unknown-theme branch. The new built-in-not-registered branch keeps its test guard because it has explicit dev-mode tests covering it.

Coverage after fix (local v8): statements 100%, lines 100%, branches 99.6% (only the pre-existing `useLazyInit` default-parameter branch remains, unrelated to this change).

## Test plan
- [x] `vp test run --coverage` — 183 tests pass, statements/lines back to 100%
- [x] `vp check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)