### PR TITLE
refactor: small quality improvements across hooks, types, and utils

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ Declarative component wrapping `useEcharts`. Accepts all hook options as props p
 | Option          | Type                                  | Default    | Description                                                                                                     |
 | --------------- | ------------------------------------- | ---------- | --------------------------------------------------------------------------------------------------------------- |
 | `option`        | `EChartsOption`                       | (required) | ECharts configuration                                                                                           |
-| `theme`         | `string \| object \| null`            | `null`     | Any registered theme name, or custom theme object                                                               |
+| `theme`         | `string \| object`                    | —          | Any registered theme name, or custom theme object                                                               |
 | `renderer`      | `'canvas' \| 'svg'`                   | `'canvas'` | Renderer type                                                                                                   |
 | `lazyInit`      | `boolean \| IntersectionObserverInit` | `false`    | Lazy initialization via IntersectionObserver                                                                    |
 | `group`         | `string`                              | —          | Chart linkage group ID                                                                                          |

--- a/src/__tests__/hooks/use-echarts.test.ts
+++ b/src/__tests__/hooks/use-echarts.test.ts
@@ -313,17 +313,6 @@ describe("useEcharts", () => {
         customTheme,
       );
     });
-
-    it("should use null when theme is explicitly null", () => {
-      const element = document.createElement("div");
-      const ref = { current: element };
-      const mockInstance = createMockInstance(element);
-      (echarts.init as ReturnType<typeof vi.fn>).mockReturnValue(mockInstance);
-
-      renderHook(() => useEcharts(ref, { option: baseOption, theme: null }));
-
-      expect(echarts.init).toHaveBeenCalledWith(element, null, expect.any(Object));
-    });
   });
 
   describe("loading state", () => {
@@ -1230,7 +1219,7 @@ describe("useEcharts", () => {
         }
       } as unknown as typeof ResizeObserver;
 
-      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 
       const element = document.createElement("div");
       const ref = { current: element };
@@ -1240,9 +1229,9 @@ describe("useEcharts", () => {
       // Should not throw
       renderHook(() => useEcharts(ref, { option: baseOption }));
 
-      expect(warnSpy).toHaveBeenCalledWith("ResizeObserver not available:", expect.any(Error));
+      expect(errorSpy).toHaveBeenCalledWith("ResizeObserver not available:", expect.any(Error));
 
-      warnSpy.mockRestore();
+      errorSpy.mockRestore();
       globalThis.ResizeObserver = originalResizeObserver;
     });
 
@@ -1256,7 +1245,7 @@ describe("useEcharts", () => {
       } as unknown as typeof ResizeObserver;
 
       const onError = vi.fn();
-      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 
       const element = document.createElement("div");
       const ref = { current: element };
@@ -1266,9 +1255,9 @@ describe("useEcharts", () => {
       renderHook(() => useEcharts(ref, { option: baseOption, onError }));
 
       expect(onError).toHaveBeenCalledWith(thrown);
-      expect(warnSpy).not.toHaveBeenCalled();
+      expect(errorSpy).not.toHaveBeenCalled();
 
-      warnSpy.mockRestore();
+      errorSpy.mockRestore();
       globalThis.ResizeObserver = originalResizeObserver;
     });
 
@@ -1619,37 +1608,6 @@ describe("useEcharts", () => {
       const firstThemeName = (echarts.init as ReturnType<typeof vi.fn>).mock.calls[0][1];
       const secondThemeName = (echarts.init as ReturnType<typeof vi.fn>).mock.calls[1][1];
       expect(firstThemeName).not.toBe(secondThemeName);
-    });
-
-    it("should fall back to Math.random when crypto.randomUUID is unavailable", () => {
-      const original = globalThis.crypto;
-      // Stub crypto with no randomUUID to exercise the fallback branch
-      Object.defineProperty(globalThis, "crypto", {
-        value: {},
-        configurable: true,
-        writable: true,
-      });
-
-      try {
-        const theme: Record<string, unknown> = { color: ["#333"] };
-        theme.self = theme;
-
-        const element = document.createElement("div");
-        const ref = { current: element };
-        const mockInstance = createMockInstance(element);
-        (echarts.init as ReturnType<typeof vi.fn>).mockReturnValue(mockInstance);
-
-        renderHook(() => useEcharts(ref, { option: baseOption, theme }));
-
-        expect(echarts.init).toHaveBeenCalled();
-        expect(echarts.registerTheme).toHaveBeenCalled();
-      } finally {
-        Object.defineProperty(globalThis, "crypto", {
-          value: original,
-          configurable: true,
-          writable: true,
-        });
-      }
     });
   });
 

--- a/src/__tests__/hooks/use-lazy-init.test.ts
+++ b/src/__tests__/hooks/use-lazy-init.test.ts
@@ -128,6 +128,36 @@ describe("useLazyInit", () => {
     });
   });
 
