### PR TITLE
refactor: unify error routing, dispose protocol, and event lifecycle

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-use-echarts",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "private": false,
   "description": "React hooks & component for Apache ECharts — TypeScript, auto-resize, themes, lazy init",
   "keywords": [

--- a/src/__tests__/hooks/use-echarts.test.ts
+++ b/src/__tests__/hooks/use-echarts.test.ts
@@ -12,6 +12,7 @@ import type { EChartsOption } from "echarts";
 import type { BuiltinTheme } from "../../types";
 import { clearThemeCache } from "../../themes";
 import { registerBuiltinThemes } from "../../themes/registry";
+import { __resetVisibilityCoordinatorForTesting__ } from "../../utils/visibility-coordinator";
 import { createMockInstance, MockResizeObserver, MockIntersectionObserver } from "../helpers";
 
 // Mock ECharts
@@ -40,6 +41,7 @@ describe("useEcharts", () => {
     clearInstanceCache();
     clearGroups();
     clearThemeCache();
+    __resetVisibilityCoordinatorForTesting__();
     resizeObserverInstances = [];
     vi.clearAllMocks();
   });
@@ -313,6 +315,32 @@ describe("useEcharts", () => {
         customTheme,
       );
     });
+
+    it("should treat runtime theme=null as default theme without throwing", () => {
+      // Public TS type forbids null, but JS callers (or escape hatches) can still
+      // pass it. typeof null === "object", so without the nullish guard
+      // resolveThemeName would route into the custom-theme path and crash.
+      const element = document.createElement("div");
+      const ref = { current: element };
+      const mockInstance = createMockInstance(element);
+      (echarts.init as ReturnType<typeof vi.fn>).mockReturnValue(mockInstance);
+
+      const onError = vi.fn();
+      expect(() => {
+        renderHook(() =>
+          useEcharts(ref, {
+            option: baseOption,
+            // Bypass TS type to simulate a JS caller passing null.
+            theme: null as unknown as undefined,
+            onError,
+          }),
+        );
+      }).not.toThrow();
+
+      expect(echarts.init).toHaveBeenCalledWith(element, null, expect.any(Object));
+      expect(echarts.registerTheme).not.toHaveBeenCalled();
+      expect(onError).not.toHaveBeenCalled();
+    });
   });
 
   describe("loading state", () => {
@@ -464,6 +492,57 @@ describe("useEcharts", () => {
         expect(mockInstance.showLoading).toHaveBeenLastCalledWith(optionB);
       });
     });
