### PR TITLE
refactor: tighten event utils, fix stale docs, restore real coverage

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,7 +64,7 @@ All instance-related state lives in `useChartCore`; the orchestrator has zero ef
 
 1. **Instance Lifecycle** (`useLayoutEffect`) — create/dispose instance, apply initial option, events, loading, group; warns on zero-size container in dev
 2. **Option Updates** (`useEffect`) — call `setOption` when option changes (reference-equality fast path → `shallowEqual` + `lastAppliedRef`)
-3. **Event Rebinding** (`useEffect`) — unbind old, bind new when `onEvents` changes (via `boundEventsRef` + `eventsEqual`; treats empty/undefined as equivalent)
+3. **Event Rebinding** (`useEffect`) — unbind old, bind new when `onEvents` changes (via `pendingUnbindRef` + `eventsEqual`; treats empty/undefined as equivalent; failed unbinds carry forward so cleanup can retry)
 4. **Loading State** (`useEffect`) — toggle `showLoading` / `hideLoading` on dynamic changes (dedup via `lastLoadingRef` + `shallowEqual` on `loadingOption`)
 5. **Group Changes** (`useEffect`) — switch chart group dynamically via `syncGroupConnectivity`
 
@@ -76,7 +76,7 @@ All instance-related state lives in `useChartCore`; the orchestrator has zero ef
 ### Key Design Patterns
 
 - Ref passed in by caller — hook does not create refs internally; `useRefElement` tracks `ref.current` so effects re-run if the DOM node is swapped
-- `useChartCore` owns all shared state internally — `lastAppliedRef`, `boundEventsRef`, `lastLoadingRef`, and the typed `latestRef` never leak to callers
+- `useChartCore` owns all shared state internally — `lastAppliedRef`, `pendingUnbindRef`, `lastLoadingRef`, and the typed `latestRef` never leak to callers
 - `useChartCore(element, shouldInit, config)` — 3-parameter API; takes the resolved element (not a ref) so DOM-node replacement re-triggers the lifecycle effect
 - WeakMap instance cache + reference counting — safe under StrictMode (instance recreated cleanly; refCount prevents premature disposal when multiple consumers share an element)
 - initOpts / theme serialized to stable keys via `computeStableKey` — JSON.stringify with a WeakMap-backed circular-id fallback prevents instance recreation from inline objects

--- a/src/__tests__/components/EChart.test.tsx
+++ b/src/__tests__/components/EChart.test.tsx
@@ -142,6 +142,20 @@ describe("EChart component", () => {
     );
   });
 
