### PR TITLE
fix: whitelist default entry in sideEffects so import "echarts" survives

### DIFF
--- a/.changeset/fix-side-effects-whitelist.md
+++ b/.changeset/fix-side-effects-whitelist.md
@@ -1,0 +1,9 @@
+---
+"react-use-echarts": patch
+---
+
+Fix `sideEffects: false` causing bundlers to tree-shake `import "echarts"` from the default entry, leaving the global ECharts registry empty and producing `TypeError: xa[a] is not a constructor` (or similar) at `echarts.init`.
+
+Switch to a whitelist that preserves the side-effect import in `dist/index.js` (consumer-side) and `src/index.ts` (this repo's showcase). The `/core` and `/themes/registry` sub-entries remain fully tree-shakable since they're not in the whitelist.
+
+Regression introduced when `import "echarts"` was added to the default entry alongside the `/core` sub-entry without updating the package-level `sideEffects` field.

--- a/package.json
+++ b/package.json
@@ -32,7 +32,10 @@
     "dist"
   ],
   "type": "module",
-  "sideEffects": false,
+  "sideEffects": [
+    "./dist/index.js",
+    "./src/index.ts"
+  ],
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {


### PR DESCRIPTION
## Summary

Hotfix for `TypeError: xa[a] is not a constructor` (or similar "not a constructor" runtime error) thrown by `echarts.init` in consumer apps using the default `react-use-echarts` entry.

### Root cause

`sideEffects: false` was added to `package.json` in early 2024, when `src/index.ts` had no side-effect imports. PR #406 (`feat: add tree-shakable core entry`) later added `import "echarts"` to `src/index.ts` to keep the default entry zero-config — but didn't update the `sideEffects` field.

With `sideEffects: false`, consumer-side bundlers (Vite/Rollup/esbuild/webpack 5+) are free to tree-shake top-level side-effect imports. The `import "echarts"` line gets dropped → the global ECharts registry stays empty → `echarts.init(...)` fails when it looks up the canvas renderer.

### Fix

Switch to a path whitelist:

```json
"sideEffects": [
  "./dist/index.js",
  "./src/index.ts"
]
```

- `dist/index.js` covers published consumer scenarios
- `src/index.ts` covers this repo's showcase (which imports from `../../src` directly)
- `/core` and `/themes/registry` sub-entries remain tree-shakable (not in the whitelist, so bundlers still treat them as side-effect-free)

### Verification

Showcase build (`vp build`) before/after, grepping for series view classes:

| | bundle size | series view classes present |
|---|---|---|
| Before fix | 634 kB (gzip 206) | **0** (line, bar, gauge, pie, …) |
| After fix | 918 kB (gzip 294) | **20+** chart types present |

The size delta confirms `import "echarts"` is now reaching the bundle.

## Test plan

- [x] `vp check` — clean
- [x] `vp test` — 256/256 pass
- [x] `vp pack` — build + attw + publint clean; `dist/index.js` still starts with `import "echarts";`
- [x] `vp build` — showcase bundle now contains all chart series
- [ ] CI green
- [ ] Deployed Pages reproduces fix after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)