+
+    it("should route loading toggle errors through onError", async () => {
+      const element = document.createElement("div");
+      const ref = { current: element };
+      const mockInstance = createMockInstance(element);
+      const loadingError = new Error("showLoading failed");
+      // Init effect's initial showLoading=false won't fire; only the dynamic
+      // toggle in Effect 4 reaches the wrapped path.
+      mockInstance.showLoading.mockImplementation(() => {
+        throw loadingError;
+      });
+      (echarts.init as ReturnType<typeof vi.fn>).mockReturnValue(mockInstance);
+
+      const onError = vi.fn();
+      const { rerender } = renderHook<ReturnType<typeof useEcharts>, { showLoading: boolean }>(
+        ({ showLoading }) => useEcharts(ref, { option: baseOption, showLoading, onError }),
+        {
+          initialProps: { showLoading: false },
+        },
+      );
+
+      rerender({ showLoading: true });
+
+      await waitFor(() => {
+        expect(onError).toHaveBeenCalledWith(loadingError);
+      });
+    });
+
+    it("should route initial showLoading errors through onError without breaking cleanup", () => {
+      const element = document.createElement("div");
+      const ref = { current: element };
+      const mockInstance = createMockInstance(element);
+      const loadingError = new Error("initial showLoading failed");
+      mockInstance.showLoading.mockImplementation(() => {
+        throw loadingError;
+      });
+      (echarts.init as ReturnType<typeof vi.fn>).mockReturnValue(mockInstance);
+
+      const onError = vi.fn();
+      const { unmount } = renderHook(() =>
+        useEcharts(ref, { option: baseOption, showLoading: true, onError }),
+      );
+
+      // Init's bare showLoading would have thrown out of the layout effect —
+      // now it routes through onError, leaving the cleanup return intact.
+      expect(onError).toHaveBeenCalledWith(loadingError);
+
+      // Cleanup must still register: unmount disposes without leaking the instance.
+      unmount();
+      expect(mockInstance.dispose).toHaveBeenCalled();
+    });
   });
 
   describe("event handling", () => {
@@ -567,6 +646,31 @@ describe("useEcharts", () => {
       expect(mockInstance.off).toHaveBeenCalledWith("click", clickHandler);
     });
 
+    it("should route initial event bind errors through onError without breaking cleanup", () => {
+      const element = document.createElement("div");
+      const ref = { current: element };
+      const mockInstance = createMockInstance(element);
+      const bindError = new Error("on() failed");
+      mockInstance.on.mockImplementation(() => {
+        throw bindError;
+      });
+      (echarts.init as ReturnType<typeof vi.fn>).mockReturnValue(mockInstance);
+
+      const onError = vi.fn();
+      const { unmount } = renderHook(() =>
+        useEcharts(ref, {
+          option: baseOption,
+          onEvents: { click: () => {} },
+          onError,
+        }),
+      );
+
+      expect(onError).toHaveBeenCalledWith(bindError);
+
+      unmount();
+      expect(mockInstance.dispose).toHaveBeenCalled();
+    });
+
     it("should rebind events when onEvents changes", async () => {
       const element = document.createElement("div");
       const ref = { current: element };
@@ -587,6 +691,304 @@ describe("useEcharts", () => {
         expect(mockInstance.off).toHaveBeenCalledWith("click", clickHandler1);
         expect(mockInstance.on).toHaveBeenCalledWith("click", clickHandler2, undefined);
       });
+    });
+
+    it("should route dynamic rebind bind errors through onError", async () => {
+      const element = document.createElement("div");
+      const ref = { current: element };
+      const mockInstance = createMockInstance(element);
+      (echarts.init as ReturnType<typeof vi.fn>).mockReturnValue(mockInstance);
+
+      const handler1 = vi.fn();
+      const handler2 = vi.fn();
+      const bindError = new Error("rebind on() failed");
+
+      // First mount binds handler1 successfully; rerender with handler2 fails on bind.
+      mockInstance.on.mockImplementationOnce(() => {});
+      mockInstance.on.mockImplementationOnce(() => {
+        throw bindError;
+      });
+
+      const onError = vi.fn();
+      const { rerender } = renderHook(
+        ({ handler }) =>
+          useEcharts(ref, { option: baseOption, onEvents: { click: { handler } }, onError }),
+        { initialProps: { handler: handler1 } },
+      );
+
+      rerender({ handler: handler2 });
+
+      await waitFor(() => {
+        expect(onError).toHaveBeenCalledWith(bindError);
+      });
+      // The old handler must still have been off()'d so it doesn't double-fire.
+      expect(mockInstance.off).toHaveBeenCalledWith("click", handler1);
+    });
+
+    it("should route dynamic rebind unbind errors through onError and still bind new handlers", async () => {
+      const element = document.createElement("div");
+      const ref = { current: element };
+      const mockInstance = createMockInstance(element);
+      (echarts.init as ReturnType<typeof vi.fn>).mockReturnValue(mockInstance);
+
+      const handler1 = vi.fn();
+      const handler2 = vi.fn();
+      const unbindError = new Error("rebind off() failed");
+
+      mockInstance.off.mockImplementation(() => {
+        throw unbindError;
+      });
+
+      const onError = vi.fn();
+      const { rerender } = renderHook(
+        ({ handler }) =>
+          useEcharts(ref, { option: baseOption, onEvents: { click: { handler } }, onError }),
+        { initialProps: { handler: handler1 } },
+      );
+
+      rerender({ handler: handler2 });
+
+      await waitFor(() => {
+        expect(onError).toHaveBeenCalledWith(unbindError);
+        // Bind path still runs after a unbind throw.
+        expect(mockInstance.on).toHaveBeenCalledWith("click", handler2, undefined);
+      });
+    });
+
+    it("should release cached instance even when cleanup unbind throws", () => {
+      const element = document.createElement("div");
+      const ref = { current: element };
+      const mockInstance = createMockInstance(element);
+      (echarts.init as ReturnType<typeof vi.fn>).mockReturnValue(mockInstance);
+
+      const unbindError = new Error("cleanup off() failed");
+      mockInstance.off.mockImplementation(() => {
+        throw unbindError;
+      });
+
+      const onError = vi.fn();
+      const { unmount } = renderHook(() =>
+        useEcharts(ref, {
+          option: baseOption,
+          onEvents: { click: () => {} },
+          onError,
+        }),
+      );
+
+      unmount();
+
+      expect(onError).toHaveBeenCalledWith(unbindError);
+      // refCount/dispose/group cleanup must all still happen.
+      expect(mockInstance.dispose).toHaveBeenCalled();
+    });
+
+    it("should not double-bind when toggling back to a previously-pending event map", async () => {
+      // Rapid toggle: off(A) throws so A stays in pending; user toggles back to
+      // A (same ref). Re-binding A would register handlers twice — the
+      // alreadyPending check must short-circuit and only off the in-between map.
+      const element = document.createElement("div");
+      const ref = { current: element };
+      const mockInstance = createMockInstance(element);
+      (echarts.init as ReturnType<typeof vi.fn>).mockReturnValue(mockInstance);
+
+      const handlerA = vi.fn();
+      const handlerB = vi.fn();
+      const eventsA = { click: handlerA };
+      const eventsB = { click: handlerB };
+
+      // off throws on the first call (when unbinding A) so A stays pending.
+      let offCallCount = 0;
+      mockInstance.off.mockImplementation(() => {
+        offCallCount += 1;
+        if (offCallCount === 1) throw new Error("first off failed");
+      });
+
+      const onError = vi.fn();
+      const { rerender } = renderHook(
+        ({ events }) => useEcharts(ref, { option: baseOption, onEvents: events, onError }),
+        {
+          initialProps: { events: eventsA },
+        },
+      );
+
+      // Toggle to B: off(A) throws, on(B) succeeds. pending = [A, B].
+      rerender({ events: eventsB });
+      await waitFor(() => {
+        expect(mockInstance.on).toHaveBeenCalledWith("click", handlerB, undefined);
+      });
+
+      mockInstance.on.mockClear();
+      mockInstance.off.mockClear();
+
+      // Toggle back to A (same reference): bind must NOT fire again, and B
+      // gets off()'d cleanly.
+      rerender({ events: eventsA });
+      await waitFor(() => {
+        expect(mockInstance.off).toHaveBeenCalledWith("click", handlerB);
+      });
+      expect(mockInstance.on).not.toHaveBeenCalled();
+    });
+
+    it("should clear pending events when onEvents transitions to undefined", async () => {
+      const element = document.createElement("div");
+      const ref = { current: element };
+      const mockInstance = createMockInstance(element);
+      (echarts.init as ReturnType<typeof vi.fn>).mockReturnValue(mockInstance);
+
+      const handler = vi.fn();
+
+      const { rerender, unmount } = renderHook(
+        ({ events }: { events: { click: typeof handler } | undefined }) =>
+          useEcharts(ref, { option: baseOption, onEvents: events }),
+        { initialProps: { events: { click: handler } as { click: typeof handler } | undefined } },
+      );
+
+      // Drop onEvents — must off the previously-bound handler and leave the
+      // pending list empty so cleanup is a no-op.
+      rerender({ events: undefined });
+      await waitFor(() => {
+        expect(mockInstance.off).toHaveBeenCalledWith("click", handler);
+      });
+
+      mockInstance.off.mockClear();
+      unmount();
+      // Cleanup with empty pending list shouldn't make any more off() calls.
+      expect(mockInstance.off).not.toHaveBeenCalled();
+    });
+
+    it("should not double-bind when toggling back to a semantically-equal inline event map", async () => {
+      // Reviewer scenario: rebind unbind throws so the old map stays pending.
+      // User then passes a new inline event map that's structurally equal to
+      // the pending one (same handler/query/context, different reference).
+      // Reference-only includes() would miss this and re-bind, doubling the
+      // handler. Semantic dedup via eventsEqual must short-circuit the bind.
+      const element = document.createElement("div");
+      const ref = { current: element };
+      const mockInstance = createMockInstance(element);
+      (echarts.init as ReturnType<typeof vi.fn>).mockReturnValue(mockInstance);
+
+      const handlerA = vi.fn();
+      const handlerB = vi.fn();
+      const eventsA1 = { click: handlerA };
+
+      // off throws on the first call (when unbinding A1).
+      let offCallCount = 0;
+      mockInstance.off.mockImplementation(() => {
+        offCallCount += 1;
+        if (offCallCount === 1) throw new Error("first off failed");
+      });
+
+      const onError = vi.fn();
+      const { rerender } = renderHook(
+        ({ events }) => useEcharts(ref, { option: baseOption, onEvents: events, onError }),
+        { initialProps: { events: eventsA1 as Record<string, typeof handlerA> } },
+      );
+
+      // Toggle to B: off(A1) throws → A1 stays pending. on(handlerB).
+      rerender({ events: { click: handlerB } });
+      await waitFor(() => {
+        expect(mockInstance.on).toHaveBeenCalledWith("click", handlerB, undefined);
+      });
+
+      mockInstance.on.mockClear();
+
+      // Toggle to a NEW inline event map that's semantically equal to A1
+      // (same handlerA reference, no query/context). Must NOT trigger another
+      // bind — otherwise handlerA would get registered twice.
+      const eventsA2 = { click: handlerA };
+      rerender({ events: eventsA2 });
+
+      await waitFor(() => {
+        // B should still get off()'d cleanly during this rebind.
+        expect(mockInstance.off).toHaveBeenCalledWith("click", handlerB);
+      });
+      expect(mockInstance.on).not.toHaveBeenCalled();
+    });
+
+    it("should unbind old events before binding when the handler reference is reused", async () => {
+      // ECharts off(name, handler) ignores query/context — so a same-handler
+      // rebind from query A → query B must off() BEFORE on(); otherwise the
+      // unbind would remove the freshly-bound handler.
+      const element = document.createElement("div");
+      const ref = { current: element };
+      const mockInstance = createMockInstance(element);
+      (echarts.init as ReturnType<typeof vi.fn>).mockReturnValue(mockInstance);
+
+      const handler = vi.fn();
+      const sequence: string[] = [];
+      mockInstance.on.mockImplementation((..._args: unknown[]) => {
+        sequence.push("on");
+      });
+      mockInstance.off.mockImplementation((..._args: unknown[]) => {
+        sequence.push("off");
+      });
+
+      const { rerender } = renderHook(
+        ({ query }) =>
+          useEcharts(ref, {
+            option: baseOption,
+            onEvents: { click: { handler, query } },
+          }),
+        { initialProps: { query: "series0" } },
+      );
+
+      // Initial mount: just on().
+      expect(sequence).toEqual(["on"]);
+
+      rerender({ query: "series1" });
+
+      await waitFor(() => {
+        // Rebind path must run off() before the new on().
+        expect(sequence).toEqual(["on", "off", "on"]);
+      });
+      expect(mockInstance.off).toHaveBeenLastCalledWith("click", handler);
+      expect(mockInstance.on).toHaveBeenLastCalledWith("click", "series1", handler, undefined);
+    });
+
+    it("should retry off() on previously-failed unbind targets at cleanup", async () => {
+      // Scenario: rebind unbind throws → cleanup must still try to off the
+      // OLD handler so it doesn't leak. Single boundEventsRef would forget the
+      // old map after the rebind; the pending list keeps both alive.
+      const element = document.createElement("div");
+      const ref = { current: element };
+      const mockInstance = createMockInstance(element);
+      (echarts.init as ReturnType<typeof vi.fn>).mockReturnValue(mockInstance);
+
+      const oldHandler = vi.fn();
+      const newHandler = vi.fn();
+
+      // off throws once during the rebind, succeeds on subsequent calls.
+      let offCallCount = 0;
+      const rebindError = new Error("rebind off failed");
+      mockInstance.off.mockImplementation(() => {
+        offCallCount += 1;
+        if (offCallCount === 1) throw rebindError;
+      });
+
+      const onError = vi.fn();
+      const { rerender, unmount } = renderHook(
+        ({ handler }) =>
+          useEcharts(ref, { option: baseOption, onEvents: { click: handler }, onError }),
+        { initialProps: { handler: oldHandler } },
+      );
+
+      // Trigger rebind: off(oldHandler) throws, on(newHandler) succeeds.
+      rerender({ handler: newHandler });
+
+      await waitFor(() => {
+        expect(onError).toHaveBeenCalledWith(rebindError);
+      });
+
+      mockInstance.off.mockClear();
+
+      // Cleanup must off both old AND new handlers — old is still pending
+      // because its unbind failed.
+      unmount();
+
+      const offCalls = mockInstance.off.mock.calls;
+      expect(offCalls).toContainEqual(["click", oldHandler]);
+      expect(offCalls).toContainEqual(["click", newHandler]);
+      expect(mockInstance.dispose).toHaveBeenCalled();
     });
   });
 
