### PR TITLE
docs: list EChartsEventHandler and Payload in exported types comment

### DIFF
--- a/.changeset/document-event-handler-payload-exports.md
+++ b/.changeset/document-event-handler-payload-exports.md
@@ -1,0 +1,5 @@
+---
+"react-use-echarts": patch
+---
+
+Document `EChartsEventHandler` and the re-exported `Payload` type in the README's "All exported types" comment. Both have been exported from the package since 1.4.0 (and earlier for `EChartsEventHandler`); only the inline reference list was missing them.

--- a/README-zh_CN.md
+++ b/README-zh_CN.md
@@ -284,8 +284,8 @@ import { isBuiltinTheme, registerCustomTheme } from "react-use-echarts"; // 主�
 import { registerBuiltinThemes } from "react-use-echarts/themes/registry"; // 内置主题 JSON（~20KB）
 
 // 所有导出类型：UseEchartsOptions, UseEchartsReturn, EChartProps,
-// EChartsEvents, EChartsEventConfig, EChartsInitOpts, BuiltinTheme, LoadingOption,
-// ChartFinder, ChartScaleValue
+// EChartsEvents, EChartsEventConfig, EChartsEventHandler, EChartsInitOpts,
+// BuiltinTheme, LoadingOption, ChartFinder, ChartScaleValue, Payload
 // EChartsOption、SetOptionOpts、ResizeOpts 来自 "echarts" 包。
 ```
 

--- a/README.md
+++ b/README.md
@@ -285,8 +285,8 @@ import { isBuiltinTheme, registerCustomTheme } from "react-use-echarts"; // them
 import { registerBuiltinThemes } from "react-use-echarts/themes/registry"; // ~20KB theme JSON
 
 // All exported types: UseEchartsOptions, UseEchartsReturn, EChartProps,
-// EChartsEvents, EChartsEventConfig, EChartsInitOpts, BuiltinTheme, LoadingOption,
-// ChartFinder, ChartScaleValue
+// EChartsEvents, EChartsEventConfig, EChartsEventHandler, EChartsInitOpts,
+// BuiltinTheme, LoadingOption, ChartFinder, ChartScaleValue, Payload
 // EChartsOption, SetOptionOpts, ResizeOpts come from the "echarts" package directly.
 ```
 


### PR DESCRIPTION
## Summary
Add `EChartsEventHandler` and `Payload` to the README's "All exported types" inline reference (English + 中文).

Both have been exported from the package — `EChartsEventHandler` for typing `onEvents` handlers, `Payload` (re-exported from echarts) for typing `dispatchAction` arguments — but they were missing from the documentation list, forcing users to discover them by reading `src/index.ts`.

## Test plan
- [x] CI green
- [x] Includes `.changeset/document-event-handler-payload-exports.md` (patch bump → **1.4.1**) so the next push to main opens the Version Packages PR

## Note
This PR also serves as the end-to-end smoke test for the new single-pipeline release flow (changesets → `release.yml` → npm OIDC trusted publishing on `release.yml`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)