### PR TITLE
perf: reduce hook render allocations

### DIFF
--- a/src/hooks/internal/event-utils.ts
+++ b/src/hooks/internal/event-utils.ts
@@ -34,14 +34,21 @@ export function bindEvents(instance: ECharts, events: EChartsEvents | undefined)
 
 /**
  * Compare two event config values for equality.
- * Normalizes both to full form, then compares handler/query/context by reference.
- * 比较两个事件配置值是否相等。标准化后按引用比较 handler/query/context。
+ * Reads handler/query/context directly without allocating normalized objects;
+ * shorthand (function) form is treated as `{ handler, query: undefined, context: undefined }`.
+ * 比较两个事件配置值是否相等。直接读取字段，避免分配标准化对象；
+ * 函数简写形式视作 `{ handler, query: undefined, context: undefined }`。
  */
 function eventConfigEqual(a: EChartsEventConfig, b: EChartsEventConfig): boolean {
   if (a === b) return true;
-  const na = normalizeEventConfig(a);
-  const nb = normalizeEventConfig(b);
-  return na.handler === nb.handler && na.query === nb.query && na.context === nb.context;
+  if (typeof a === "function") {
+    if (typeof b === "function") return false;
+    return a === b.handler && b.query === undefined && b.context === undefined;
+  }
+  if (typeof b === "function") {
+    return a.handler === b && a.query === undefined && a.context === undefined;
+  }
+  return a.handler === b.handler && a.query === b.query && a.context === b.context;
 }
 
 /**

--- a/src/hooks/internal/use-chart-core.ts
+++ b/src/hooks/internal/use-chart-core.ts
@@ -183,18 +183,23 @@ export function useChartCore(
   // --- Internal ref: latest values for effects to read without re-triggering.
   // Adding a field to LatestConfig forces it to appear in both the initializer
   // and the sync layout effect below — TS catches stale-config drift at compile time.
-  const latestRef = useRef<LatestConfig>({
-    option,
-    theme,
-    renderer,
-    initOpts,
-    setOptionOpts,
-    showLoading,
-    loadingOption,
-    onEvents,
-    group,
-    onError,
-  });
+  // Lazy-init pattern (`null!` + first-render assign) avoids re-evaluating the
+  // 10-field literal on every render — `useRef`'s argument is only used once.
+  const latestRef = useRef<LatestConfig>(null!);
+  if (latestRef.current === null) {
+    latestRef.current = {
+      option,
+      theme,
+      renderer,
+      initOpts,
+      setOptionOpts,
+      showLoading,
+      loadingOption,
+      onEvents,
+      group,
+      onError,
+    };
+  }
 
   useLayoutEffect(() => {
     latestRef.current = {

--- a/src/hooks/use-echarts.ts
+++ b/src/hooks/use-echarts.ts
@@ -1,4 +1,4 @@
-import { useMemo, type RefObject } from "react";
+import { type RefObject } from "react";
 import type { UseEchartsOptions, UseEchartsReturn } from "../types";
 import { useLazyInitForElement } from "./use-lazy-init";
 import { useChartCore } from "./internal/use-chart-core";
@@ -37,29 +37,22 @@ function useEcharts(
 
   // Core owns all instance IO — including the imperative resize/clear methods
   // — so error routing through onError lives in one module.
-  const { getInstance, setOption, dispatchAction, clear, resize } = useChartCore(
-    element,
-    shouldInit,
-    {
-      option,
-      theme,
-      renderer,
-      initOpts,
-      setOptionOpts,
-      showLoading,
-      loadingOption,
-      onEvents,
-      group,
-      onError,
-    },
-  );
+  const chart = useChartCore(element, shouldInit, {
+    option,
+    theme,
+    renderer,
+    initOpts,
+    setOptionOpts,
+    showLoading,
+    loadingOption,
+    onEvents,
+    group,
+    onError,
+  });
 
   useResizeObserver(element, autoResize, onError);
 
-  return useMemo(
-    () => ({ setOption, getInstance, resize, dispatchAction, clear }),
-    [setOption, getInstance, resize, dispatchAction, clear],
-  );
+  return chart;
 }
 
 export default useEcharts;


### PR DESCRIPTION
## Summary
- Return the memoized chart handle directly from `useChartCore` in `useEcharts`.
- Lazy-initialize `latestRef` so the latest-config object is not rebuilt on every render.
- Compare event configs directly on the hot path without allocating normalized objects.

## Validation
- `vp check`
- `vp test run src/__tests__/hooks/event-utils.test.ts`
- User reported `vp test` full suite: 12 test files, 239 tests passed.