### PR TITLE
docs: sync CLAUDE.md to current source + demo dispatchAction/clear

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,52 +31,57 @@ src/
 ├── index.ts                    # Package entry, re-exports everything
 ├── components/EChart.tsx       # Declarative component wrapping useEcharts
 ├── hooks/
-│   ├── use-echarts.ts          # Orchestrator hook (loading, group effects + delegates to internal hooks)
+│   ├── use-echarts.ts          # Orchestrator hook (zero effects of its own; delegates to internal hooks)
 │   ├── use-lazy-init.ts        # IntersectionObserver hook
 │   └── internal/
-│       ├── use-chart-core.ts   # Core: instance lifecycle + option sync + event rebinding + loading + group (5 effects)
-│       ├── use-resize-observer.ts # ResizeObserver auto-resize (1 effect)
-│       └── event-utils.ts      # Pure functions: bindEvents / unbindEvents
+│       ├── use-chart-core.ts   # Core: instance lifecycle + option sync + event rebinding + loading + group (6 effects); exposes setOption / dispatchAction / clear / getInstance
+│       ├── use-resize-observer.ts # ResizeObserver auto-resize + visibilitychange resync (2 effects: onError ref sync + observer)
+│       ├── use-ref-element.ts  # Track ref.current across DOM-node replacement (re-runs effects when ref swaps)
+│       └── event-utils.ts      # Pure functions: bindEvents / unbindEvents / eventsEqual
 ├── themes/
-│   ├── index.ts                # Lightweight theme utilities (no JSON)
+│   ├── index.ts                # Lightweight theme utilities (no JSON); LRU contentHashCache for custom themes
 │   ├── registry.ts             # Built-in theme registration (imports JSON)
 │   └── presets/                # Built-in theme JSON (light/dark/macarons)
 ├── utils/
