### PR TITLE
chore: dedupe publint/attw config to a single pack entry

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -57,11 +57,12 @@ export default defineConfig({
       plugins: [babel({ presets: [reactCompilerPreset()] })],
     },
     {
+      // publint/attw validate the whole package (tarball + exports map) once
+      // from the index entry above — they're not per-entry, so re-declaring
+      // them here re-runs attw redundantly on the same tarball.
       entry: { core: "src/core.ts" },
       format: ["esm"],
       dts: { build: true },
-      publint: true,
-      attw: { profile: "esm-only" },
       platform: "browser",
       plugins: [babel({ presets: [reactCompilerPreset()] })],
     },
@@ -72,11 +73,10 @@ export default defineConfig({
       platform: "browser",
     },
     {
+      // publint/attw run once from the index entry (see core entry note).
       entry: { "preset-full": "src/preset-full.ts" },
       format: ["esm"],
       dts: { build: true },
-      publint: true,
-      attw: { profile: "esm-only" },
       platform: "browser",
       plugins: [babel({ presets: [reactCompilerPreset()] })],
     },


### PR DESCRIPTION
## What

Consolidate `publint` / `attw` declarations onto the single `index` pack entry in `vite.config.ts`, removing them from the `core` and `preset-full` entries.

## Why

`publint` and `attw` validate the **whole package** (the built tarball + the full `package.json` exports map) — they are package-level, not per-entry. Declaring `attw: { profile: "esm-only" }` on three separate pack entries caused attw to run **3× redundantly** on the same tarball and triggered vite-plus's warning on every `vp pack`:

```
warn: Multiple publint or attw configurations found for package … Consider merging them.
```

(`publint: true` was already deduped by the toolchain since it's a boolean; the three `attw` object literals were not.)

## Impact

- ✅ Warning gone; attw/publint each run once instead of 3×/1×
- ✅ **Coverage unchanged** — a single package-level run validates all export subpaths (`.`, `./core`, `./preset-full`, `./themes/registry`)
- ✅ `vp check` clean, `vp test` 277 passed, `vp pack` reports "No problems found" for both attw and publint

🤖 Generated with [Claude Code](https://claude.com/claude-code)