@@ -706,6 +1108,67 @@ describe("useEcharts", () => {
       });
 
       globalThis.IntersectionObserver = originalIntersectionObserver;
+    });
+
+    it("should route group switch errors through onError", async () => {
+      // ECharts assigns instance.group via setter under the hood (connect.ts:65/85).
+      // Simulate a throw at that layer by trapping property assignment.
+      const element = document.createElement("div");
+      const ref = { current: element };
+      const mockInstance = createMockInstance(element);
+      const groupError = new Error("group switch failed");
+      const proxied = new Proxy(mockInstance, {
+        set(target, prop, value) {
+          if (prop === "group" && value === "groupB") {
+            throw groupError;
+          }
+          (target as Record<string | symbol, unknown>)[prop as string] = value;
+          return true;
+        },
+      });
+      (echarts.init as ReturnType<typeof vi.fn>).mockReturnValue(proxied);
+
+      const onError = vi.fn();
+      const { rerender } = renderHook(
+        ({ group }) => useEcharts(ref, { option: baseOption, group, onError }),
+        { initialProps: { group: "groupA" } },
+      );
+
+      rerender({ group: "groupB" });
+
+      await waitFor(() => {
+        expect(onError).toHaveBeenCalledWith(groupError);
+      });
+    });
+
+    it("should route initial group assignment errors through onError without breaking cleanup", () => {
+      const element = document.createElement("div");
+      const ref = { current: element };
+      const mockInstance = createMockInstance(element);
+      const groupError = new Error("initial group assign failed");
+      const proxied = new Proxy(mockInstance, {
+        set(target, prop, value) {
+          if (prop === "group" && value === "initialGroup") {
+            throw groupError;
+          }
+          (target as Record<string | symbol, unknown>)[prop as string] = value;
+          return true;
+        },
+      });
+      (echarts.init as ReturnType<typeof vi.fn>).mockReturnValue(proxied);
+
+      const onError = vi.fn();
+      const { unmount } = renderHook(() =>
+        useEcharts(ref, { option: baseOption, group: "initialGroup", onError }),
+      );
+
+      // Init's bare updateGroup would have thrown out of the layout effect —
+      // now it routes through onError, leaving the cleanup return intact.
+      expect(onError).toHaveBeenCalledWith(groupError);
+
+      // Cleanup must still register: unmount disposes without leaking.
+      unmount();
+      expect(mockInstance.dispose).toHaveBeenCalled();
     });
   });
 
@@ -844,6 +1307,52 @@ describe("useEcharts", () => {
         expect(mockInstance.setOption).toHaveBeenCalledTimes(2);
       });
     });
+
+    it("should keep prop dedup consistent after imperative setOption", async () => {
+      // Imperative setOption must update lastAppliedRef so subsequent prop-driven
+      // Effect 2 sees the actual instance state, not a stale "what props sent last".
+      const element = document.createElement("div");
+      const ref = { current: element };
+      const mockInstance = createMockInstance(element);
+      (echarts.init as ReturnType<typeof vi.fn>).mockReturnValue(mockInstance);
+
+      const sharedSeries = baseOption.series;
+      const propOptionA: EChartsOption = { series: sharedSeries };
+      const propOptionAEqual: EChartsOption = { series: sharedSeries };
+      const imperativeOption: EChartsOption = { series: [{ type: "bar", data: [9] }] };
+
+      const { result, rerender } = renderHook(({ option }) => useEcharts(ref, { option }), {
+        initialProps: { option: propOptionA },
+      });
+
+      // 1. Init applied propOptionA.
+      await waitFor(() => {
+        expect(mockInstance.setOption).toHaveBeenCalledTimes(1);
+      });
+
+      // 2. Imperative call switches the chart to a different option.
+      act(() => {
+        result.current.setOption(imperativeOption);
+      });
+      await waitFor(() => {
+        expect(mockInstance.setOption).toHaveBeenCalledTimes(2);
+        expect(mockInstance.setOption).toHaveBeenLastCalledWith(
+          imperativeOption,
+          expect.any(Object),
+        );
+      });
+
+      // 3. Re-render with a fresh prop ref shallow-equal to propOptionA.
+      //    Without the fix: lastAppliedRef stale at A → shallowEqual(A, A_new)
+      //    skips, chart keeps the imperative option (silently wrong).
+      //    With the fix: lastAppliedRef holds the imperative option → diff
+      //    against the new prop → re-applies the prop option, restoring it.
+      rerender({ option: propOptionAEqual });
+      await waitFor(() => {
+        expect(mockInstance.setOption).toHaveBeenCalledTimes(3);
+        expect(mockInstance.setOption).toHaveBeenLastCalledWith(propOptionAEqual, undefined);
+      });
+    });
   });
 
   describe("getInstance", () => {
@@ -892,6 +1401,44 @@ describe("useEcharts", () => {
       act(() => {
         result.current.resize();
       });
+    });
+
+    it("should route resize errors through onError", () => {
+      const element = document.createElement("div");
+      const ref = { current: element };
+      const mockInstance = createMockInstance(element);
+      const resizeError = new Error("resize failed");
+      mockInstance.resize.mockImplementation(() => {
+        throw resizeError;
+      });
+      (echarts.init as ReturnType<typeof vi.fn>).mockReturnValue(mockInstance);
+
+      const onError = vi.fn();
+      const { result } = renderHook(() => useEcharts(ref, { option: baseOption, onError }));
+
+      act(() => {
+        result.current.resize();
+      });
+
+      expect(onError).toHaveBeenCalledWith(resizeError);
+    });
+
+    it("should rethrow resize errors when no onError", () => {
+      const element = document.createElement("div");
+      const ref = { current: element };
+      const mockInstance = createMockInstance(element);
+      mockInstance.resize.mockImplementation(() => {
+        throw new Error("resize boom");
+      });
+      (echarts.init as ReturnType<typeof vi.fn>).mockReturnValue(mockInstance);
+
+      const { result } = renderHook(() => useEcharts(ref, { option: baseOption }));
+
+      expect(() => {
+        act(() => {
+          result.current.resize();
+        });
+      }).toThrow("resize boom");
     });
   });
 
@@ -1003,6 +1550,44 @@ describe("useEcharts", () => {
         result.current.clear();
       });
     });
