### PR TITLE
refactor(types): unify echarts type imports to echarts/core

### DIFF
--- a/src/core.ts
+++ b/src/core.ts
@@ -64,7 +64,7 @@ export type {
  * the imperative `dispatchAction` returned from `useEcharts`.
  * 转出的 ECharts `Payload` 类型，便于在调用 `dispatchAction` 时显式标注参数。
  */
-export type { Payload } from "echarts";
+export type { Payload } from "echarts/core";
 
 /**
  * Theme utilities (lightweight, no JSON bundled)

--- a/src/hooks/internal/use-chart-core.ts
+++ b/src/hooks/internal/use-chart-core.ts
@@ -1,7 +1,7 @@
 import { useEffect, useEffectEvent, useMemo, useRef, useState, useLayoutEffect } from "react";
 import * as echarts from "echarts/core";
-import type { ECharts } from "echarts/core";
-import type { SetOptionOpts, EChartsOption } from "echarts";
+import type { ECharts, SetOptionOpts } from "echarts/core";
+import type { EChartsOption } from "echarts";
 import type {
   EChartsEvents,
   EChartsInitOpts,

--- a/src/index.ts
+++ b/src/index.ts
@@ -62,7 +62,7 @@ export type {
  * the imperative `dispatchAction` returned from `useEcharts`.
  * 转出的 ECharts `Payload` 类型，便于在调用 `dispatchAction` 时显式标注参数。
  */
-export type { Payload } from "echarts";
+export type { Payload } from "echarts/core";
 
 /**
  * Theme utilities (lightweight, no JSON bundled)

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,6 +1,5 @@
-import type { ECharts } from "echarts/core";
 import type {
-  EChartsOption,
+  ECharts,
   SetOptionOpts,
   EChartsInitOpts as RawEChartsInitOpts,
   Payload,
@@ -13,7 +12,10 @@ import type {
   CollapseAxisBreakPayload,
   ExpandAxisBreakPayload,
   ToggleAxisBreakPayload,
-} from "echarts";
+} from "echarts/core";
+// EChartsOption is the full pre-composed option type; only the full "echarts"
+// package exports it (echarts/core ships ComposeOption / EChartsCoreOption).
+import type { EChartsOption } from "echarts";
 import type { CSSProperties, RefCallback } from "react";
 
 /**


### PR DESCRIPTION
## Summary
- Move all movable type-only imports in `src/` from the full `"echarts"` package to the `"echarts/core"` subpath, so type imports match the runtime imports already used throughout the library.
- Affected: `src/index.ts`, `src/core.ts` (`Payload` re-export), `src/types/index.ts` (12 types), `src/hooks/internal/use-chart-core.ts` (`ECharts`, `SetOptionOpts`).
- **Intentionally kept** `EChartsOption` on `"echarts"` — `echarts/core` only exports the `ComposeOption` / `EChartsCoreOption` building blocks, not the pre-composed type. Added a one-line comment in `types/index.ts` documenting why.

All changes are type-only with zero runtime impact.

## Test plan
- [x] `vp check` — format + lint + typecheck clean
- [x] `vp test` — 277 passed / 1 skipped
- [x] `vp pack` — 4 entries build clean, attw `esm-only` + publint pass (confirms the public `Payload` re-export resolves correctly in the published `.d.ts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)