### PR TITLE
[codex] align vite-plus configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,10 @@ jobs:
           node-version: ${{ matrix.node }}
           cache: true
 
+      # `vp pack` shells out to pnpm while creating the package tarball.
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6
+
       - name: Install dependencies
         run: vp install --frozen-lockfile
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,9 +25,6 @@ jobs:
           node-version: ${{ matrix.node }}
           cache: true
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v6
-
       - name: Install dependencies
         run: vp install --frozen-lockfile
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,6 +43,10 @@ jobs:
           node-version: "24"
           cache: true
 
+      # `vp pack` shells out to pnpm while creating the package tarball.
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6
+
       - name: Install dependencies
         run: vp install --frozen-lockfile
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,9 +43,6 @@ jobs:
           node-version: "24"
           cache: true
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v6
-
       - name: Install dependencies
         run: vp install --frozen-lockfile
 

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ dist-ssr
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json
+!.vscode/settings.json
 .idea
 .DS_Store
 *.suo

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+  "oxc.fmt.configPath": "./vite.config.ts",
+  "typescript.tsdk": "node_modules/typescript/lib"
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,10 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  vite: npm:@voidzero-dev/vite-plus-core@^0.1.22
+  vitest: npm:@voidzero-dev/vite-plus-test@^0.1.22
+
 importers:
 
   .:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,6 @@
+overrides:
+  vite: npm:@voidzero-dev/vite-plus-core@^0.1.22
+  vitest: npm:@voidzero-dev/vite-plus-test@^0.1.22
+
 allowBuilds:
   esbuild: true

--- a/src/__tests__/browser/lazy-init.test.tsx
+++ b/src/__tests__/browser/lazy-init.test.tsx
@@ -7,7 +7,7 @@
  * `getInstance()` to transition from undefined → defined. Not asserting exact
  * timing or layout numbers.
  */
-import { describe, it, expect } from "vitest";
+import { describe, it, expect } from "vite-plus/test";
 import { render, act } from "@testing-library/react";
 import { useRef } from "react";
 import * as echarts from "echarts/core";

--- a/src/__tests__/browser/resize.test.tsx
+++ b/src/__tests__/browser/resize.test.tsx
@@ -7,7 +7,7 @@
  * Smoke-level: width changes are observable on the ECharts instance after a
  * container resize. Does NOT assert exact frame coalescing counts.
  */
-import { describe, it, expect } from "vitest";
+import { describe, it, expect } from "vite-plus/test";
 import { render } from "@testing-library/react";
 import { useRef } from "react";
 import * as echarts from "echarts/core";

--- a/src/__tests__/browser/visibility.test.tsx
+++ b/src/__tests__/browser/visibility.test.tsx
@@ -9,7 +9,7 @@
  * file is a placeholder skipped by default and documents the gap so it can be
  * upgraded with a Playwright tab-toggle helper later.
  */
-import { describe, it } from "vitest";
+import { describe, it } from "vite-plus/test";
 
 describe("visibilitychange resync in real browser", () => {
   it.skip("resyncs chart size after tab returns to foreground", () => {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,11 +1,9 @@
 import { defineConfig } from "vite-plus";
 import babel from "@rolldown/plugin-babel";
 import react, { reactCompilerPreset } from "@vitejs/plugin-react";
-// Use the bundled provider from vite-plus-test (vitest is aliased to it in
-// package.json). Importing @vitest/browser-playwright as an external dep would
-// pull a separate copy that mismatches vite-plus-test's bundled Vitest core
-// version, triggering the "Running mixed versions" warning at test start.
-import { playwright } from "vitest/browser/providers/playwright";
+// Use the provider bundled with vite-plus-test so the browser runner and
+// Vitest core stay on the same Vite+ managed version.
+import { playwright } from "vite-plus/test/browser/providers/playwright";
 
 const repositoryName = process.env.GITHUB_REPOSITORY?.split("/")[1];
 const base = process.env.GITHUB_ACTIONS === "true" && repositoryName ? `/${repositoryName}/` : "/";


### PR DESCRIPTION
## Summary
- add pnpm workspace overrides so Vite and Vitest resolve through Vite+
- move remaining test/provider imports to vite-plus/test subpaths
- simplify CI/release setup-vp usage and add project VS Code formatter settings

## Validation
- vp install --frozen-lockfile
- vp check
- vp test run --coverage --project unit
- vp test run --project browser
- vp build
- vp pack
- vp run size