+
+    it("should route clear errors through onError", () => {
+      const element = document.createElement("div");
+      const ref = { current: element };
+      const mockInstance = createMockInstance(element);
+      const clearError = new Error("clear failed");
+      mockInstance.clear.mockImplementation(() => {
+        throw clearError;
+      });
+      (echarts.init as ReturnType<typeof vi.fn>).mockReturnValue(mockInstance);
+
+      const onError = vi.fn();
+      const { result } = renderHook(() => useEcharts(ref, { option: baseOption, onError }));
+
+      act(() => {
+        result.current.clear();
+      });
+
+      expect(onError).toHaveBeenCalledWith(clearError);
+    });
+
+    it("should rethrow clear errors when no onError", () => {
+      const element = document.createElement("div");
+      const ref = { current: element };
+      const mockInstance = createMockInstance(element);
+      mockInstance.clear.mockImplementation(() => {
+        throw new Error("clear boom");
+      });
+      (echarts.init as ReturnType<typeof vi.fn>).mockReturnValue(mockInstance);
+
+      const { result } = renderHook(() => useEcharts(ref, { option: baseOption }));
+
+      expect(() => {
+        act(() => {
+          result.current.clear();
+        });
+      }).toThrow("clear boom");
+    });
   });
 
   describe("cleanup", () => {
@@ -1047,6 +1632,30 @@ describe("useEcharts", () => {
       renderHook(() => useEcharts(ref, { option: baseOption }));
 
       expect(getCachedInstance(element)).toBe(mockInstance);
+    });
+
+    it("should route release failures through onError without breaking unmount", () => {
+      // releaseCachedInstance now propagates leaveGroup/dispose failures so
+      // callers can route them. The hook cleanup runs inside a layout effect,
+      // where a thrown error would disrupt React commit — it must catch and
+      // route the failure like any other effect-side error.
+      const element = document.createElement("div");
+      const ref = { current: element };
+      const mockInstance = createMockInstance(element);
+      const disposeError = new Error("dispose failed");
+      mockInstance.dispose.mockImplementation(() => {
+        throw disposeError;
+      });
+      (echarts.init as ReturnType<typeof vi.fn>).mockReturnValue(mockInstance);
+
+      const onError = vi.fn();
+      const { unmount } = renderHook(() => useEcharts(ref, { option: baseOption, onError }));
+
+      expect(() => unmount()).not.toThrow();
+      expect(onError).toHaveBeenCalledWith(disposeError);
+      // Cache bookkeeping ran inside instance-cache's own finally, so the
+      // entry is gone even though dispose itself threw.
+      expect(getCachedInstance(element)).toBeUndefined();
     });
   });
 
@@ -1395,6 +2004,35 @@ describe("useEcharts", () => {
 
         expect(globalThis.cancelAnimationFrame).toHaveBeenCalledWith(42);
       });
+
+      it("should route RAF resize errors through onError", () => {
+        const element = document.createElement("div");
+        const ref = { current: element };
+        const mockInstance = createMockInstance(element);
+        const resizeError = new Error("RAF resize failed");
+        mockInstance.resize.mockImplementation(() => {
+          throw resizeError;
+        });
+        (echarts.init as ReturnType<typeof vi.fn>).mockReturnValue(mockInstance);
+
+        globalThis.requestAnimationFrame = vi.fn((cb: FrameRequestCallback) => {
+          cb(0);
+          return 1;
+        });
+
+        const onError = vi.fn();
+        renderHook(() => useEcharts(ref, { option: baseOption, onError }));
+
+        const observer = resizeObserverInstances[0] as unknown as MockResizeObserver;
+        act(() => {
+          observer.callback(
+            [] as unknown as ResizeObserverEntry[],
+            observer as unknown as ResizeObserver,
+          );
+        });
+
+        expect(onError).toHaveBeenCalledWith(resizeError);
+      });
     });
 
     it("should not create resize observer when autoResize is false", () => {
@@ -1465,6 +2103,38 @@ describe("useEcharts", () => {
         mockInstance.resize.mockClear();
         document.dispatchEvent(new Event("visibilitychange"));
         expect(mockInstance.resize).not.toHaveBeenCalled();
+      });
+
+      it("should attach a single document listener regardless of hook count", () => {
+        const addSpy = vi.spyOn(document, "addEventListener");
+        const removeSpy = vi.spyOn(document, "removeEventListener");
+
+        const element1 = document.createElement("div");
+        const element2 = document.createElement("div");
+        const mockInstance1 = createMockInstance(element1);
+        const mockInstance2 = createMockInstance(element2);
+        (echarts.init as ReturnType<typeof vi.fn>)
+          .mockReturnValueOnce(mockInstance1)
+          .mockReturnValueOnce(mockInstance2);
+
+        const hook1 = renderHook(() => useEcharts({ current: element1 }, { option: baseOption }));
+        const hook2 = renderHook(() => useEcharts({ current: element2 }, { option: baseOption }));
+
+        const visibilityAdds = addSpy.mock.calls.filter((c) => c[0] === "visibilitychange");
+        expect(visibilityAdds).toHaveLength(1);
+
+        // First unmount keeps the shared listener attached.
+        hook1.unmount();
+        let visibilityRemoves = removeSpy.mock.calls.filter((c) => c[0] === "visibilitychange");
+        expect(visibilityRemoves).toHaveLength(0);
+
+        // Last unmount detaches the single listener.
+        hook2.unmount();
+        visibilityRemoves = removeSpy.mock.calls.filter((c) => c[0] === "visibilitychange");
+        expect(visibilityRemoves).toHaveLength(1);
+
+        addSpy.mockRestore();
+        removeSpy.mockRestore();
       });
     });
   });

--- a/src/__tests__/utils/instance-cache.test.ts
+++ b/src/__tests__/utils/instance-cache.test.ts
@@ -6,6 +6,7 @@ import {
   getReferenceCount,
   clearInstanceCache,
 } from "../../utils/instance-cache";
+import { addToGroup, clearGroups, getGroupInstances } from "../../utils/connect";
 import type { ECharts } from "echarts";
 import { createMockInstance as createBaseMockInstance } from "../helpers";
 
@@ -135,6 +136,129 @@ describe("instance-cache utilities", () => {
       expect(instance2.dispose).toHaveBeenCalled();
       expect(getCachedInstance(el1)).toBeUndefined();
       expect(getCachedInstance(el2)).toBeUndefined();
+    });
+
+    it("should leave group memberships before disposing", () => {
+      // Without leaveGroup integration, clearInstanceCache disposes instances
+      // but leaves stale references in groupRegistry until pruneDisposed runs.
+      clearGroups();
+
+      const element = document.createElement("div");
+      const instance = createMockInstance();
+      setCachedInstance(element, instance);
+      addToGroup(instance, "g1");
+
+      expect(getGroupInstances("g1")).toContain(instance);
+
+      clearInstanceCache();
+
+      // The instance is gone from the group registry without relying on
+      // pruneDisposed's lazy cleanup.
+      expect(getGroupInstances("g1")).not.toContain(instance);
+    });
+
+    it("should continue clearing remaining instances when one dispose throws", () => {
+      const el1 = document.createElement("div");
+      const el2 = document.createElement("div");
+      const instance1 = createMockInstance();
+      const instance2 = createMockInstance();
+      (instance1.dispose as unknown as ReturnType<typeof vi.fn>).mockImplementation(() => {
+        throw new Error("instance1 dispose failed");
+      });
+
+      setCachedInstance(el1, instance1);
+      setCachedInstance(el2, instance2);
+
+      // Per-instance failure must not strand the rest, and outer finally
+      // resets the cache so subsequent tests start clean.
+      expect(() => clearInstanceCache()).not.toThrow();
+      expect(instance2.dispose).toHaveBeenCalled();
+      expect(getCachedInstance(el1)).toBeUndefined();
+      expect(getCachedInstance(el2)).toBeUndefined();
+    });
+  });
+
+  describe("releaseCachedInstance disposal protocol", () => {
+    it("should leave group before disposing when refCount hits zero", () => {
+      clearGroups();
+
+      const element = document.createElement("div");
+      const instance = createMockInstance();
+      setCachedInstance(element, instance);
+      addToGroup(instance, "released-group");
+
+      expect(getGroupInstances("released-group")).toContain(instance);
+
+      releaseCachedInstance(element);
+
+      // Centralized protocol: release path drops group ownership before
+      // dispose so groupRegistry doesn't carry a disposed reference.
+      expect(getGroupInstances("released-group")).not.toContain(instance);
+      expect(instance.dispose).toHaveBeenCalled();
+    });
+
+    it("should preserve group while refCount remains above zero", () => {
+      clearGroups();
+
+      const element = document.createElement("div");
+      const instance = createMockInstance();
+      // Two consumers — refCount becomes 2.
+      setCachedInstance(element, instance);
+      setCachedInstance(element, instance);
+      addToGroup(instance, "shared-group");
+
+      // First release decrements to 1, no dispose, no leaveGroup.
+      releaseCachedInstance(element);
+      expect(instance.dispose).not.toHaveBeenCalled();
+      expect(getGroupInstances("shared-group")).toContain(instance);
+
+      // Last release disposes and leaves the group.
+      releaseCachedInstance(element);
+      expect(instance.dispose).toHaveBeenCalled();
+      expect(getGroupInstances("shared-group")).not.toContain(instance);
+    });
+
+    it("should still dispose instance when leaveGroup throws", () => {
+      clearGroups();
+
+      const element = document.createElement("div");
+      const baseInstance = createBaseMockInstance();
+      // Proxy throws on the .group=undefined assignment that removeFromGroup
+      // performs, simulating a failure inside leaveGroup.
+      const instance = new Proxy(baseInstance, {
+        set(target, prop, value) {
+          if (prop === "group" && value === undefined) {
+            throw new Error("leaveGroup failed");
+          }
+          (target as Record<string | symbol, unknown>)[prop as string] = value;
+          return true;
+        },
+      }) as unknown as ECharts;
+
+      setCachedInstance(element, instance);
+      addToGroup(instance, "throwing-group");
+
+      // Throw propagates so callers can log/route, but dispose still runs and
+      // the cache entry is gone.
+      expect(() => releaseCachedInstance(element)).toThrow("leaveGroup failed");
+      expect(baseInstance.dispose).toHaveBeenCalled();
+      expect(getCachedInstance(element)).toBeUndefined();
+      expect(getReferenceCount(element)).toBe(0);
+    });
+
+    it("should still clear cache bookkeeping when dispose throws", () => {
+      const element = document.createElement("div");
+      const instance = createMockInstance();
+      (instance.dispose as unknown as ReturnType<typeof vi.fn>).mockImplementation(() => {
+        throw new Error("dispose failed");
+      });
+
+      setCachedInstance(element, instance);
+
+      expect(() => releaseCachedInstance(element)).toThrow("dispose failed");
+      // trackedElements / instanceCache cleanup ran in finally despite throw.
+      expect(getCachedInstance(element)).toBeUndefined();
+      expect(getReferenceCount(element)).toBe(0);
     });
   });
 