-│   ├── instance-cache.ts       # WeakMap instance cache + reference counting
-│   ├── connect.ts              # Chart group linkage logic
-│   └── shallow-equal.ts        # Shallow equality for option deduplication
+│   ├── instance-cache.ts       # WeakMap instance cache + reference counting (warns on mismatched setCachedInstance)
+│   ├── connect.ts              # Chart group linkage logic (syncGroupConnectivity centralizes connect/disconnect)
+│   ├── shallow-equal.ts        # Shallow equality for option / setOptionOpts / loadingOption deduplication
+│   ├── stable-key.ts           # Stable dependency keys via JSON + circular-id WeakMap fallback
+│   └── dev-warnings.ts         # Shared dev-mode warning sets (unknown theme, zero-size container)
 ├── types/index.ts              # All type definitions
 └── __tests__/                  # Mirror structure: components/, hooks/, themes/, utils/
 ```
 
 ## Architecture
 
-### Hook Decomposition — 7 Effects Across 2 Modules
+### Hook Decomposition — 8 Effects Across 2 Modules
 
 All instance-related state lives in `useChartCore`; the orchestrator has zero effects of its own.
 
 **`useChartCore`** (6 effects — ref sync + init applies all state for instance recreation, separate effects handle dynamic changes):
 
-0. **Ref Sync** (`useLayoutEffect`, no deps) — keep 9 refs in sync with latest props every render
+0. **Ref Sync** (`useLayoutEffect`, no deps) — sync the typed `latestRef` (one `LatestConfig` object holding all 10 latest config fields) every render so dependent effects read fresh values without re-running. Adding a new field forces it to appear in both the initializer and the sync block; TS catches stale-config drift at compile time.
 
-1. **Instance Lifecycle** (`useLayoutEffect`) — create/dispose instance, apply initial option, events, loading, group
-2. **Option Updates** (`useEffect`) — call `setOption` when option changes (dedup via `shallowEqual` + `lastAppliedRef`)
-3. **Event Rebinding** (`useEffect`) — unbind old, bind new when `onEvents` changes (via `boundEventsRef`)
-4. **Loading State** (`useEffect`) — toggle `showLoading` / `hideLoading` on dynamic changes
-5. **Group Changes** (`useEffect`) — switch chart group dynamically
+1. **Instance Lifecycle** (`useLayoutEffect`) — create/dispose instance, apply initial option, events, loading, group; warns on zero-size container in dev
+2. **Option Updates** (`useEffect`) — call `setOption` when option changes (reference-equality fast path → `shallowEqual` + `lastAppliedRef`)
+3. **Event Rebinding** (`useEffect`) — unbind old, bind new when `onEvents` changes (via `boundEventsRef` + `eventsEqual`; treats empty/undefined as equivalent)
+4. **Loading State** (`useEffect`) — toggle `showLoading` / `hideLoading` on dynamic changes (dedup via `lastLoadingRef` + `shallowEqual` on `loadingOption`)
+5. **Group Changes** (`useEffect`) — switch chart group dynamically via `syncGroupConnectivity`
 
-**`useResizeObserver`** (1 fully independent effect):
+**`useResizeObserver`** (2 effects):
 
-6. **Resize Observer** (`useEffect`) — create/destroy ResizeObserver with RAF throttle
+6. **onError Ref Sync** (`useLayoutEffect`, no deps) — keep latest `onError` callback reachable from inside the observer effect
+7. **Resize Observer** (`useEffect`) — create/destroy ResizeObserver with RAF throttle; also listens to `document.visibilitychange` to resync when the tab returns to foreground (RAF is throttled in hidden tabs)
 
 ### Key Design Patterns
 
-- Ref passed in by caller — hook does not create refs internally
-- `useChartCore` owns all shared state internally — `lastAppliedRef`, `boundEventsRef`, and 9 synced refs never leak to callers
-- `useChartCore(ref, shouldInit, config)` — 3-parameter API via config object
+- Ref passed in by caller — hook does not create refs internally; `useRefElement` tracks `ref.current` so effects re-run if the DOM node is swapped
+- `useChartCore` owns all shared state internally — `lastAppliedRef`, `boundEventsRef`, `lastLoadingRef`, and the typed `latestRef` never leak to callers
+- `useChartCore(element, shouldInit, config)` — 3-parameter API; takes the resolved element (not a ref) so DOM-node replacement re-triggers the lifecycle effect
 - WeakMap instance cache + reference counting — safe under StrictMode (instance recreated cleanly; refCount prevents premature disposal when multiple consumers share an element)
-- initOpts / theme serialized to stable keys — prevents instance recreation from inline objects
-- Two-level theme cache — custom theme objects auto-deduplicated (with circular reference protection); `contentHash` param avoids double JSON.stringify
+- initOpts / theme serialized to stable keys via `computeStableKey` — JSON.stringify with a WeakMap-backed circular-id fallback prevents instance recreation from inline objects
+- Two-level theme cache — custom theme objects auto-deduplicated (with circular-reference protection); `contentHash` param avoids double JSON.stringify; `contentHashCache` is a true LRU
+- Errors from `setOption` / `dispatchAction` / ResizeObserver init route through the shared `onError` callback (or fall back to `console.error` / re-throw)
 - `shallowEqual` on option updates — avoids unnecessary `setOption` when top-level keys are identical
 - `eventsEqual` on event rebinding — avoids unnecessary unbind/rebind when inline event objects have identical handlers
 - Memoized return value — `useMemo` ensures referential stability

--- a/examples/component/ComponentRef.tsx
+++ b/examples/component/ComponentRef.tsx
@@ -1,33 +1,35 @@
-import React, { useRef } from "react";
+import React, { useRef, useState } from "react";
 import { EChart } from "../../src";
 import type { UseEchartsReturn } from "../../src";
 import { useTheme } from "../components/theme-context";
 import type { EChartsOption } from "echarts";
 
+const baseOption: EChartsOption = {
+  backgroundColor: "transparent",
+  title: { text: "Traffic Sources", left: "center" },
+  tooltip: { trigger: "item" },
+  legend: { bottom: 0 },
+  series: [
+    {
+      type: "pie",
+      radius: ["40%", "65%"],
+      label: { show: true, formatter: "{b}: {d}%" },
+      data: [
+        { value: 1048, name: "Search" },
+        { value: 735, name: "Direct" },
+        { value: 580, name: "Email" },
+        { value: 484, name: "Social" },
+        { value: 300, name: "Referral" },
+      ],
+    },
+  ],
+};
+
 const ComponentRef: React.FC = () => {
   const chartRef = useRef<UseEchartsReturn>(null);
   const { mode } = useTheme();
-
-  const option: EChartsOption = {
-    backgroundColor: "transparent",
-    title: { text: "Traffic Sources", left: "center" },
-    tooltip: { trigger: "item" },
-    legend: { bottom: 0 },
-    series: [
-      {
-        type: "pie",
-        radius: ["40%", "65%"],
-        label: { show: true, formatter: "{b}: {d}%" },
-        data: [
-          { value: 1048, name: "Search" },
-          { value: 735, name: "Direct" },
-          { value: 580, name: "Email" },
-          { value: 484, name: "Social" },
-          { value: 300, name: "Referral" },
-        ],
-      },
-    ],
-  };
+  const [highlighted, setHighlighted] = useState(false);
+  const [cleared, setCleared] = useState(false);
 
   const handleUpdate = () => {
     chartRef.current?.setOption({
@@ -45,6 +47,26 @@ const ComponentRef: React.FC = () => {
     });
   };
 
+  const handleToggleHighlight = () => {
+    chartRef.current?.dispatchAction({
+      type: highlighted ? "downplay" : "highlight",
+      seriesIndex: 0,
+      dataIndex: 0,
+    });
+    setHighlighted((v) => !v);
+  };
+
+  const handleClear = () => {
+    chartRef.current?.clear();
+    setHighlighted(false);
+    setCleared(true);
+  };
+
+  const handleReset = () => {
+    chartRef.current?.setOption(baseOption, { notMerge: true });
+    setCleared(false);
+  };
+
   const handleResize = () => {
     chartRef.current?.resize();
   };
@@ -52,8 +74,17 @@ const ComponentRef: React.FC = () => {
   return (
     <div>
       <div className="controls">
-        <button type="button" className="btn" onClick={handleUpdate}>
+        <button type="button" className="btn" onClick={handleUpdate} disabled={cleared}>
           Randomize Data
+        </button>
+        <button type="button" className="btn" onClick={handleToggleHighlight} disabled={cleared}>
+          {highlighted ? "Downplay" : "Highlight Top"}
+        </button>
+        <button type="button" className="btn" onClick={handleClear} disabled={cleared}>
+          Clear
+        </button>
+        <button type="button" className="btn" onClick={handleReset} disabled={!cleared}>
+          Reset
         </button>
         <button type="button" className="btn" onClick={handleResize}>
           Manual Resize
@@ -61,7 +92,7 @@ const ComponentRef: React.FC = () => {
       </div>
       <EChart
         ref={chartRef}
-        option={option}
+        option={baseOption}
         theme={mode}
         style={{ height: "340px", width: "100%" }}
       />

--- a/examples/global.css
+++ b/examples/global.css
@@ -192,6 +192,17 @@ pre {
   outline: 2px solid var(--c-accent);
   outline-offset: 2px;
 }
+.btn:disabled,
+.btn[disabled] {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+.btn:disabled:hover,
+.btn[disabled]:hover {
+  color: var(--c-text-2);
+  border-color: var(--c-border);
+  background: var(--c-surface);
+}
 
 .chart-container {
   width: 100%;


### PR DESCRIPTION
## Summary

- **CLAUDE.md** brought in line with the current source: missing internal/util files added to the tree, hook-decomposition effect counts corrected (5→6 in `useChartCore`, 1→2 in `useResizeObserver`, 7→8 total), Effect 0 description updated to reflect the consolidated typed `latestRef`, and Key Design Patterns updated (`useChartCore` now takes an element rather than a ref, `computeStableKey` / LRU theme cache / `onError` routing called out).
- **`examples/component/ComponentRef.tsx`** gains a positive demo for the imperative API added in 1.3.1: `Highlight Top` ↔ `Downplay` (dispatchAction), `Clear` (clear), and `Reset` (setOption with `notMerge`). `OnErrorDemo` only used `dispatchAction` to deliberately throw, so users had no example of the happy path. `baseOption` is hoisted to module scope to keep the EChart option ref stable.
- **`examples/global.css`** adds `.btn:disabled` styling so disabled buttons are visually distinct (previously identical to enabled).

No source code or public API changes.

## Test plan

- [x] `vp check` (format + lint + typecheck): pass
- [x] `vp test run`: 199 / 199 pass
- [x] Manual browser test of the new ComponentRef demo:
  - Highlight Top → Search slice pulled out, button label flips to Downplay
  - Downplay → slice returns to normal, button label flips back
  - Clear → chart empties; Randomize / Highlight / Clear disable, Reset enables
  - Reset → chart fully restores, Reset re-disables
- [x] No new console errors observed during the manual test