### PR TITLE
test(hooks): cover useLazyInit default options branch

### DIFF
--- a/src/__tests__/hooks/use-lazy-init.test.ts
+++ b/src/__tests__/hooks/use-lazy-init.test.ts
@@ -43,6 +43,16 @@ describe("useLazyInit", () => {
     expect(mockObserve).not.toHaveBeenCalled();
   });
 
+  it("should default to lazy mode disabled when options argument is omitted", () => {
+    const element = document.createElement("div");
+    const ref = { current: element };
+
+    const { result } = renderHook(() => useLazyInit(ref));
+
+    expect(result.current).toBe(true);
+    expect(mockObserve).not.toHaveBeenCalled();
+  });
+
   it("should return false initially when lazy mode is enabled", () => {
     const element = document.createElement("div");
     const ref = { current: element };


### PR DESCRIPTION
## Summary
Adds a test case that invokes `useLazyInit(ref)` without the `options` argument so the default-parameter branch (`= false`) is exercised. This was the only remaining uncovered branch in the project.

## Test plan
- [x] `vp test run --coverage` — 184 tests pass; coverage now 100% across statements / branches / functions / lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)