--- a/src/__tests__/utils/visibility-coordinator.test.ts
+++ b/src/__tests__/utils/visibility-coordinator.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi, beforeEach } from "vite-plus/test";
+import {
+  subscribeVisibilityResume,
+  __resetVisibilityCoordinatorForTesting__,
+} from "../../utils/visibility-coordinator";
+
+describe("visibility-coordinator", () => {
+  beforeEach(() => {
+    __resetVisibilityCoordinatorForTesting__();
+  });
+
+  it("attaches a single document listener regardless of subscriber count", () => {
+    const addSpy = vi.spyOn(document, "addEventListener");
+
+    const unsub1 = subscribeVisibilityResume(() => {});
+    const unsub2 = subscribeVisibilityResume(() => {});
+    const unsub3 = subscribeVisibilityResume(() => {});
+
+    const visibilityAdds = addSpy.mock.calls.filter((c) => c[0] === "visibilitychange");
+    expect(visibilityAdds).toHaveLength(1);
+
+    unsub1();
+    unsub2();
+    unsub3();
+    addSpy.mockRestore();
+  });
+
+  it("removes the document listener only after the last subscriber leaves", () => {
+    const removeSpy = vi.spyOn(document, "removeEventListener");
+
+    const unsub1 = subscribeVisibilityResume(() => {});
+    const unsub2 = subscribeVisibilityResume(() => {});
+
+    unsub1();
+    let visibilityRemoves = removeSpy.mock.calls.filter((c) => c[0] === "visibilitychange");
+    expect(visibilityRemoves).toHaveLength(0);
+
+    unsub2();
+    visibilityRemoves = removeSpy.mock.calls.filter((c) => c[0] === "visibilitychange");
+    expect(visibilityRemoves).toHaveLength(1);
+
+    removeSpy.mockRestore();
+  });
+
+  it("fires subscribers only when the tab becomes visible", () => {
+    const originalDescriptor = Object.getOwnPropertyDescriptor(Document.prototype, "hidden");
+    let hidden = false;
+    Object.defineProperty(Document.prototype, "hidden", {
+      configurable: true,
+      get: () => hidden,
+    });
+
+    try {
+      const cb = vi.fn();
+      subscribeVisibilityResume(cb);
+
+      hidden = true;
+      document.dispatchEvent(new Event("visibilitychange"));
+      expect(cb).not.toHaveBeenCalled();
+
+      hidden = false;
+      document.dispatchEvent(new Event("visibilitychange"));
+      expect(cb).toHaveBeenCalledTimes(1);
+    } finally {
+      if (originalDescriptor) {
+        Object.defineProperty(Document.prototype, "hidden", originalDescriptor);
+      } else {
+        delete (Document.prototype as unknown as { hidden?: boolean }).hidden;
+      }
+    }
+  });
+
+  it("__resetForTesting__ detaches an active listener", () => {
+    const removeSpy = vi.spyOn(document, "removeEventListener");
+
+    // Make the coordinator attach a listener.
+    subscribeVisibilityResume(() => {});
+
+    // Reset while attached — covers the cleanup branch.
+    __resetVisibilityCoordinatorForTesting__();
+
+    const visibilityRemoves = removeSpy.mock.calls.filter((c) => c[0] === "visibilitychange");
+    expect(visibilityRemoves).toHaveLength(1);
+
+    // Reset again while detached — should be a no-op (no extra removeEventListener).
+    __resetVisibilityCoordinatorForTesting__();
+    const stillOne = removeSpy.mock.calls.filter((c) => c[0] === "visibilitychange");
+    expect(stillOne).toHaveLength(1);
+
+    removeSpy.mockRestore();
+  });
+});

