### PR TITLE
refactor: defensive code quality improvements

### DIFF
--- a/src/__tests__/hooks/event-utils.test.ts
+++ b/src/__tests__/hooks/event-utils.test.ts
@@ -24,6 +24,15 @@ describe("eventsEqual", () => {
     expect(eventsEqual(undefined, { click: handler() })).toBe(false);
   });
 
+  it("should treat empty object and undefined as equivalent", () => {
+    expect(eventsEqual({}, undefined)).toBe(true);
+    expect(eventsEqual(undefined, {})).toBe(true);
+  });
+
+  it("should return true for two empty objects", () => {
+    expect(eventsEqual({}, {})).toBe(true);
+  });
+
   it("should return true for same function handlers", () => {
     const h = handler();
     expect(eventsEqual({ click: h }, { click: h })).toBe(true);

--- a/src/__tests__/hooks/use-lazy-init.test.ts
+++ b/src/__tests__/hooks/use-lazy-init.test.ts
@@ -138,23 +138,6 @@ describe("useLazyInit", () => {
     expect(mockObserve).not.toHaveBeenCalled();
   });
 
-  it("should initialize immediately when IntersectionObserver is unavailable", () => {
-    const originalIntersectionObserver = globalThis.IntersectionObserver;
-    Reflect.deleteProperty(globalThis, "IntersectionObserver");
-
-    try {
-      const element = document.createElement("div");
-      const ref = { current: element };
-
-      const { result } = renderHook(() => useLazyInit(ref, true));
-
-      expect(result.current).toBe(true);
-      expect(mockObserve).not.toHaveBeenCalled();
-    } finally {
-      globalThis.IntersectionObserver = originalIntersectionObserver;
-    }
-  });
-
   it("should observe a replacement ref element before it is visible", async () => {
     const element1 = document.createElement("div");
     const element2 = document.createElement("div");

--- a/src/__tests__/themes/index.test.ts
+++ b/src/__tests__/themes/index.test.ts
@@ -141,6 +141,29 @@ describe("themes utilities", () => {
       expect(name2).toBe(name);
     });
 
+    it("should refresh entry position on access (LRU semantics)", () => {
+      // Fill cache to capacity
+      for (let i = 0; i < 100; i++) {
+        getOrRegisterCustomTheme({ lru: [`#${String(i).padStart(6, "0")}`] });
+      }
+
+      // Touch theme #0 with a new reference → moves it to MRU position
+      getOrRegisterCustomTheme({ lru: [`#${String(0).padStart(6, "0")}`] });
+
+      // Insert one more theme → triggers eviction; LRU should evict #1, not #0
+      getOrRegisterCustomTheme({ lru: ["#extra000"] });
+
+      vi.clearAllMocks();
+
+      // Theme #0 should still be cached (was recently accessed)
+      getOrRegisterCustomTheme({ lru: [`#${String(0).padStart(6, "0")}`] });
+      expect(echarts.registerTheme).not.toHaveBeenCalled();
+
+      // Theme #1 should have been evicted (least recently used)
+      getOrRegisterCustomTheme({ lru: [`#${String(1).padStart(6, "0")}`] });
+      expect(echarts.registerTheme).toHaveBeenCalledTimes(1);
+    });
+
     it("should evict oldest content cache entry when exceeding max size", () => {
       // Register 101 unique themes to trigger eviction (max is 100)
       for (let i = 0; i < 101; i++) {

--- a/src/__tests__/utils/connect.test.ts
+++ b/src/__tests__/utils/connect.test.ts
@@ -52,6 +52,22 @@ describe("connect utilities", () => {
       expect(getGroupInstances("group1")).toHaveLength(2);
     });
 
+    it("should reconnect when re-adding after the group was disconnected", () => {
+      const instance1 = createMockInstance();
+      const instance2 = createMockInstance();
+      const instance3 = createMockInstance();
+
+      addToGroup(instance1, "group1");
+      addToGroup(instance2, "group1");
+      removeFromGroup(instance1, "group1");
+      vi.clearAllMocks();
+
+      addToGroup(instance3, "group1");
+
+      expect(echarts.connect).toHaveBeenCalledWith("group1");
+      expect(getGroupInstances("group1")).toHaveLength(2);
+    });
+
     it("should handle adding to multiple groups", () => {
       const instance1 = createMockInstance();
       const instance2 = createMockInstance();

--- a/src/__tests__/utils/instance-cache.test.ts
+++ b/src/__tests__/utils/instance-cache.test.ts
@@ -46,17 +46,35 @@ describe("instance-cache utilities", () => {
       expect(getReferenceCount(element)).toBe(1);
     });
 
-    it("should increment ref count for existing element", () => {
+    it("should increment ref count for existing element with same instance", () => {
+      const element = document.createElement("div");
+      const instance = createMockInstance();
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+      setCachedInstance(element, instance);
+      const result = setCachedInstance(element, instance);
+
+      expect(result).toBe(instance);
+      expect(getReferenceCount(element)).toBe(2);
+      expect(warnSpy).not.toHaveBeenCalled();
+      warnSpy.mockRestore();
+    });
+
+    it("should warn and keep the cached instance when called with a different one", () => {
       const element = document.createElement("div");
       const instance1 = createMockInstance();
       const instance2 = createMockInstance();
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
 
       setCachedInstance(element, instance1);
       const result = setCachedInstance(element, instance2);
 
-      // Should return the original cached instance
       expect(result).toBe(instance1);
       expect(getReferenceCount(element)).toBe(2);
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("called with a different instance"),
+      );
+      warnSpy.mockRestore();
     });
   });
 

--- a/src/hooks/internal/event-utils.ts
+++ b/src/hooks/internal/event-utils.ts
@@ -46,18 +46,18 @@ function eventConfigEqual(a: EChartsEventConfig, b: EChartsEventConfig): boolean
 
 /**
  * Shallow comparison of two EChartsEvents maps.
- * Compares keys, then each event config at the handler/query/context level.
- * 两个事件映射的浅比较。比较键，然后在 handler/query/context 级别比较每个事件配置。
+ * Empty maps and undefined are treated as equivalent (no listeners).
+ * 两个事件映射的浅比较；空对象与 undefined 视为等价（均表示无监听）。
  */
 export function eventsEqual(a: EChartsEvents | undefined, b: EChartsEvents | undefined): boolean {
   if (a === b) return true;
-  if (!a || !b) return false;
-  const keysA = Object.keys(a);
-  const keysB = Object.keys(b);
+  const keysA = a ? Object.keys(a) : [];
+  const keysB = b ? Object.keys(b) : [];
   if (keysA.length !== keysB.length) return false;
+  if (keysA.length === 0) return true;
   for (const key of keysA) {
-    if (!Object.prototype.hasOwnProperty.call(b, key)) return false;
-    if (!eventConfigEqual(a[key], b[key])) return false;
+    if (!Object.prototype.hasOwnProperty.call(b!, key)) return false;
+    if (!eventConfigEqual(a![key], b![key])) return false;
   }
   return true;
 }

--- a/src/hooks/internal/use-chart-core.ts
+++ b/src/hooks/internal/use-chart-core.ts
@@ -132,6 +132,24 @@ interface ChartCoreConfig {
   onError?: (e: unknown) => void;
 }
 
+/**
+ * Resolved latest values that must stay current for refs read inside effects
+ * without re-triggering them. Defaults applied (renderer, showLoading) so the
+ * fields are non-optional from the consumer's perspective.
+ */
+interface LatestConfig {
+  option: EChartsOption;
+  theme: UseEchartsOptions["theme"];
+  renderer: "canvas" | "svg";
+  initOpts: EChartsInitOpts | undefined;
+  setOptionOpts: SetOptionOpts | undefined;
+  showLoading: boolean;
+  loadingOption: LoadingOption | undefined;
+  onEvents: EChartsEvents | undefined;
+  group: string | undefined;
+  onError: ((e: unknown) => void) | undefined;
+}
+
 interface ChartCoreReturn {
   getInstance: () => ECharts | undefined;
   setOption: (option: EChartsOption, opts?: SetOptionOpts) => void;
@@ -164,27 +182,35 @@ export function useChartCore(
     onError,
   } = config;
 
-  // --- Internal refs: latest values for the init effect to read without re-triggering ---
-  const optionRef = useRef(option);
-  const setOptionOptsRef = useRef(setOptionOpts);
-  const showLoadingRef = useRef(showLoading);
-  const loadingOptionRef = useRef(loadingOption);
-  const onEventsRef = useRef(onEvents);
-  const groupRef = useRef(group);
-  const onErrorRef = useRef(onError);
-  const themeRef = useRef(theme);
-  const initOptsRef = useRef(initOpts);
+  // --- Internal ref: latest values for effects to read without re-triggering.
+  // Adding a field to LatestConfig forces it to appear in both the initializer
+  // and the sync layout effect below — TS catches stale-config drift at compile time.
+  const latestRef = useRef<LatestConfig>({
+    option,
+    theme,
+    renderer,
+    initOpts,
+    setOptionOpts,
+    showLoading,
+    loadingOption,
+    onEvents,
+    group,
+    onError,
+  });
 
   useLayoutEffect(() => {
-    optionRef.current = option;
-    setOptionOptsRef.current = setOptionOpts;
-    showLoadingRef.current = showLoading;
-    loadingOptionRef.current = loadingOption;
-    onEventsRef.current = onEvents;
-    groupRef.current = group;
-    onErrorRef.current = onError;
-    themeRef.current = theme;
-    initOptsRef.current = initOpts;
+    latestRef.current = {
+      option,
+      theme,
+      renderer,
+      initOpts,
+      setOptionOpts,
+      showLoading,
+      loadingOption,
+      onEvents,
+      group,
+      onError,
+    };
   });
 
   // --- Internal shared state ---
@@ -208,11 +234,12 @@ export function useChartCore(
       const instance = getInstance();
       if (!instance) return;
       try {
-        const finalOpts = { ...setOptionOptsRef.current, ...opts };
+        const finalOpts = { ...latestRef.current.setOptionOpts, ...opts };
         instance.setOption(newOption, finalOpts);
       } catch (error) {
-        if (onErrorRef.current) {
-          onErrorRef.current(error);
+        const onError = latestRef.current.onError;
+        if (onError) {
+          onError(error);
         } else {
           throw error;
         }
@@ -235,7 +262,8 @@ export function useChartCore(
 
     warnZeroSizeContainer(element);
 
-    const resolvedTheme = resolveThemeName(themeRef.current, themeKey);
+    const latest = latestRef.current;
+    const resolvedTheme = resolveThemeName(latest.theme, themeKey);
 
     const existing = getCachedInstance(element);
     let instance: ECharts;
@@ -254,39 +282,38 @@ export function useChartCore(
       try {
         instance = echarts.init(element, resolvedTheme, {
           renderer,
-          ...initOptsRef.current,
+          ...latest.initOpts,
         });
       } catch (error) {
-        logError(error, "ECharts init failed:", onErrorRef.current);
+        logError(error, "ECharts init failed:", latest.onError);
         return;
       }
       setCachedInstance(element, instance);
     }
 
     try {
-      instance.setOption(optionRef.current, setOptionOptsRef.current);
+      instance.setOption(latest.option, latest.setOptionOpts);
       lastAppliedRef.current = {
-        option: optionRef.current,
-        opts: setOptionOptsRef.current,
+        option: latest.option,
+        opts: latest.setOptionOpts,
       };
     } catch (error) {
-      logError(error, "ECharts setOption failed:", onErrorRef.current);
+      logError(error, "ECharts setOption failed:", latest.onError);
     }
 
-    if (showLoadingRef.current) {
-      instance.showLoading(loadingOptionRef.current);
+    if (latest.showLoading) {
+      instance.showLoading(latest.loadingOption);
     }
     lastLoadingRef.current = {
-      showLoading: showLoadingRef.current,
-      loadingOption: loadingOptionRef.current,
+      showLoading: latest.showLoading,
+      loadingOption: latest.loadingOption,
     };
 
-    bindEvents(instance, onEventsRef.current);
-    boundEventsRef.current = onEventsRef.current;
+    bindEvents(instance, latest.onEvents);
+    boundEventsRef.current = latest.onEvents;
 
-    const currentGroup = groupRef.current;
-    if (currentGroup) {
-      updateGroup(instance, undefined, currentGroup);
+    if (latest.group) {
+      updateGroup(instance, undefined, latest.group);
     }
 
     return () => {
@@ -331,7 +358,7 @@ export function useChartCore(
       instance.setOption(option, setOptionOpts);
       lastAppliedRef.current = { option, opts: setOptionOpts };
     } catch (error) {
-      logError(error, "ECharts setOption failed:", onErrorRef.current);
+      logError(error, "ECharts setOption failed:", latestRef.current.onError);
     }
   }, [getInstance, option, setOptionOpts]);
 

--- a/src/hooks/use-lazy-init.ts
+++ b/src/hooks/use-lazy-init.ts
@@ -22,7 +22,6 @@ export function useLazyInitForElement(
 ): boolean {
   const isLazyMode = options !== false;
   const [isInView, setIsInView] = useState(!isLazyMode);
-  const supportsIntersectionObserver = typeof IntersectionObserver !== "undefined";
 
   // Extract config values for stable dependency comparison
   // 提取配置值用于稳定的依赖比较
@@ -46,7 +45,7 @@ export function useLazyInitForElement(
   useEffect(() => {
     // Skip if lazy mode is disabled or already in view
     // 如果禁用了懒加载模式或已经可见，则跳过
-    if (!isLazyMode || isInView || !supportsIntersectionObserver || !element) return;
+    if (!isLazyMode || isInView || !element) return;
 
     const observer = new IntersectionObserver((entries) => {
       const [entry] = entries;
@@ -64,9 +63,9 @@ export function useLazyInitForElement(
       observer.disconnect();
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps -- isInView excluded: observer self-disconnects on intersection
-  }, [element, isLazyMode, observerOptions, supportsIntersectionObserver]);
+  }, [element, isLazyMode, observerOptions]);
 
   // Derive visibility — when lazy mode is toggled off at runtime,
   // the hook should report visible without waiting for an effect tick.
-  return !isLazyMode || !supportsIntersectionObserver || isInView;
+  return !isLazyMode || isInView;
 }

--- a/src/themes/index.ts
+++ b/src/themes/index.ts
@@ -37,7 +37,7 @@ const customThemeCache = new WeakMap<object, string>();
  * 基于内容的缓存，用于自定义主题去重
  * Prevents ECharts global registry from growing when different
  * object references carry identical theme content.
- * Capped at MAX_CONTENT_CACHE_SIZE — oldest entries evicted on overflow.
+ * Capped at MAX_CONTENT_CACHE_SIZE — least-recently-used entries evicted on overflow.
  */
 const MAX_CONTENT_CACHE_SIZE = 100;
 const contentHashCache = new Map<string, string>();
@@ -133,6 +133,9 @@ export function getOrRegisterCustomTheme(themeConfig: object, precomputedHash?: 
   if (contentHash) {
     const existingName = contentHashCache.get(contentHash);
     if (existingName) {
+      // Refresh recency: delete + re-set moves the entry to the end of insertion order.
+      contentHashCache.delete(contentHash);
+      contentHashCache.set(contentHash, existingName);
       // Cache the reference for fast lookup next time
       customThemeCache.set(themeConfig, existingName);
       return existingName;

--- a/src/utils/connect.ts
+++ b/src/utils/connect.ts
@@ -64,9 +64,7 @@ export function addToGroup(instance: ECharts, groupId: string): void {
   (instance as EChartsWithGroup).group = groupId;
   group.add(instance);
 
-  if (group.size > 1) {
-    echarts.connect(groupId);
-  }
+  syncGroupConnectivity(groupId, group);
 }
 
 /**

--- a/src/utils/instance-cache.ts
+++ b/src/utils/instance-cache.ts
@@ -48,6 +48,13 @@ export function setCachedInstance(element: HTMLElement, instance: ECharts): ECha
   const existing = instanceCache.get(element);
 
   if (existing) {
+    /* v8 ignore next 6 -- NODE_ENV is always "test" in vitest; production branch never taken */
+    if (process.env.NODE_ENV !== "production" && existing.instance !== instance) {
+      console.warn(
+        "react-use-echarts: setCachedInstance called with a different instance for an already-cached element; " +
+          "the new instance is ignored and the cached one is reused.",
+      );
+    }
     // Increment reference count
     existing.refCount += 1;
     return existing.instance;


### PR DESCRIPTION
## Summary

A pass of defensive cleanups across the codebase. No public API changes, no new features — each commit fixes a small drift, mislabel, or missing safeguard surfaced by an architectural review of the develop branch.

- **#1 connect** — `addToGroup` now routes through `syncGroupConnectivity` so add and remove paths share one source of truth.
- **#2 lazy-init** — Drop dead `typeof IntersectionObserver !== "undefined"` guard. Library is CSR-only and targets React 19 + ECharts 6.x.
- **#3 event-utils** — `eventsEqual({}, undefined)` now returns true. Both shapes mean "no listeners"; Effect 3 stays a no-op when transitioning between them.
- **#4 instance-cache** — `setCachedInstance` warns in dev when called with a mismatched instance for an already-cached element. Previously the new instance was silently dropped.
- **#5 themes** — `contentHashCache` eviction is true LRU instead of FIFO. Refresh entry position on hit so eviction targets the least-recently-used hash, not the first inserted.
- **#6 use-chart-core** — Consolidate nine per-field refs into a single `LatestConfig`-typed ref. Adding a new field now forces it to appear in both the initializer and the layout effect; TypeScript catches stale-config drift at compile time.

Each commit is self-contained and individually revertable.

## Test plan

- [x] `vp test run` — 188 passed
- [x] `vp test run --coverage` — 100% statements / branches / functions / lines
- [x] `vp check` — format + lint + typecheck clean
- [x] `vp pack` — publint + attw clean
- [ ] Spot check `vp dev`: lazy-init example, group-connect example, theme switch, StrictMode

🤖 Generated with [Claude Code](https://claude.com/claude-code)