### PR TITLE
chore: bump pnpm/action-setup to v6 (Node 24 runtime)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
           cache: true
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Install dependencies
         run: vp install --frozen-lockfile

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
           cache: true
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Install dependencies
         run: vp install --frozen-lockfile


### PR DESCRIPTION
## Summary
- Bump `pnpm/action-setup` from `v4` (Node 20) to `v6` (Node 24)
- Same change in `ci.yml` and `release.yml`

## Why
GitHub Actions has deprecated Node.js 20 actions:
- Forced to Node 24 starting **2026-06-02**
- Node 20 fully removed **2026-09-16**
- `pnpm/action-setup@v4` was the only remaining Node 20 action in this repo (`actions/checkout@v6`, `voidzero-dev/setup-vp@v1`, `changesets/action@v1`, codecov/composite, pages actions are all on Node 24 / composite)

`v6` requires pnpm ≥ 11, which matches `packageManager: "pnpm@11.0.3"` in `package.json` — no migration concerns.

## Test plan
- [x] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)