### PR TITLE
feat: add tree-shakable core entry

### DIFF
--- a/.changeset/tree-shakable-core-entry.md
+++ b/.changeset/tree-shakable-core-entry.md
@@ -1,0 +1,19 @@
+---
+"react-use-echarts": minor
+---
+
+Add tree-shakable `react-use-echarts/core` subpath entry.
+
+The default entry now imports `"echarts"` as a side-effect to preserve its zero-config behavior (every chart and component pre-registered). The new `/core` entry skips that import, letting consumers register only the modules they need via `echarts.use([...])` for substantially smaller production bundles. Both entries share the same public API — only the import path differs.
+
+```tsx
+import * as echarts from "echarts/core";
+import { LineChart } from "echarts/charts";
+import { GridComponent } from "echarts/components";
+import { CanvasRenderer } from "echarts/renderers";
+echarts.use([LineChart, GridComponent, CanvasRenderer]);
+
+import { useEcharts, EChart } from "react-use-echarts/core";
+```
+
+This is fully backwards-compatible: the default entry's behavior is unchanged.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,7 @@ All `useEcharts` options as props + `style` (default `{ width: '100%', height: '
 - `isBuiltinTheme(name)`, `isKnownTheme(name)`, `registerCustomTheme(name, config)` — from `'react-use-echarts'`
 - `registerBuiltinThemes()` — from `'react-use-echarts/themes/registry'` (separate entry, ~20KB theme JSON)
 - `useLazyInit(ref, options)` — standalone lazy init hook
+- `'react-use-echarts/core'` — tree-shakable subpath entry. Same public API as the default, but skips `import "echarts"` so consumers register only the chart types they use via `echarts.use([...])`. Pair with `import * as echarts from "echarts/core"`.
 
 ## Gotchas
 

--- a/README-zh_CN.md
+++ b/README-zh_CN.md
@@ -161,6 +161,25 @@ useEcharts(chartRef, {
 });
 ```
 
+### 使用 `/core` 子入口做 Tree-shaking
+
+默认入口 `react-use-echarts` 会副作用 import `"echarts"`，自动注册全部图表与组件，新手开箱即用，但会把整个 ECharts（约 290KB gzip）打入产物。生产环境只用到少量图表类型时，推荐使用 `react-use-echarts/core` 子入口——它跳过这一副作用，由你自己按需注册：
+
+```tsx
+import * as echarts from "echarts/core";
+import { LineChart } from "echarts/charts";
+import { GridComponent, TooltipComponent } from "echarts/components";
+import { CanvasRenderer } from "echarts/renderers";
+echarts.use([LineChart, GridComponent, TooltipComponent, CanvasRenderer]);
+
+import { useEcharts, EChart } from "react-use-echarts/core";
+// 公开 API 与默认入口完全一致，只是 import 路径不同。
+```
+
+两个入口共享同一套 API，选择 `/core` 时打包器会把未使用的 ECharts 模块 tree-shake 掉。内置主题仍通过 `react-use-echarts/themes/registry` 注册。
+
+> ECharts 维护单一全局 registry，因此 `echarts.use([...])` 调用会跨模块叠加——每种图表类型在应用中任意位置 `use()` 一次即可。
+
 ### 在 Next.js（App Router）中使用
 
 包入口与 `themes/registry` 已标注 `"use client"`，因此即便在 React
@@ -282,6 +301,7 @@ export default function Page() {
 import { useLazyInit } from "react-use-echarts"; // 独立的懒加载 Hook
 import { isBuiltinTheme, registerCustomTheme } from "react-use-echarts"; // 主题工具（不含 JSON）
 import { registerBuiltinThemes } from "react-use-echarts/themes/registry"; // 内置主题 JSON（~20KB）
+import { useEcharts, EChart } from "react-use-echarts/core"; // tree-shakable 子入口（见使用示例）
 
 // 所有导出类型：UseEchartsOptions, UseEchartsReturn, EChartProps,
 // EChartsEvents, EChartsEventConfig, EChartsEventHandler, EChartsInitOpts,

--- a/README.md
+++ b/README.md
@@ -161,6 +161,25 @@ useEcharts(chartRef, {
 });
 ```
 