--- a/src/hooks/internal/event-utils.ts
+++ b/src/hooks/internal/event-utils.ts
@@ -65,6 +65,10 @@ export function eventsEqual(a: EChartsEvents | undefined, b: EChartsEvents | und
 /**
  * Unbind events from ECharts instance
  * 从 ECharts 实例解绑事件
+ *
+ * Relies on ECharts `off(name, handler)` matching listeners by handler
+ * reference (independent of `query`). Multiple bindings of the same handler
+ * with different queries are removed together.
  */
 export function unbindEvents(instance: ECharts, events: EChartsEvents | undefined): void {
   if (!events) return;

--- a/src/hooks/internal/use-chart-core.ts
+++ b/src/hooks/internal/use-chart-core.ts
@@ -17,6 +17,7 @@ import {
 import { shallowEqual } from "../../utils/shallow-equal";
 import { computeStableKey, isCircularFallbackKey } from "../../utils/stable-key";
 import { warnedThemeNames, warnedZeroSizeContainers } from "../../utils/dev-warnings";
+import { routeEffectError, routeImperativeError } from "../../utils/error";
 import { bindEvents, unbindEvents, eventsEqual } from "./event-utils";
 
 /**
@@ -28,9 +29,12 @@ import { bindEvents, unbindEvents, eventsEqual } from "./event-utils";
  *   to avoid redundant JSON.stringify inside getOrRegisterCustomTheme.
  */
 function resolveThemeName(
-  theme: string | object | null | undefined,
+  theme: string | object | undefined,
   themeKey: string | null,
 ): string | null {
+  // Public type forbids null, but JS callers can still pass it. typeof null
+  // is "object" so without this guard we'd hit getOrRegisterCustomTheme(null)
+  // and throw inside the WeakMap path — outside Effect 1's init try/catch.
   if (theme == null) return null;
   if (typeof theme === "string") {
     if (
@@ -63,18 +67,6 @@ function resolveThemeName(
   if (typeof theme !== "object") return null;
   const contentHash = themeKey && !isCircularFallbackKey(themeKey) ? themeKey : undefined;
   return getOrRegisterCustomTheme(theme, contentHash);
-}
-
-function logError(
-  error: unknown,
-  message: string,
-  onError: ((e: unknown) => void) | undefined,
-): void {
-  if (onError) {
-    onError(error);
-  } else {
-    console.error(message, error);
-  }
 }
 
 function warnZeroSizeContainer(element: HTMLElement): void {
@@ -158,6 +150,7 @@ interface ChartCoreReturn {
     opt?: boolean | { silent?: boolean; flush?: boolean | undefined },
   ) => void;
   clear: () => void;
+  resize: () => void;
 }
 
 // --- Hook ---
@@ -219,7 +212,12 @@ export function useChartCore(
   });
 
   // --- Internal shared state ---
-  const boundEventsRef = useRef<EChartsEvents | undefined>(undefined);
+  // Event maps for which bindEvents() has been attempted but unbindEvents()
+  // has not yet successfully completed. Typically holds one entry (the
+  // currently bound events), but grows when an unbind attempt fails so
+  // cleanup can retry and avoid leaking handlers. The tail entry is treated
+  // as the current declared intent for dedup against new prop values.
+  const pendingUnbindRef = useRef<EChartsEvents[]>([]);
   const lastAppliedRef = useRef<LastApplied | null>(null);
   const lastLoadingRef = useRef<LastLoading | null>(null);
 
@@ -238,16 +236,14 @@ export function useChartCore(
     (newOption: EChartsOption, opts?: SetOptionOpts) => {
       const instance = getInstance();
       if (!instance) return;
+      const finalOpts = { ...latestRef.current.setOptionOpts, ...opts };
       try {
-        const finalOpts = { ...latestRef.current.setOptionOpts, ...opts };
         instance.setOption(newOption, finalOpts);
+        // Keep lastAppliedRef in sync so prop-driven Effect 2 dedup reflects
+        // what's actually on the instance, not what props last sent.
+        lastAppliedRef.current = { option: newOption, opts: finalOpts };
       } catch (error) {
-        const onError = latestRef.current.onError;
-        if (onError) {
-          onError(error);
-        } else {
-          throw error;
-        }
+        routeImperativeError(error, latestRef.current.onError);
       }
     },
     [getInstance],
@@ -260,19 +256,30 @@ export function useChartCore(
       try {
         instance.dispatchAction(payload, opt);
       } catch (error) {
-        const onError = latestRef.current.onError;
-        if (onError) {
-          onError(error);
-        } else {
-          throw error;
-        }
+        routeImperativeError(error, latestRef.current.onError);
       }
     },
     [getInstance],
   );
 
   const clear = useCallback(() => {
-    getInstance()?.clear();
+    const instance = getInstance();
+    if (!instance) return;
+    try {
+      instance.clear();
+    } catch (error) {
+      routeImperativeError(error, latestRef.current.onError);
+    }
+  }, [getInstance]);
+
+  const resize = useCallback(() => {
+    const instance = getInstance();
+    if (!instance) return;
+    try {
+      instance.resize();
+    } catch (error) {
+      routeImperativeError(error, latestRef.current.onError);
+    }
   }, [getInstance]);
 
   // =====================================================================
@@ -298,8 +305,8 @@ export function useChartCore(
       if (process.env.NODE_ENV !== "production") {
         console.warn(
           "react-use-echarts: multiple hooks share the same DOM element. " +
-            "The shared instance will be reused - theme/renderer/initOpts changes will not recreate it, " +
-            "and option/events/loading/group updates from different hooks may overwrite each other.",
+            "The shared instance is reused; theme/renderer/initOpts changes from later hooks are ignored, " +
+            "and option/events/loading/group writes from later hooks overwrite earlier ones.",
         );
       }
       instance = existing;
@@ -311,7 +318,7 @@ export function useChartCore(
           ...latest.initOpts,
         });
       } catch (error) {
-        logError(error, "ECharts init failed:", latest.onError);
+        routeEffectError(error, "ECharts init failed:", latest.onError);
         return;
       }
       setCachedInstance(element, instance);
@@ -324,22 +331,37 @@ export function useChartCore(
         opts: latest.setOptionOpts,
       };
     } catch (error) {
-      logError(error, "ECharts setOption failed:", latest.onError);
+      routeEffectError(error, "ECharts setOption failed:", latest.onError);
     }
 
-    if (latest.showLoading) {
-      instance.showLoading(latest.loadingOption);
+    try {
+      if (latest.showLoading) {
+        instance.showLoading(latest.loadingOption);
+      }
+      lastLoadingRef.current = {
+        showLoading: latest.showLoading,
+        loadingOption: latest.loadingOption,
+      };
+    } catch (error) {
+      routeEffectError(error, "ECharts loading toggle failed:", latest.onError);
     }
-    lastLoadingRef.current = {
-      showLoading: latest.showLoading,
-      loadingOption: latest.loadingOption,
-    };
 
-    bindEvents(instance, latest.onEvents);
-    boundEventsRef.current = latest.onEvents;
+    // Track for cleanup regardless of partial bind failure so off() can be
+    // attempted on any handlers that did get bound (off is tolerant of
+    // unknown handlers).
+    pendingUnbindRef.current = latest.onEvents ? [latest.onEvents] : [];
+    try {
+      bindEvents(instance, latest.onEvents);
+    } catch (error) {
+      routeEffectError(error, "ECharts event bind failed:", latest.onError);
+    }
 
     if (latest.group) {
-      updateGroup(instance, undefined, latest.group);
+      try {
+        updateGroup(instance, undefined, latest.group);
+      } catch (error) {
+        routeEffectError(error, "ECharts group switch failed:", latest.onError);
+      }
     }
 
     return () => {
@@ -349,15 +371,29 @@ export function useChartCore(
       const inst = getCachedInstance(element);
       if (!inst) return;
 
-      const instGroup = getInstanceGroup(inst);
-      if (instGroup) {
-        updateGroup(inst, instGroup, undefined);
+      // releaseCachedInstance must always run (refCount/dispose/group cleanup);
+      // walk every pending entry so handlers from previous failed unbinds
+      // get one more chance, and let `finally` guarantee the release lands
+      // even if the user's onError callback itself throws.
+      try {
+        for (const entry of pendingUnbindRef.current) {
+          try {
+            unbindEvents(inst, entry);
+          } catch (error) {
+            routeEffectError(error, "ECharts event unbind failed:", latestRef.current.onError);
+          }
+        }
+      } finally {
+        pendingUnbindRef.current = [];
+        // Release can now throw (instance-cache propagates leaveGroup/dispose
+        // failures to the caller). Route it like any other effect-side error
+        // so the React commit isn't disrupted at unmount.
+        try {
+          releaseCachedInstance(element);
+        } catch (error) {
+          routeEffectError(error, "ECharts release failed:", latestRef.current.onError);
+        }
       }
-
-      unbindEvents(inst, boundEventsRef.current);
-      boundEventsRef.current = undefined;
-
-      releaseCachedInstance(element);
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps -- latest config values are read from refs; only structural deps trigger re-init
   }, [shouldInit, element, themeKey, renderer, initOptsKey]);
@@ -384,7 +420,7 @@ export function useChartCore(
       instance.setOption(option, setOptionOpts);
       lastAppliedRef.current = { option, opts: setOptionOpts };
     } catch (error) {
-      logError(error, "ECharts setOption failed:", latestRef.current.onError);
+      routeEffectError(error, "ECharts setOption failed:", latestRef.current.onError);
     }
   }, [getInstance, option, setOptionOpts]);
 
@@ -398,11 +434,44 @@ export function useChartCore(
     const instance = getInstance();
     if (!instance) return;
 
-    if (eventsEqual(boundEventsRef.current, onEvents)) return;
+    const pending = pendingUnbindRef.current;
+    const lastIntent = pending[pending.length - 1];
+    if (eventsEqual(lastIntent, onEvents)) return;
 
-    unbindEvents(instance, boundEventsRef.current);
-    bindEvents(instance, onEvents);
-    boundEventsRef.current = onEvents;
+    // Semantic match — handler/query/context all equal — rather than just
+    // reference identity, so an inline event map that's a fresh object but
+    // describes the same bindings still gets recognized as already-bound.
+    const alreadyPending =
+      onEvents !== undefined && pending.some((entry) => eventsEqual(entry, onEvents));
+
+    // Order matters: ECharts `off(name, handler)` matches by handler reference
+    // and ignores query/context, so a same-handler rebind (query A → query B)
+    // must unbind the old binding BEFORE the new one is registered — otherwise
+    // the off call would remove the freshly-bound handler too.
+    const stillPending: EChartsEvents[] = [];
+    for (const prev of pending) {
+      // Skip entries semantically equivalent to onEvents — their handlers
+      // remain bound and are carried forward via the onEvents entry pushed
+      // at the tail below.
+      if (eventsEqual(prev, onEvents)) continue;
+      try {
+        unbindEvents(instance, prev);
+      } catch (error) {
+        routeEffectError(error, "ECharts event unbind failed:", latestRef.current.onError);
+        stillPending.push(prev);
+      }
+    }
+
+    if (onEvents && !alreadyPending) {
+      try {
+        bindEvents(instance, onEvents);
+      } catch (error) {
+        routeEffectError(error, "ECharts event bind failed:", latestRef.current.onError);
+      }
+    }
+
+    if (onEvents) stillPending.push(onEvents);
+    pendingUnbindRef.current = stillPending;
   }, [getInstance, onEvents]);
 
   // =====================================================================
@@ -421,12 +490,16 @@ export function useChartCore(
     if (last && last.showLoading === showLoading && shallowEqual(last.loadingOption, loadingOption))
       return;
 
-    if (showLoading) {
-      instance.showLoading(loadingOption);
-    } else {
-      instance.hideLoading();
+    try {
+      if (showLoading) {
+        instance.showLoading(loadingOption);
+      } else {
+        instance.hideLoading();
+      }
+      lastLoadingRef.current = { showLoading, loadingOption };
+    } catch (error) {
+      routeEffectError(error, "ECharts loading toggle failed:", latestRef.current.onError);
     }
-    lastLoadingRef.current = { showLoading, loadingOption };
   }, [getInstance, showLoading, loadingOption]);
 
   // =====================================================================
@@ -442,11 +515,15 @@ export function useChartCore(
     const currentGroup = getInstanceGroup(instance);
     if (currentGroup === group) return;
 
-    updateGroup(instance, currentGroup, group);
+    try {
+      updateGroup(instance, currentGroup, group);
+    } catch (error) {
+      routeEffectError(error, "ECharts group switch failed:", latestRef.current.onError);
+    }
   }, [getInstance, group]);
 
   return useMemo(
-    () => ({ getInstance, setOption, dispatchAction, clear }),
-    [getInstance, setOption, dispatchAction, clear],
+    () => ({ getInstance, setOption, dispatchAction, clear, resize }),
+    [getInstance, setOption, dispatchAction, clear, resize],
   );
 }

