### PR TITLE
chore: align scripts and toolchain notes with vite-plus 0.1.20

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,14 +15,14 @@ vp install                    # Install dependencies
 vp dev                        # Dev server (localhost:3000, serves examples/)
 vp build                      # Build examples app
 vp pack                       # Library build → dist/
-vp test                       # Vitest (watch mode)
-vp test run                   # Single run
-vp test run --coverage        # Coverage report (v8)
-vp lint .                     # Oxlint
-vp check                      # format + lint + typecheck
+vp test                       # Single run (default since vite-plus 0.1.x)
+vp test watch                 # Watch mode
+vp test --coverage            # Coverage report (v8)
+vp lint                       # Oxlint
+vp check                      # format + lint + typecheck (typecheck via tsgolint)
 ```
 
-**Pre-PR checklist:** `vp check && vp test run`
+**Pre-PR checklist:** `vp check && vp test`
 
 ## Codebase Structure
 

--- a/package.json
+++ b/package.json
@@ -52,14 +52,12 @@
   "scripts": {
     "dev": "vp dev",
     "build": "vp build",
-    "build:pages": "vp build",
     "pack": "vp pack",
     "test": "vp test",
-    "coverage": "vp test run --coverage",
-    "lint": "vp lint .",
+    "coverage": "vp test --coverage",
+    "lint": "vp lint",
     "check": "vp check",
     "prepublishOnly": "vp pack",
-    "typecheck": "tsc -b",
     "prepare": "vp config"
   },
   "devDependencies": {
@@ -93,7 +91,7 @@
     "react-dom": "^19.0.0"
   },
   "engines": {
-    "node": ">=22"
+    "node": ">=22.12.0"
   },
   "packageManager": "pnpm@11.0.3"
 }


### PR DESCRIPTION
## Summary
- Drop dead `build:pages` script and redundant `typecheck` script (already covered by `vp check` via tsgolint)
- Simplify `coverage` / `lint` scripts to the post-0.1.x `vp` command surface
- Tighten `engines.node` to `>=22.12.0` to match vite-plus's own runtime floor
- Refresh CLAUDE.md to reflect new `vp test` defaults (single run; `vp test watch` for watch mode)

## Test plan
- [x] `vp check` — format, lint, typecheck pass
- [x] `vp test --coverage` — 239 tests pass, 100% coverage maintained (Statements 569/569, Branches 274/274, Functions 75/75, Lines 518/518)
- [x] No CI / docs / examples reference removed `build:pages` or `typecheck` scripts

🤖 Generated with [Claude Code](https://claude.com/claude-code)