+### Tree-shaking with the `/core` Entry
+
+The default `react-use-echarts` entry imports `"echarts"` for its side-effect registration of every chart and component, so users get a zero-config experience at the cost of bundling all of ECharts (~290KB gzip). For production apps that only render a handful of chart types, the `react-use-echarts/core` subpath skips that side-effect and lets you register exactly what you need:
+
+```tsx
+import * as echarts from "echarts/core";
+import { LineChart } from "echarts/charts";
+import { GridComponent, TooltipComponent } from "echarts/components";
+import { CanvasRenderer } from "echarts/renderers";
+echarts.use([LineChart, GridComponent, TooltipComponent, CanvasRenderer]);
+
+import { useEcharts, EChart } from "react-use-echarts/core";
+// Same API as the default entry — only the import path differs.
+```
+
+The two entries share the same public API; pick `/core` when you want bundlers to tree-shake unused ECharts modules out of your final build. Built-in themes still work via `react-use-echarts/themes/registry`.
+
+> ECharts maintains a single global registry, so `echarts.use([...])` calls compose across modules — call it once per chart type, anywhere in your app.
+
 ### Use with Next.js (App Router)
 
 The package entry and `themes/registry` are marked with `"use client"`, so
@@ -283,6 +302,7 @@ Declarative component wrapping `useEcharts`. Accepts all hook options as props p
 import { useLazyInit } from "react-use-echarts"; // standalone lazy init hook
 import { isBuiltinTheme, registerCustomTheme } from "react-use-echarts"; // theme utils (no JSON)
 import { registerBuiltinThemes } from "react-use-echarts/themes/registry"; // ~20KB theme JSON
+import { useEcharts, EChart } from "react-use-echarts/core"; // tree-shakable entry (see Recipes)
 
 // All exported types: UseEchartsOptions, UseEchartsReturn, EChartProps,
 // EChartsEvents, EChartsEventConfig, EChartsEventHandler, EChartsInitOpts,

