### PR TITLE
fix: resync option after imperative drift

### DIFF
--- a/src/__tests__/helpers.ts
+++ b/src/__tests__/helpers.ts
@@ -13,6 +13,7 @@ export function createMockInstance(element?: HTMLElement) {
     isDisposed: vi.fn(() => false),
     dispatchAction: vi.fn(),
     clear: vi.fn(),
+    appendData: vi.fn(),
   };
 }
 

--- a/src/__tests__/hooks/use-echarts.test.ts
+++ b/src/__tests__/hooks/use-echarts.test.ts
@@ -1588,6 +1588,117 @@ describe("useEcharts", () => {
         });
       }).toThrow("clear boom");
     });
+
+    it("should re-apply prop option after imperative clear when rerender is shallow-equal", async () => {
+      // Without resetting lastAppliedRef inside clear(), the option-sync
+      // effect's dedup fast path sees an unchanged option vs lastApplied and
+      // skips setOption, leaving the chart blank after clear(). Resetting
+      // forces re-application.
+      const element = document.createElement("div");
+      const ref = { current: element };
+      const mockInstance = createMockInstance(element);
+      (echarts.init as ReturnType<typeof vi.fn>).mockReturnValue(mockInstance);
+
+      const sharedSeries = baseOption.series;
+      const propOptionA: EChartsOption = { series: sharedSeries };
+      const propOptionAEqual: EChartsOption = { series: sharedSeries };
+
+      const { result, rerender } = renderHook(({ option }) => useEcharts(ref, { option }), {
+        initialProps: { option: propOptionA },
+      });
+
+      // 1. Init applied propOptionA.
+      await waitFor(() => {
+        expect(mockInstance.setOption).toHaveBeenCalledTimes(1);
+      });
+
+      // 2. Imperative clear() — chart is now blank; lastAppliedRef must be cleared.
+      act(() => {
+        result.current.clear();
+      });
+      expect(mockInstance.clear).toHaveBeenCalledTimes(1);
+
+      // 3. Rerender with a fresh ref shallow-equal to propOptionA. The dedup
+      //    fast path would skip without the fix; with the fix lastAppliedRef
+      //    is null, so setOption is invoked again to restore the chart.
+      rerender({ option: propOptionAEqual });
+      await waitFor(() => {
+        expect(mockInstance.setOption).toHaveBeenCalledTimes(2);
+        expect(mockInstance.setOption).toHaveBeenLastCalledWith(propOptionAEqual, undefined);
+      });
+    });
+  });
+
+  describe("appendData", () => {
+    it("should forward params to instance", () => {
+      const element = document.createElement("div");
+      const ref = { current: element };
+      const mockInstance = createMockInstance(element);
+      (echarts.init as ReturnType<typeof vi.fn>).mockReturnValue(mockInstance);
+
+      const { result } = renderHook(() => useEcharts(ref, { option: baseOption }));
+
+      const params = { seriesIndex: 0, data: [1, 2, 3] };
+      act(() => {
+        result.current.appendData(params);
+      });
+      expect(mockInstance.appendData).toHaveBeenCalledWith(params);
+    });
+
+    it("should not throw when instance is not initialized", () => {
+      const ref = { current: null };
+      const { result } = renderHook(() => useEcharts(ref, { option: baseOption }));
+      act(() => {
+        result.current.appendData({ seriesIndex: 0, data: [] });
+      });
+    });
+
+    it("should reset dedup memory so a shallow-equal-new-ref rerender re-applies setOption", async () => {
+      // Same drift mechanic as clear(): appendData mutates instance state
+      // outside the declarative option, so the next prop rerender that is
+      // shallow-equal but a new reference must NOT be skipped by dedup.
+      const element = document.createElement("div");
+      const ref = { current: element };
+      const mockInstance = createMockInstance(element);
+      (echarts.init as ReturnType<typeof vi.fn>).mockReturnValue(mockInstance);
+
+      const propA = { series: baseOption.series } as EChartsOption;
+
+      const { result, rerender } = renderHook(({ option }) => useEcharts(ref, { option }), {
+        initialProps: { option: propA },
+      });
+      await waitFor(() => {
+        expect(mockInstance.setOption).toHaveBeenCalledTimes(1);
+      });
+
+      act(() => {
+        result.current.appendData({ seriesIndex: 0, data: [42] });
+      });
+      expect(mockInstance.appendData).toHaveBeenCalledTimes(1);
+
+      rerender({ option: { series: baseOption.series } });
+      await waitFor(() => {
+        expect(mockInstance.setOption).toHaveBeenCalledTimes(2);
+      });
+    });
+
+    it("should route errors through onError", () => {
+      const element = document.createElement("div");
+      const ref = { current: element };
+      const mockInstance = createMockInstance(element);
+      const err = new Error("appendData boom");
+      mockInstance.appendData.mockImplementation(() => {
+        throw err;
+      });
+      (echarts.init as ReturnType<typeof vi.fn>).mockReturnValue(mockInstance);
+
+      const onError = vi.fn();
+      const { result } = renderHook(() => useEcharts(ref, { option: baseOption, onError }));
+      act(() => {
+        result.current.appendData({ seriesIndex: 0, data: [] });
+      });
+      expect(onError).toHaveBeenCalledWith(err);
+    });
   });
 
   describe("cleanup", () => {

--- a/src/hooks/internal/use-chart-core.ts
+++ b/src/hooks/internal/use-chart-core.ts
@@ -151,6 +151,7 @@ interface ChartCoreReturn {
   ) => void;
   clear: () => void;
   resize: () => void;
+  appendData: (params: { seriesIndex: number; data: ArrayLike<unknown> }) => void;
 }
 
 // --- Hook ---
@@ -273,6 +274,10 @@ export function useChartCore(
     if (!instance) return;
     try {
       instance.clear();
+      // Drop dedup memory: instance is now blank, so a subsequent prop
+      // rerender with a shallow-equal-but-new option ref must re-apply
+      // it instead of being skipped by Effect 2's shallowEqual fast path.
+      lastAppliedRef.current = null;
     } catch (error) {
       routeImperativeError(error, latestRef.current.onError);
     }
@@ -287,6 +292,23 @@ export function useChartCore(
       routeImperativeError(error, latestRef.current.onError);
     }
   }, [getInstance]);
