### PR TITLE
chore: add changeset for 1.5.1 toolchain refresh

### DIFF
--- a/.changeset/refresh-toolchain-deps.md
+++ b/.changeset/refresh-toolchain-deps.md
@@ -1,0 +1,12 @@
+---
+"react-use-echarts": patch
+---
+
+Refresh dev toolchain — no runtime / API changes.
+
+- `@vitejs/plugin-react` → ^6.0.2
+- `react-router-dom` → ^7.15.1 (examples app only)
+- `@types/node` → ^25.8.0
+- `publint` → ^0.3.21
+
+Published bundle is bit-identical to 1.5.0; bump is purely to keep release cadence in sync with the upstream toolchain refresh.


### PR DESCRIPTION
## Summary
- Adds a `patch` changeset documenting the dev-dep bumps that landed in #408 (publint) and #409 (`@vitejs/plugin-react`, `react-router-dom`, `@types/node`).
- Triggers Changesets release PR to bump `1.5.0 → 1.5.1`.

## Notes
- **No runtime / API changes.** Published bundle is bit-identical to 1.5.0; bump is purely to keep release cadence in sync with the upstream toolchain refresh.
- Direct push to `main` was rejected by branch protection, so flowing through this PR.

## Test plan
- [ ] `vp check && vp test` green in CI
- [ ] Changesets bot opens follow-up "chore: release" PR after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)