+  it("should reuse memoized values on re-render with stable props", () => {
+    (echarts.init as ReturnType<typeof vi.fn>).mockImplementation((el: HTMLElement) =>
+      createMockInstance(el),
+    );
+
+    const option = { series: [{ type: "line" as const, data: [1, 2, 3] }] };
+    const style = { height: 400 };
+    const { rerender, container } = render(<EChart option={option} style={style} className="c" />);
+    const firstChild = container.firstChild;
+    rerender(<EChart option={option} style={style} className="c" />);
+    expect(container.firstChild).toBe(firstChild);
+    expect(echarts.init).toHaveBeenCalledTimes(1);
+  });
+
   it("should dispose instance on unmount and clear cache entry", () => {
     const dispose = vi.fn();
     let cachedElement: HTMLElement | null = null;

--- a/src/__tests__/hooks/event-utils.test.ts
+++ b/src/__tests__/hooks/event-utils.test.ts
@@ -82,6 +82,7 @@ describe("eventsEqual", () => {
     expect(eventsEqual({ click: { handler: handler() } }, { click: h })).toBe(false);
     expect(eventsEqual({ click: { handler: h, query: "series" } }, { click: h })).toBe(false);
     expect(eventsEqual({ click: { handler: h, context } }, { click: h })).toBe(false);
+    expect(eventsEqual({ click: handler() }, { click: handler() })).toBe(false);
   });
 
   it("should return false when query differs", () => {

--- a/src/__tests__/hooks/use-echarts.test.ts
+++ b/src/__tests__/hooks/use-echarts.test.ts
@@ -947,8 +947,8 @@ describe("useEcharts", () => {
 
     it("should retry off() on previously-failed unbind targets at cleanup", async () => {
       // Scenario: rebind unbind throws → cleanup must still try to off the
-      // OLD handler so it doesn't leak. Single boundEventsRef would forget the
-      // old map after the rebind; the pending list keeps both alive.
+      // OLD handler so it doesn't leak. A single "currently-bound" ref would
+      // forget the old map after the rebind; the pending list keeps both alive.
       const element = document.createElement("div");
       const ref = { current: element };
       const mockInstance = createMockInstance(element);

--- a/src/components/EChart.tsx
+++ b/src/components/EChart.tsx
@@ -14,7 +14,6 @@ import type { EChartProps, UseEchartsReturn } from "../types";
  * <EChart option={{ series: [{ type: 'line', data: [1,2,3] }] }} />
  * ```
  */
-/* v8 ignore next -- React Compiler transforms rest-spread into an uncovered branch */
 function EChart({
   ref,
   style,

--- a/src/hooks/internal/event-utils.ts
+++ b/src/hooks/internal/event-utils.ts
@@ -1,20 +1,5 @@
 import type { ECharts } from "echarts";
-import type { EChartsEvents, EChartsEventConfig, EChartsEventHandler } from "../../types";
-
-/**
- * Normalize event config to full object form
- * 将事件配置标准化为完整对象形式
- */
-function normalizeEventConfig(config: EChartsEventConfig): {
-  handler: EChartsEventHandler;
-  query?: string | object;
-  context?: object;
-} {
-  if (typeof config === "function") {
-    return { handler: config };
-  }
-  return config;
-}
+import type { EChartsEvents, EChartsEventConfig } from "../../types";
 
 /**
  * Bind events to ECharts instance
@@ -23,7 +8,11 @@ function normalizeEventConfig(config: EChartsEventConfig): {
 export function bindEvents(instance: ECharts, events: EChartsEvents | undefined): void {
   if (!events) return;
   for (const [eventName, config] of Object.entries(events)) {
-    const { handler, query, context } = normalizeEventConfig(config);
+    if (typeof config === "function") {
+      instance.on(eventName, config, undefined);
+      continue;
+    }
+    const { handler, query, context } = config;
     if (query !== undefined) {
       instance.on(eventName, query, handler, context);
     } else {
@@ -80,7 +69,7 @@ export function eventsEqual(a: EChartsEvents | undefined, b: EChartsEvents | und
 export function unbindEvents(instance: ECharts, events: EChartsEvents | undefined): void {
   if (!events) return;
   for (const [eventName, config] of Object.entries(events)) {
-    const { handler } = normalizeEventConfig(config);
+    const handler = typeof config === "function" ? config : config.handler;
     instance.off(eventName, handler);
   }
 }

--- a/src/hooks/internal/use-chart-core.ts
+++ b/src/hooks/internal/use-chart-core.ts
@@ -433,7 +433,8 @@ export function useChartCore(
   // Effect 3: EVENT REBINDING
   //
   // When onEvents reference changes, unbind old and bind new handlers.
-  // Uses boundEventsRef to track what's currently bound.
+  // Uses pendingUnbindRef to track entries pending cleanup; the tail entry
+  // is treated as the current declared intent for dedup.
   // =====================================================================
   useEffect(() => {
     const instance = getInstance();

--- a/src/hooks/internal/use-chart-core.ts
+++ b/src/hooks/internal/use-chart-core.ts
@@ -185,6 +185,7 @@ export function useChartCore(
   // and the sync layout effect below — TS catches stale-config drift at compile time.
   // Lazy-init pattern (`null!` + first-render assign) avoids re-evaluating the
   // 10-field literal on every render — `useRef`'s argument is only used once.
+  // Constraint: nothing may read `latestRef.current` before the if-block runs.
   const latestRef = useRef<LatestConfig>(null!);
   if (latestRef.current === null) {
     latestRef.current = {


### PR DESCRIPTION
## Summary

A polish pass — no behavior changes. Five small, traceable commits:

- **perf**: inline `normalizeEventConfig` into `bindEvents` / `unbindEvents`, removing per-call allocations on hot paths
- **docs**: rename stale \`boundEventsRef\` references to \`pendingUnbindRef\` (4 sites: source comment, test comment, CLAUDE.md ×2) — left over from the c508862 rename
- **docs**: clarify the \`null!\` lazy-init constraint in \`useChartCore\` so a future reader doesn't introduce a render-time read before the guard
- **test**: drop the over-broad \`/* v8 ignore next */\` on \`EChart.tsx\` (which was hiding the entire file from coverage as 0/0) and add a stable-props rerender assertion that covers the React Compiler memo cache-hit branch
- **test**: self-contain the event config symmetry assertions

## Coverage

- **Before**: \`EChart.tsx\` reported 0/0 (file fully suppressed); rest 100%
- **After**: 591/591 stmts, 293/293 branches, 76/76 funcs, 529/529 lines — true 100%

## Test plan

- [x] \`vp check\` — format + lint + typecheck
- [x] \`vp test\` — 241/241 pass
- [x] \`vp test --coverage\` — 100% across all metrics

🤖 Generated with [Claude Code](https://claude.com/claude-code)