+
+  const appendData = useCallback(
+    (params: { seriesIndex: number; data: ArrayLike<unknown> }) => {
+      const instance = getInstance();
+      if (!instance) return;
+      try {
+        instance.appendData(params);
+        // appendData drifts the instance from declarative `option`, same as
+        // clear(): drop dedup memory so the next shallow-equal-new-ref
+        // option prop re-applies setOption to resync.
+        lastAppliedRef.current = null;
+      } catch (error) {
+        routeImperativeError(error, latestRef.current.onError);
+      }
+    },
+    [getInstance],
+  );
 
   // =====================================================================
   // Effect 1: INSTANCE LIFECYCLE (init / recreate / cleanup)
@@ -530,7 +552,7 @@ export function useChartCore(
   }, [getInstance, group]);
 
   return useMemo(
-    () => ({ getInstance, setOption, dispatchAction, clear, resize }),
-    [getInstance, setOption, dispatchAction, clear, resize],
+    () => ({ getInstance, setOption, dispatchAction, clear, resize, appendData }),
+    [getInstance, setOption, dispatchAction, clear, resize, appendData],
   );
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -250,6 +250,17 @@ export interface UseEchartsReturn {
    * @see https://echarts.apache.org/en/api.html#echartsInstance.clear
    */
   clear: () => void;
+
+  /**
+   * Append data to a series; useful for streaming. After a successful append,
+   * the chart's data has drifted from the declarative `option` — the next
+   * shallow-equal-but-new-reference `option` rerender re-applies setOption
+   * to resync.
+   * 向 series 追加数据，常用于流式更新。追加后内部数据会与声明式 option 偏离，
+   * 下一次浅相等但新引用的 option rerender 会重新应用 setOption 进行同步。
+   * @see https://echarts.apache.org/en/api.html#echartsInstance.appendData
+   */
+  appendData: (params: { seriesIndex: number; data: ArrayLike<unknown> }) => void;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Reset `lastAppliedRef` after a successful `clear()` so the next shallow-equal option rerender actually fires `setOption`
- Treat `appendData()` as imperative drift — also reset `lastAppliedRef` so the chart can recover from an externally-mutated state
- Regression coverage for both paths

## Why
`useChartCore` dedupes Option Updates via `shallowEqual` against `lastAppliedRef`. Once you call `clear()` or `appendData()`, the chart no longer reflects the declarative option, but the dedup state still says "already applied" — so a rerender with `{ ...option }` (new ref, same content) silently skipped `setOption` and the chart never recovered.

## Test plan
- [x] `vp test src/__tests__/hooks/use-echarts.test.ts`
- [x] `vp check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)