+  it("should not recreate observer when threshold is an inline array across rerenders", () => {
+    const element = document.createElement("div");
+    const ref = { current: element };
+
+    let constructorCount = 0;
+    class CountingObserver {
+      constructor(_cb: IntersectionObserverCallback, options?: IntersectionObserverInit) {
+        constructorCount += 1;
+        lastConstructorOptions = options;
+      }
+      observe = mockObserve;
+      disconnect = mockDisconnect;
+      unobserve = mockUnobserve;
+    }
+    globalThis.IntersectionObserver = CountingObserver as unknown as typeof IntersectionObserver;
+
+    const { rerender } = renderHook(
+      // Inline array literal — different reference every render
+      () => useLazyInit(ref, { threshold: [0, 0.5, 1] }),
+    );
+
+    expect(constructorCount).toBe(1);
+    expect(lastConstructorOptions?.threshold).toEqual([0, 0.5, 1]);
+
+    rerender();
+    rerender();
+
+    expect(constructorCount).toBe(1);
+  });
+
   it("should handle null ref", () => {
     const ref = { current: null };
 

--- a/src/hooks/internal/use-resize-observer.ts
+++ b/src/hooks/internal/use-resize-observer.ts
@@ -38,7 +38,7 @@ export function useResizeObserver(
       if (onErrorRef.current) {
         onErrorRef.current(error);
       } else {
-        console.warn("ResizeObserver not available:", error);
+        console.error("ResizeObserver not available:", error);
       }
     }
 

--- a/src/hooks/use-lazy-init.ts
+++ b/src/hooks/use-lazy-init.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState, useMemo, type RefObject } from "react";
+import { useEffect, useState, type RefObject } from "react";
 import { useRefElement } from "./internal/use-ref-element";
 
 /**
@@ -30,40 +30,39 @@ export function useLazyInitForElement(
   const optRootMargin = isObject ? options.rootMargin : undefined;
   const optThreshold = isObject ? options.threshold : undefined;
 
-  // Create stable observer options to avoid unnecessary recreation
-  // when inline objects are passed (e.g. lazyInit={{ threshold: 0.5 }})
-  // 创建稳定的 observer 配置，避免传入内联对象时不必要的 observer 重建
-  const observerOptions = useMemo(
-    (): IntersectionObserverInit => ({
-      root: optRoot ?? null,
-      rootMargin: optRootMargin ?? "50px",
-      threshold: optThreshold ?? 0.1,
-    }),
-    [optRoot, optRootMargin, optThreshold],
-  );
+  // Stable dep for inline number[] threshold (e.g. lazyInit={{ threshold: [0, 0.5, 1] }})
+  // so a new array literal each render doesn't recreate the observer.
+  const thresholdDep = Array.isArray(optThreshold) ? optThreshold.join(",") : optThreshold;
 
   useEffect(() => {
     // Skip if lazy mode is disabled or already in view
     // 如果禁用了懒加载模式或已经可见，则跳过
     if (!isLazyMode || isInView || !element) return;
 
-    const observer = new IntersectionObserver((entries) => {
-      const [entry] = entries;
-      if (entry.isIntersecting) {
-        setIsInView(true);
-        // Once visible, stop observing
-        // 一旦可见，就停止观察
-        observer.disconnect();
-      }
-    }, observerOptions);
+    const observer = new IntersectionObserver(
+      (entries) => {
+        const [entry] = entries;
+        if (entry.isIntersecting) {
+          setIsInView(true);
+          // Once visible, stop observing
+          // 一旦可见，就停止观察
+          observer.disconnect();
+        }
+      },
+      {
+        root: optRoot ?? null,
+        rootMargin: optRootMargin ?? "50px",
+        threshold: optThreshold ?? 0.1,
+      },
+    );
 
     observer.observe(element);
 
     return () => {
       observer.disconnect();
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- isInView excluded: observer self-disconnects on intersection
-  }, [element, isLazyMode, observerOptions]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- isInView excluded (observer self-disconnects); thresholdDep stabilizes inline number[] in place of optThreshold
+  }, [element, isLazyMode, optRoot, optRootMargin, thresholdDep]);
 
   // Derive visibility — when lazy mode is toggled off at runtime,
   // the hook should report visible without waiting for an effect tick.

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -127,16 +127,16 @@ export interface UseEchartsOptions {
    * - any theme name already registered via `registerCustomTheme()` or `echarts.registerTheme()`
    *   — unknown strings silently fall back to the default theme (typos are NOT detected at runtime)
    * - a custom theme config object (auto-deduplicated by content hash)
-   * - `null` / `undefined` for the default theme
+   * - omit the field for the default theme
    *
    * 主题。可为：
    * - 内置主题名：`"light" | "dark" | "macarons"`
    * - 已通过 `registerCustomTheme()` 或 `echarts.registerTheme()` 注册过的任意主题名
    *   —— 未知字符串会静默回退到默认主题（运行时不会检测拼写错误）
    * - 自定义主题配置对象（按内容哈希自动去重）
-   * - `null` / `undefined` 表示默认主题
+   * - 省略字段表示默认主题
    */
-  theme?: BuiltinTheme | (string & {}) | object | null;
+  theme?: BuiltinTheme | (string & {}) | object;
 
   /**
    * Renderer type

--- a/src/utils/stable-key.ts
+++ b/src/utils/stable-key.ts
@@ -9,18 +9,14 @@
 const CIRCULAR_PREFIX = "__circular_";
 
 // Stable IDs for objects that cannot be JSON-serialized (e.g. circular references).
-// Each object gets a unique string via crypto.randomUUID (Math.random fallback),
-// stored in a WeakMap so the same object consistently maps to the same id.
+// Each object gets a unique string via crypto.randomUUID, stored in a WeakMap so
+// the same object consistently maps to the same id.
 const circularObjectIds = new WeakMap<object, string>();
 
 function getCircularObjectId(obj: object): string {
   let id = circularObjectIds.get(obj);
   if (!id) {
-    const rand =
-      typeof crypto !== "undefined" && typeof crypto.randomUUID === "function"
-        ? crypto.randomUUID()
-        : `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
-    id = `${CIRCULAR_PREFIX}${rand}`;
+    id = `${CIRCULAR_PREFIX}${crypto.randomUUID()}`;
     circularObjectIds.set(obj, id);
   }
   return id;


### PR DESCRIPTION
## Summary

Four small, independent quality improvements with no behavior change for typical usage. All preserve **100% line/branch/function coverage**.

- **useLazyInit**: drop the `observerOptions` `useMemo` layer and inline the `IntersectionObserverInit`. Stabilize inline `number[]` thresholds via conditional `join` so `lazyInit={{ threshold: [0, 0.5, 1] }}` no longer recreates the observer on every parent re-render. Adds a regression test.
- **useResizeObserver**: align the fallback log with the rest of the library (`console.warn` → `console.error`); update both call-site spies in the matching test.
- **theme type**: drop the redundant `| null` from `UseEchartsOptions['theme']`. The optional property already covers "no theme" via `undefined`, and runtime `theme == null` still handles both. README table and the explicit-null test case updated accordingly. (Type-only narrowing — TS users writing `theme: null` will see a type error; runtime is unchanged.)
- **stable-key**: remove the `Math.random` fallback for `crypto.randomUUID`. The declared minimum runtime (Node 22+, modern browsers) always provides it. Drops the corresponding fallback test.

## Test plan

- [x] `pnpm typecheck`
- [x] `vp lint .` — 0 warnings / 0 errors
- [x] `vp test run` — 198/198 pass (one new regression test added)
- [x] `vp test run --coverage` — Statements 100%, Branches 100%, Functions 100%, Lines 100%
- [x] `vp check` — format + lint + typecheck all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)