--- a/src/hooks/internal/use-ref-element.ts
+++ b/src/hooks/internal/use-ref-element.ts
@@ -2,6 +2,11 @@ import { useLayoutEffect, useState, type RefObject } from "react";
 
 /**
  * Tracks the current element behind a stable RefObject across renders.
+ *
+ * Trade-off: re-checks `ref.current` after every commit because the
+ * consumer-facing API is a `RefObject` (not a ref callback). Cost is one
+ * equality check per commit; switching to a ref-callback API would change
+ * the public hook signature.
  */
 export function useRefElement<T extends Element>(ref: RefObject<T | null>): T | null {
   const [element, setElement] = useState<T | null>(() => ref.current);

--- a/src/hooks/internal/use-resize-observer.ts
+++ b/src/hooks/internal/use-resize-observer.ts
@@ -1,5 +1,7 @@
 import { useEffect, useLayoutEffect, useRef } from "react";
 import { getCachedInstance } from "../../utils/instance-cache";
+import { routeEffectError } from "../../utils/error";
+import { subscribeVisibilityResume } from "../../utils/visibility-coordinator";
 
 /**
  * Internal hook: ResizeObserver-based auto-resize with RAF throttle.
@@ -23,6 +25,14 @@ export function useResizeObserver(
     let resizeObserver: ResizeObserver | undefined;
     let rafId: number | undefined;
 
+    const safeResize = (): void => {
+      try {
+        getCachedInstance(element)?.resize();
+      } catch (error) {
+        routeEffectError(error, "ECharts resize failed:", onErrorRef.current);
+      }
+    };
+
     try {
       resizeObserver = new ResizeObserver(() => {
         if (rafId !== undefined) {
@@ -30,33 +40,26 @@ export function useResizeObserver(
         }
         rafId = requestAnimationFrame(() => {
           rafId = undefined;
-          getCachedInstance(element)?.resize();
+          safeResize();
         });
       });
       resizeObserver.observe(element);
     } catch (error) {
-      if (onErrorRef.current) {
-        onErrorRef.current(error);
-      } else {
-        console.error("ResizeObserver not available:", error);
-      }
+      routeEffectError(error, "ResizeObserver not available:", onErrorRef.current);
     }
 
     // Browsers throttle requestAnimationFrame in hidden tabs, so a resize that
     // fires while the tab is in background may never reach the chart. Resync
-    // when the tab becomes visible again.
-    const handleVisibilityChange = (): void => {
-      if (document.hidden) return;
-      getCachedInstance(element)?.resize();
-    };
-    document.addEventListener("visibilitychange", handleVisibilityChange);
+    // when the tab becomes visible again. Subscription goes through a module
+    // coordinator so a single document listener serves all chart instances.
+    const unsubscribeVisibility = subscribeVisibilityResume(safeResize);
 
     return () => {
       if (rafId !== undefined) {
         cancelAnimationFrame(rafId);
       }
       resizeObserver?.disconnect();
-      document.removeEventListener("visibilitychange", handleVisibilityChange);
+      unsubscribeVisibility();
     };
   }, [element, autoResize]);
 }

--- a/src/hooks/use-echarts.ts
+++ b/src/hooks/use-echarts.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, type RefObject } from "react";
+import { useMemo, type RefObject } from "react";
 import type { UseEchartsOptions, UseEchartsReturn } from "../types";
 import { useLazyInitForElement } from "./use-lazy-init";
 import { useChartCore } from "./internal/use-chart-core";
@@ -35,25 +35,26 @@ function useEcharts(
   const element = useRefElement(ref);
   const shouldInit = useLazyInitForElement(element, lazyInit);
 
-  // Core: instance lifecycle + option sync + events + loading + group (1 useLayoutEffect + 4 useEffect)
-  const { getInstance, setOption, dispatchAction, clear } = useChartCore(element, shouldInit, {
-    option,
-    theme,
-    renderer,
-    initOpts,
-    setOptionOpts,
-    showLoading,
-    loadingOption,
-    onEvents,
-    group,
-    onError,
-  });
+  // Core owns all instance IO — including the imperative resize/clear methods
+  // — so error routing through onError lives in one module.
+  const { getInstance, setOption, dispatchAction, clear, resize } = useChartCore(
+    element,
+    shouldInit,
+    {
+      option,
+      theme,
+      renderer,
+      initOpts,
+      setOptionOpts,
+      showLoading,
+      loadingOption,
+      onEvents,
+      group,
+      onError,
+    },
+  );
 
   useResizeObserver(element, autoResize, onError);
-
-  const resize = useCallback(() => {
-    getInstance()?.resize();
-  }, [getInstance]);
 
   return useMemo(
     () => ({ setOption, getInstance, resize, dispatchAction, clear }),

--- a/src/utils/connect.ts
+++ b/src/utils/connect.ts
@@ -88,6 +88,19 @@ export function removeFromGroup(instance: ECharts, groupId: string): void {
 }
 
 /**
+ * Remove an instance from whatever group it currently belongs to (if any).
+ * Centralizes the "look up own group → leave it" pattern so dispose paths
+ * don't have to inline `getInstanceGroup` + `removeFromGroup`.
+ * 让实例脱离当前所在的组（若存在），集中表达 dispose 前的所有权清理。
+ */
+export function leaveGroup(instance: ECharts): void {
+  const groupId = getInstanceGroup(instance);
+  if (groupId) {
+    removeFromGroup(instance, groupId);
+  }
+}
+
+/**
  * Update group for chart instance
  * 更新图表实例的组
  * @param instance ECharts instance

--- a/src/utils/error.ts
+++ b/src/utils/error.ts
@@ -1,0 +1,29 @@
+/**
+ * Error routing utilities for chart instance operations.
+ *
+ * Two contexts with different fallbacks:
+ * - effect: failures inside React effects can't throw (would break commit);
+ *   fall back to console.error.
+ * - imperative: failures from user-invoked methods must surface; fall back
+ *   to rethrow so the caller's try/catch / promise rejection sees them.
+ *
+ * 图表操作的错误路由工具。effect 上下文回退 console.error；命令式上下文回退 rethrow。
+ */
+
+type OnError = ((error: unknown) => void) | undefined;
+
+export function routeEffectError(error: unknown, message: string, onError: OnError): void {
+  if (onError) {
+    onError(error);
+  } else {
+    console.error(message, error);
+  }
+}
+
+export function routeImperativeError(error: unknown, onError: OnError): void {
+  if (onError) {
+    onError(error);
+    return;
+  }
+  throw error;
+}

--- a/src/utils/instance-cache.ts
+++ b/src/utils/instance-cache.ts
@@ -1,4 +1,5 @@
 import type { ECharts } from "echarts";
+import { leaveGroup } from "./connect";
 
 /**
  * Cache entry for ECharts instance
@@ -69,6 +70,23 @@ export function setCachedInstance(element: HTMLElement, instance: ECharts): ECha
 }
 
 /**
+ * Disposal protocol: leave any group membership, then dispose the instance.
+ * Centralized so all dispose entry points (releaseCachedInstance,
+ * clearInstanceCache) drop group ownership before tearing down — otherwise
+ * groupRegistry holds stale references that only get pruned lazily.
+ * `try/finally` ensures `instance.dispose()` runs even if leaveGroup throws,
+ * since an alive-but-orphaned instance is worse than a stale group entry.
+ * 集中表达"离组 + dispose"协议，避免 groupRegistry 残留过期引用。
+ */
+function performDispose(instance: ECharts): void {
+  try {
+    leaveGroup(instance);
+  } finally {
+    instance.dispose();
+  }
+}
+
+/**
  * Decrement reference count and dispose if zero
  * 减少引用计数，如果为零则销毁实例
  * @param element DOM element
@@ -83,10 +101,15 @@ export function releaseCachedInstance(element: HTMLElement): void {
   entry.refCount -= 1;
 
   if (entry.refCount <= 0) {
-    // Dispose instance and remove from cache
-    entry.instance.dispose();
-    instanceCache.delete(element);
-    trackedElements.delete(element);
+    // Cache bookkeeping must run even if dispose throws — otherwise
+    // trackedElements would carry a stale reference that the next clear
+    // tries to performDispose again.
+    try {
+      performDispose(entry.instance);
+    } finally {
+      instanceCache.delete(element);
+      trackedElements.delete(element);
+    }
   }
 }
 
@@ -105,11 +128,20 @@ export function getReferenceCount(element: HTMLElement): number {
  * 清除所有缓存实例，dispose 所有仍存活的实例。
  */
 export function clearInstanceCache(): void {
-  for (const element of trackedElements) {
-    // trackedElements and instanceCache are always in sync,
-    // so the entry is guaranteed to exist here.
-    instanceCache.get(element)!.instance.dispose();
+  // Best-effort per instance: a single failure must not strand the rest, and
+  // the outer `finally` guarantees the cache resets so test isolation holds.
+  try {
+    for (const element of trackedElements) {
+      try {
+        // trackedElements and instanceCache are always in sync,
+        // so the entry is guaranteed to exist here.
+        performDispose(instanceCache.get(element)!.instance);
+      } catch {
+        // Swallow per-instance failure; continue disposing remaining entries.
+      }
+    }
+  } finally {
+    trackedElements.clear();
+    instanceCache = new WeakMap<HTMLElement, CacheEntry>();
   }
-  trackedElements.clear();
-  instanceCache = new WeakMap<HTMLElement, CacheEntry>();
 }

--- a/src/utils/visibility-coordinator.ts
+++ b/src/utils/visibility-coordinator.ts
@@ -1,0 +1,46 @@
+/**
+ * Module-level coordinator for `document.visibilitychange` resume callbacks.
+ * One DOM listener regardless of subscriber count; attaches lazily on first
+ * subscriber, detaches on last unsubscribe.
+ *
+ * 模块级 visibilitychange 协调器：单 listener + 多订阅者，按需挂载/卸载。
+ */
+
+const subscribers = new Set<() => void>();
+let attached = false;
+
+function onVisibilityChange(): void {
+  if (document.hidden) return;
+  for (const cb of subscribers) cb();
+}
+
+/**
+ * Subscribe a callback to fire when the tab returns to the foreground.
+ * Returns an unsubscribe function.
+ */
+export function subscribeVisibilityResume(cb: () => void): () => void {
+  subscribers.add(cb);
+  if (!attached) {
+    document.addEventListener("visibilitychange", onVisibilityChange);
+    attached = true;
+  }
+  return () => {
+    subscribers.delete(cb);
+    if (subscribers.size === 0 && attached) {
+      document.removeEventListener("visibilitychange", onVisibilityChange);
+      attached = false;
+    }
+  };
+}
+
+/**
+ * Reset coordinator state (for testing). Drops all subscribers and the
+ * document listener so each test starts from a clean slate.
+ */
+export function __resetVisibilityCoordinatorForTesting__(): void {
+  if (attached) {
+    document.removeEventListener("visibilitychange", onVisibilityChange);
+    attached = false;
+  }
+  subscribers.clear();
+}


### PR DESCRIPTION
## Summary

Architectural cleanup across three orthogonal lines so each hook operation has a single, predictable error path.

- **Error routing** — extract `routeEffectError` / `routeImperativeError` (`src/utils/error.ts`). Effect paths fall back to `console.error`; imperative APIs rethrow when no `onError`. All instance writes (init, setOption, loading toggle, group switch, event bind/unbind, clear, resize) now go through one of the two helpers — previously several paths bypassed `onError` or threw into React commit.
- **Dispose protocol** — centralize `leaveGroup + dispose` as `performDispose` in `instance-cache`. `releaseCachedInstance` and `clearInstanceCache` share the protocol and use `try/finally` so cache bookkeeping always runs even when `leaveGroup` or `instance.dispose` throws. Hook cleanup wraps the release call in `routeEffectError` so failures don't surface in React commit at unmount.
- **Event lifecycle** — replace single `boundEventsRef` with `pendingUnbindRef` list of "event maps that may still be bound". Failed unbinds stay in the list so cleanup retries on unmount. Effect 3 now unbinds before binding (ECharts `off` matches by handler reference, so bind-first would let same-handler rebinds clobber the new binding) and uses `eventsEqual` for semantic dedup so an inline event map structurally equal to a pending entry doesn't trigger a double bind.

Other fixes:
- `visibility-coordinator`: single `document.visibilitychange` listener shared by all chart instances via subscriber Set
- `resolveThemeName`: keep nullish guard so JS callers passing `null` at runtime route to default theme instead of crashing in the WeakMap path
- imperative `setOption`: sync `lastAppliedRef` so prop-driven dedup reflects actual instance state
- internal docs: trade-off notes on `useRefElement` polling and `unbindEvents`' reliance on ECharts `off()` handler matching

## Test plan

- [x] `vp check` — format / lint / typecheck pass
- [x] `vp test run` — 239 tests pass (+32 new)
- [x] `vp test run --coverage` — 100% across statements / branches / functions / lines
- [x] No public API changes; same `useEcharts` / `EChart` surface
- [ ] CI green on Node 22 and 24

🤖 Generated with [Claude Code](https://claude.com/claude-code)