### PR TITLE
refactor: route useLazyInit threshold dep through computeStableKey

### DIFF
--- a/src/__tests__/utils/stable-key.test.ts
+++ b/src/__tests__/utils/stable-key.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from "vite-plus/test";
+import { computeStableKey, isCircularFallbackKey } from "../../utils/stable-key";
+
+describe("computeStableKey", () => {
+  it("returns null for nullish values", () => {
+    expect(computeStableKey(null)).toBeNull();
+    expect(computeStableKey(undefined)).toBeNull();
+  });
+
+  it("returns strings unchanged", () => {
+    expect(computeStableKey("light")).toBe("light");
+    expect(computeStableKey("")).toBe("");
+  });
+
+  it("stringifies numbers", () => {
+    expect(computeStableKey(0)).toBe("0");
+    expect(computeStableKey(0.5)).toBe("0.5");
+  });
+
+  it("returns null for unsupported primitives", () => {
+    expect(computeStableKey(true)).toBeNull();
+    expect(computeStableKey(Symbol("x"))).toBeNull();
+  });
+
+  it("JSON-serializes plain objects and arrays", () => {
+    expect(computeStableKey({ a: 1, b: 2 })).toBe('{"a":1,"b":2}');
+    expect(computeStableKey([0, 0.5, 1])).toBe("[0,0.5,1]");
+  });
+
+  it("falls back to a stable id for circular objects", () => {
+    const a: { self?: unknown } = {};
+    a.self = a;
+
+    const key1 = computeStableKey(a);
+    const key2 = computeStableKey(a);
+
+    expect(key1).not.toBeNull();
+    expect(key1).toBe(key2);
+    expect(isCircularFallbackKey(key1!)).toBe(true);
+  });
+
+  it("returns distinct fallback ids for distinct circular objects", () => {
+    const a: { self?: unknown } = {};
+    a.self = a;
+    const b: { self?: unknown } = {};
+    b.self = b;
+
+    expect(computeStableKey(a)).not.toBe(computeStableKey(b));
+  });
+});
+
+describe("isCircularFallbackKey", () => {
+  it("identifies fallback ids", () => {
+    const a: { self?: unknown } = {};
+    a.self = a;
+    expect(isCircularFallbackKey(computeStableKey(a)!)).toBe(true);
+  });
+
+  it("rejects regular keys", () => {
+    expect(isCircularFallbackKey("light")).toBe(false);
+    expect(isCircularFallbackKey('{"a":1}')).toBe(false);
+  });
+});

--- a/src/hooks/use-lazy-init.ts
+++ b/src/hooks/use-lazy-init.ts
@@ -1,5 +1,6 @@
 import { useEffect, useState, type RefObject } from "react";
 import { useRefElement } from "./internal/use-ref-element";
+import { computeStableKey } from "../utils/stable-key";
 
 /**
  * Hook for lazy initialization using IntersectionObserver
@@ -32,7 +33,7 @@ export function useLazyInitForElement(
 
   // Stable dep for inline number[] threshold (e.g. lazyInit={{ threshold: [0, 0.5, 1] }})
   // so a new array literal each render doesn't recreate the observer.
-  const thresholdDep = Array.isArray(optThreshold) ? optThreshold.join(",") : optThreshold;
+  const thresholdDep = computeStableKey(optThreshold);
 
   useEffect(() => {
     // Skip if lazy mode is disabled or already in view

--- a/src/utils/stable-key.ts
+++ b/src/utils/stable-key.ts
@@ -24,17 +24,19 @@ function getCircularObjectId(obj: object): string {
 
 /**
  * Compute a stable identity key for a value.
- * Strings are returned as-is; objects are JSON-serialized; circular objects
- * fall back to a WeakMap-assigned id; nullish returns null.
+ * Strings pass through; numbers coerce via `String(...)`; objects are
+ * JSON-serialized (circular ones fall back to a WeakMap-assigned id);
+ * nullish and other unsupported types return null.
  */
 export function computeStableKey(value: unknown): string | null {
   if (value == null) return null;
   if (typeof value === "string") return value;
+  if (typeof value === "number") return String(value);
   if (typeof value !== "object") return null;
   try {
     return JSON.stringify(value);
   } catch {
-    return getCircularObjectId(value as object);
+    return getCircularObjectId(value);
   }
 }
 


### PR DESCRIPTION
## Summary

- `useLazyInit`: replace local `Array.isArray + .join(',')` fork with a single `computeStableKey(optThreshold)` call — eliminates the second 'serialize-for-dep' dialect in the codebase.
- `computeStableKey`: widen to accept numbers (the extra type thresholds need) so call sites can be unconditional.
- Add dedicated `stable-key.test.ts` covering all branches directly instead of leaning on indirect coverage from consumers.

## Test plan

- [x] `vp check` — format + lint + typecheck pass, 0 warnings, 0 errors
- [x] `vp test run` — 199/199 passing
- [x] `vp test run --coverage` — Statements / Branches / Functions / Lines all 100%

🤖 Generated with [Claude Code](https://claude.com/claude-code)