--- a/examples/components/DemoTabs.tsx
+++ b/examples/components/DemoTabs.tsx
@@ -14,7 +14,9 @@ interface DemoTabsProps {
 type Tab = "preview" | "code";
 
 const fixImports = (src: string): string =>
-  src.replace(/from ["']\.\.\/\.\.\/src["']/g, 'from "react-use-echarts"');
+  src
+    .replace(/from ["']\.\.\/\.\.\/src\/core["']/g, 'from "react-use-echarts/core"')
+    .replace(/from ["']\.\.\/\.\.\/src["']/g, 'from "react-use-echarts"');
 
 const DemoTabs: React.FC<DemoTabsProps> = ({ sourcePath, loadSource, children }) => {
   const [tab, setTab] = useState<Tab>("preview");

--- a/examples/core-entry/CoreEntryChart.tsx
+++ b/examples/core-entry/CoreEntryChart.tsx
@@ -1,0 +1,55 @@
+/**
+ * Demonstrates the `react-use-echarts/core` subpath entry.
+ *
+ * The default `react-use-echarts` entry pulls in `"echarts"` for its
+ * side-effect registration of every chart and component. The `/core` entry
+ * skips that import, letting the consumer register only what's actually
+ * rendered — bundlers then tree-shake away the rest of ECharts.
+ *
+ * Note: inside this example app every demo lives in the same bundle, so the
+ * default entry's full echarts is already loaded by other routes. The
+ * tree-shaking benefit is realized in a standalone consumer project that
+ * imports ONLY from `react-use-echarts/core`.
+ */
+import React, { useRef } from "react";
+import * as echarts from "echarts/core";
+import { LineChart } from "echarts/charts";
+import { GridComponent, TooltipComponent, TitleComponent } from "echarts/components";
+import { CanvasRenderer } from "echarts/renderers";
+import { useEcharts } from "../../src/core";
+import { useTheme } from "../components/theme-context";
+import type { EChartsOption } from "echarts";
+
+// Register only the pieces this chart needs. ECharts maintains a single
+// global registry, so `use()` calls compose across modules in the consumer
+// application.
+echarts.use([LineChart, GridComponent, TooltipComponent, TitleComponent, CanvasRenderer]);
+
+const CoreEntryChart: React.FC = () => {
+  const chartRef = useRef<HTMLDivElement>(null);
+  const { mode } = useTheme();
+
+  const options: EChartsOption = {
+    backgroundColor: "transparent",
+    title: { text: "Tree-shakable Line Chart" },
+    tooltip: { trigger: "axis" },
+    xAxis: {
+      type: "category",
+      data: ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"],
+    },
+    yAxis: { type: "value" },
+    series: [
+      {
+        data: [120, 200, 150, 80, 70, 110, 130],
+        type: "line",
+        smooth: true,
+      },
+    ],
+  };
+
+  useEcharts(chartRef, { option: options, theme: mode });
+
+  return <div ref={chartRef} className="chart-container" />;
+};
+
+export default CoreEntryChart;

--- a/examples/data/features.ts
+++ b/examples/data/features.ts
@@ -97,6 +97,15 @@ export const featureItems: readonly FeatureItem[] = [
     source: () => import("../error/OnErrorDemo.tsx?raw"),
     sourcePath: "examples/error/OnErrorDemo.tsx",
   },
+  {
+    id: "core-entry",
+    title: "Tree-shakable Core Entry",
+    description: "Use react-use-echarts/core with echarts.use([...]) for minimal bundles.",
+    icon: "layers",
+    component: React.lazy(() => import("../core-entry/CoreEntryChart")),
+    source: () => import("../core-entry/CoreEntryChart.tsx?raw"),
+    sourcePath: "examples/core-entry/CoreEntryChart.tsx",
+  },
 ];
 
 export const findFeatureItem = (id: string | undefined): FeatureItem | undefined =>

--- a/package.json
+++ b/package.json
@@ -40,6 +40,10 @@
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
     },
+    "./core": {
+      "types": "./dist/core.d.ts",
+      "default": "./dist/core.js"
+    },
     "./themes/registry": {
       "types": "./dist/themes/registry.d.ts",
       "default": "./dist/themes/registry.js"
@@ -103,6 +107,13 @@
       "name": "dist/index.js (gzip)",
       "path": "dist/index.js",
       "limit": "12 KB",
+      "gzip": true,
+      "brotli": false
+    },
+    {
+      "name": "dist/core.js (gzip)",
+      "path": "dist/core.js",
+      "limit": "11 KB",
       "gzip": true,
       "brotli": false
     },

--- a/src/__tests__/browser/lazy-init.test.tsx
+++ b/src/__tests__/browser/lazy-init.test.tsx
@@ -10,8 +10,16 @@
 import { describe, it, expect } from "vitest";
 import { render, act } from "@testing-library/react";
 import { useRef } from "react";
+import * as echarts from "echarts/core";
+import { LineChart } from "echarts/charts";
+import { GridComponent } from "echarts/components";
+import { CanvasRenderer } from "echarts/renderers";
 import useEcharts from "../../hooks/use-echarts";
 import type { UseEchartsReturn } from "../../types";
+
+// Browser tests import the hook directly, bypassing the default entry's
+// `import "echarts"` side-effect. Register only what this test renders.
+echarts.use([LineChart, GridComponent, CanvasRenderer]);
 
 function LazyChart({ chartRef }: { chartRef: { current: UseEchartsReturn | null } }) {
   const containerRef = useRef<HTMLDivElement>(null);

--- a/src/__tests__/browser/resize.test.tsx
+++ b/src/__tests__/browser/resize.test.tsx
@@ -10,8 +10,16 @@
 import { describe, it, expect } from "vitest";
 import { render } from "@testing-library/react";
 import { useRef } from "react";
+import * as echarts from "echarts/core";
+import { LineChart } from "echarts/charts";
+import { GridComponent } from "echarts/components";
+import { CanvasRenderer } from "echarts/renderers";
 import useEcharts from "../../hooks/use-echarts";
 import type { UseEchartsReturn } from "../../types";
+
+// Browser tests import the hook directly, bypassing the default entry's
+// `import "echarts"` side-effect. Register only what this test renders.
+echarts.use([LineChart, GridComponent, CanvasRenderer]);
 
 function ResizableChart({
   chartRef,

--- a/src/__tests__/components/EChart.test.tsx
+++ b/src/__tests__/components/EChart.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vite-plus/test";
 import { render } from "@testing-library/react";
 import { createRef } from "react";
-import * as echarts from "echarts";
+import * as echarts from "echarts/core";
 import EChart from "../../components/EChart";
 import { clearInstanceCache, getCachedInstance } from "../../utils/instance-cache";
 import { clearGroups } from "../../utils/connect";
@@ -9,7 +9,7 @@ import type { UseEchartsReturn } from "../../types";
 import { createMockInstance, MockResizeObserver, MockIntersectionObserver } from "../helpers";
 
 // Mock ECharts
-vi.mock("echarts", () => ({
+vi.mock("echarts/core", () => ({
   init: vi.fn(),
   connect: vi.fn(),
   disconnect: vi.fn(),

--- a/src/__tests__/core.test.ts
+++ b/src/__tests__/core.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect, vi } from "vite-plus/test";
+
+// Both entries re-export the same underlying modules; the only intentional
+// difference is that `../index` has a top-level `import "echarts"` side-effect
+// (full echarts registration) and `../core` does not. Mock both module
+// specifiers so neither entry pulls in the real ECharts during this smoke
+// test — we only care about the surface contract, not runtime behavior.
+vi.mock("echarts", () => ({}));
+vi.mock("echarts/core", () => ({
+  init: vi.fn(),
+  connect: vi.fn(),
+  disconnect: vi.fn(),
+  registerTheme: vi.fn(),
+}));
+
+import * as core from "../core";
+import * as main from "../index";
+
+describe("react-use-echarts/core entry", () => {
+  it("exposes the same public symbols as the default entry", () => {
+    const coreKeys = new Set(Object.keys(core));
+    const mainKeys = new Set(Object.keys(main));
+
+    // Catch drift in either direction: any symbol added/removed in one entry
+    // must be mirrored in the other, or the public surfaces diverge.
+    expect(coreKeys).toEqual(mainKeys);
+  });
+
+  it("re-exports the documented runtime symbols", () => {
+    // Sanity check the names users are documented to import. Keeps the smoke
+    // test honest if someone accidentally swaps an `export {}` for a comment.
+    expect(typeof core.useEcharts).toBe("function");
+    expect(typeof core.EChart).toBe("function");
+    expect(typeof core.useLazyInit).toBe("function");
+    expect(typeof core.isBuiltinTheme).toBe("function");
+    expect(typeof core.isKnownTheme).toBe("function");
+    expect(typeof core.registerCustomTheme).toBe("function");
+  });
+});

--- a/src/__tests__/hooks/event-utils.test.ts
+++ b/src/__tests__/hooks/event-utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from "vite-plus/test";
-import type { ECharts } from "echarts";
+import type { ECharts } from "echarts/core";
 import { bindEvents, unbindEvents, eventsEqual } from "../../hooks/internal/event-utils";
 
 const handler = () => vi.fn<(params: unknown) => void>();

--- a/src/__tests__/hooks/theme-change.test.ts
+++ b/src/__tests__/hooks/theme-change.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vite-plus/test";
 import { renderHook } from "@testing-library/react";
-import * as echarts from "echarts";
+import * as echarts from "echarts/core";
 import useEcharts from "../../hooks/use-echarts";
 import { getCachedInstance, clearInstanceCache } from "../../utils/instance-cache";
 import { clearGroups } from "../../utils/connect";
@@ -9,7 +9,7 @@ import { clearThemeCache } from "../../themes";
 import { createMockInstance, MockResizeObserver, MockIntersectionObserver } from "../helpers";
 
 // Mock ECharts
-vi.mock("echarts", () => ({
+vi.mock("echarts/core", () => ({
   init: vi.fn(),
   connect: vi.fn(),
   disconnect: vi.fn(),

--- a/src/__tests__/hooks/use-echarts.test.ts
+++ b/src/__tests__/hooks/use-echarts.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vite-plus/test";
 import { renderHook, act, waitFor } from "@testing-library/react";
-import * as echarts from "echarts";
+import * as echarts from "echarts/core";
 import useEcharts from "../../hooks/use-echarts";
 import {
   clearInstanceCache,
@@ -16,7 +16,7 @@ import { __resetVisibilityCoordinatorForTesting__ } from "../../utils/visibility
 import { createMockInstance, MockResizeObserver, MockIntersectionObserver } from "../helpers";
 
 // Mock ECharts
-vi.mock("echarts", () => ({
+vi.mock("echarts/core", () => ({
   init: vi.fn(),
   connect: vi.fn(),
   disconnect: vi.fn(),

--- a/src/__tests__/themes/index.test.ts
+++ b/src/__tests__/themes/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vite-plus/test";
-import * as echarts from "echarts";
+import * as echarts from "echarts/core";
 import {
   isBuiltinTheme,
   isBuiltinThemeRegistered,
@@ -10,7 +10,7 @@ import {
 } from "../../themes";
 
 // Mock ECharts
-vi.mock("echarts", () => ({
+vi.mock("echarts/core", () => ({
   registerTheme: vi.fn(),
 }));
 

--- a/src/__tests__/themes/registry.test.ts
+++ b/src/__tests__/themes/registry.test.ts
@@ -1,10 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from "vite-plus/test";
-import * as echarts from "echarts";
+import * as echarts from "echarts/core";
 import { clearThemeCache, isBuiltinThemeRegistered } from "../../themes";
 import { registerBuiltinThemes } from "../../themes/registry";
 
 // Mock ECharts
-vi.mock("echarts", () => ({
+vi.mock("echarts/core", () => ({
   registerTheme: vi.fn(),
 }));
 

--- a/src/__tests__/utils/connect.test.ts
+++ b/src/__tests__/utils/connect.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vite-plus/test";
-import * as echarts from "echarts";
+import * as echarts from "echarts/core";
 import {
   addToGroup,
   removeFromGroup,
@@ -12,7 +12,7 @@ import {
 import { createMockInstance as createBaseMockInstance } from "../helpers";
 
 // Mock ECharts
-vi.mock("echarts", () => ({
+vi.mock("echarts/core", () => ({
   connect: vi.fn(),
   disconnect: vi.fn(),
 }));

--- a/src/__tests__/utils/instance-cache.test.ts
+++ b/src/__tests__/utils/instance-cache.test.ts
@@ -7,7 +7,7 @@ import {
   clearInstanceCache,
 } from "../../utils/instance-cache";
 import { addToGroup, clearGroups, getGroupInstances } from "../../utils/connect";
-import type { ECharts } from "echarts";
+import type { ECharts } from "echarts/core";
 import { createMockInstance as createBaseMockInstance } from "../helpers";
 
 function createMockInstance() {

--- a/src/core.ts
+++ b/src/core.ts
@@ -1,18 +1,26 @@
 "use client";
 
 /**
- * react-use-echarts
- * A React hook library for Apache ECharts with TypeScript support
- * 基于 TypeScript 的 Apache ECharts React Hook 库
+ * react-use-echarts/core
+ * Tree-shakable entry. Identical public API to the default entry, but does
+ * NOT import `"echarts"` for its side-effect registration of every chart and
+ * component. Consumers register only what they need:
+ *
+ * ```ts
+ * import * as echarts from "echarts/core";
+ * import { LineChart } from "echarts/charts";
+ * import { GridComponent } from "echarts/components";
+ * import { CanvasRenderer } from "echarts/renderers";
+ * echarts.use([LineChart, GridComponent, CanvasRenderer]);
+ *
+ * import { useEcharts } from "react-use-echarts/core";
+ * ```
+ *
+ * react-use-echarts 的 tree-shakable 子入口。与默认入口 API 完全一致，但不会
+ * 副作用 import `"echarts"`，由使用方按需 `echarts.use([...])` 注册图表/组件。
  *
  * @packageDocumentation
  */
-
-// Side-effect import: pulls in the full echarts entry, which calls `use([...all charts/components])`
-// against the shared ECharts global registry. Keeps the default entry zero-config.
-// The `/core` subpath entry deliberately omits this import so consumers can
-// register only what they need via `echarts.use([...])`.
-import "echarts";
 
 /**
  * Main hook for using ECharts in React components

--- a/src/hooks/internal/event-utils.ts
+++ b/src/hooks/internal/event-utils.ts
@@ -1,4 +1,4 @@
-import type { ECharts } from "echarts";
+import type { ECharts } from "echarts/core";
 import type { EChartsEvents, EChartsEventConfig } from "../../types";
 
 /**

--- a/src/hooks/internal/use-chart-core.ts
+++ b/src/hooks/internal/use-chart-core.ts
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useCallback, useLayoutEffect, useMemo } from "react";
-import * as echarts from "echarts";
-import type { ECharts, SetOptionOpts, EChartsOption } from "echarts";
+import * as echarts from "echarts/core";
+import type { ECharts } from "echarts/core";
+import type { SetOptionOpts, EChartsOption } from "echarts";
 import type {
   EChartsEvents,
   EChartsInitOpts,

--- a/src/themes/index.ts
+++ b/src/themes/index.ts
@@ -1,4 +1,4 @@
-import * as echarts from "echarts";
+import * as echarts from "echarts/core";
 import type { BuiltinTheme } from "../types";
 import { resetDevWarnings } from "../utils/dev-warnings";
 

--- a/src/themes/registry.ts
+++ b/src/themes/registry.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import * as echarts from "echarts";
+import * as echarts from "echarts/core";
 import type { BuiltinTheme } from "../types";
 import { isBuiltinThemeRegistered, markBuiltinThemeRegistered } from "./index";
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,6 +1,6 @@
+import type { ECharts } from "echarts/core";
 import type {
   EChartsOption,
-  ECharts,
   SetOptionOpts,
   EChartsInitOpts as RawEChartsInitOpts,
   Payload,

--- a/src/utils/connect.ts
+++ b/src/utils/connect.ts
@@ -1,5 +1,5 @@
-import * as echarts from "echarts";
-import type { ECharts } from "echarts";
+import * as echarts from "echarts/core";
+import type { ECharts } from "echarts/core";
 
 /**
  * ECharts documents `instance.group = 'xxx'` as the standard pattern for

--- a/src/utils/instance-cache.ts
+++ b/src/utils/instance-cache.ts
@@ -1,4 +1,4 @@
-import type { ECharts } from "echarts";
+import type { ECharts } from "echarts/core";
 import { leaveGroup } from "./connect";
 
 /**

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -59,6 +59,15 @@ export default defineConfig({
       plugins: [babel({ presets: [reactCompilerPreset()] })],
     },
     {
+      entry: { core: "src/core.ts" },
+      format: ["esm"],
+      dts: { build: true },
+      publint: true,
+      attw: { profile: "esm-only" },
+      platform: "browser",
+      plugins: [babel({ presets: [reactCompilerPreset()] })],
+    },
+    {
       entry: { "themes/registry": "src/themes/registry.ts" },
       format: ["esm"],
       dts: { build: true },


### PR DESCRIPTION
## Summary

- Add `react-use-echarts/core` subpath as a tree-shakable companion to the default entry.
- The default entry now imports `"echarts"` purely as a side-effect (full chart/component registration via the ECharts global registry) so it stays zero-config; the `/core` entry skips that import so consumers register only what they use via `echarts.use([...])`.
- Public API is identical between the two entries — only the import path differs. Fully backwards-compatible.

This aligns with the 2026 community direction: vue-echarts v8 and nuxt-echarts both use the `echarts/core` + `echarts.use([...])` pattern, and the ECharts handbook recommends it as the canonical tree-shaking approach. The double-entry layout additionally gives newcomers a zero-config fallback that vue-echarts doesn't provide.

### Usage

```tsx
import * as echarts from "echarts/core";
import { LineChart } from "echarts/charts";
import { GridComponent } from "echarts/components";
import { CanvasRenderer } from "echarts/renderers";
echarts.use([LineChart, GridComponent, CanvasRenderer]);

import { useEcharts, EChart } from "react-use-echarts/core";
```

### Implementation notes

- Internal runtime + `ECharts` type imports unified on `echarts/core` (keeps `init()`'s return type and the declared `ECharts` parameter type from being seen as nominally distinct by TS). `EChartsOption` and other types not surfaced by `echarts/core.d.ts` stay on the main entry.
- Six test files migrated to `vi.mock("echarts/core")` to match the new specifier; browser smoke tests register their own minimal `echarts.use([...])` since they import the hook directly and bypass the default entry's side-effect.
- New `src/__tests__/core.test.ts` asserts both entries expose the exact same export set, catching drift.
- `package.json` `exports` adds `./core`; `vite.config.ts` `pack` gets a third entry with `dts` / `publint` / `attw esm-only`.
- `size-limit` adds an 11 KB gzip budget for `dist/core.js` (measured at 10.77 KB).
- A new "Tree-shakable Core Entry" feature demo lives in `examples/core-entry/`.

## Test plan

- [x] `vp check` — format + lint + typecheck pass
- [x] `vp test run --project unit` — 252 tests pass (including the new `core.test.ts`)
- [x] `vp test run --project browser` — 2 pass + 1 skipped
- [x] `vp pack` — publint + two attw (esm-only) reports clean
- [x] `vp run size` — all three budgets pass (index 10.77/12 KB · core 10.77/11 KB · registry 2.42/3 KB)
- [x] Verified `dist/index.js` starts with `import "echarts";` and `dist/core.js` has zero `from "echarts"` references (only `echarts/core`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)