### PR TITLE
perf: memoize stable dependency keys in useChartCore

### DIFF
--- a/src/hooks/internal/use-chart-core.ts
+++ b/src/hooks/internal/use-chart-core.ts
@@ -216,9 +216,15 @@ export function useChartCore(
   // React reconciles this state update.
   const [liveInstance, setLiveInstance] = useState<ECharts | undefined>(undefined);
 
-  // --- Stable dependency keys (plain calls; React Compiler memoizes) ---
-  const themeKey = computeStableKey(theme);
-  const initOptsKey = computeStableKey(initOpts);
+  // --- Stable dependency keys, memoized on the raw input reference. React
+  // Compiler skips this whole hook because it disables a react-hooks ESLint
+  // rule (the trimmed lifecycle-effect deps below) — the compiler bails on any
+  // function that opts out of its rules. So it won't auto-memoize these calls;
+  // without an explicit useMemo, computeStableKey would re-run JSON.stringify
+  // every render for object theme / initOpts (the stable-ref usage CLAUDE.md
+  // recommends). No regression for inline objects — the dep changes either way.
+  const themeKey = useMemo(() => computeStableKey(theme), [theme]);
+  const initOptsKey = useMemo(() => computeStableKey(initOpts), [initOpts]);
 
   // --- Public API ---
 


### PR DESCRIPTION
## 背景

`useChartCore` 中的 `themeKey` / `initOptsKey` 由 `computeStableKey()`（对 object 输入会调用 `JSON.stringify`）计算。原注释声称 *"plain calls; React Compiler memoizes"*，但这是不准确的。

通过 babel 的 React Compiler `logger` 实测确认：**React Compiler 会跳过整个 `useChartCore`**，诊断原文为 *"skipped optimizing this component because one or more React ESLint rules were disabled"* —— 即文件中的 `// eslint-disable-next-line react-hooks/exhaustive-deps`（有意裁剪的生命周期 effect 依赖）。编译器一旦发现函数禁用了 react-hooks 规则就整体 bail。

结果：`computeStableKey` 在每次渲染都重新执行。叠加 CLAUDE.md 推荐的"传入 memoized theme 对象"（稳定引用）用法 + 频繁重渲染时，对（可能较大的）theme/initOpts 反复 `JSON.stringify`，纯属浪费。

## 改动

- 用 `useMemo` 按原始输入引用 memoize `themeKey` / `initOptsKey`，恢复作者注释本意的 memoization。
- 修正不准确的注释为实测确认的真实 bail 原因。

## 正确性 / 必要性

- **行为完全等价**：`computeStableKey` 是纯函数且仅依赖其唯一输入；对内联对象无回归（依赖引用变化时两种写法都会重算）。
- **必要**：编译器实测确证跳过此 hook，不会自动 memoize；手写 `useMemo` 是唯一途径，且与本 hook 已有的 2 个手写 `useMemo`（api / return）同源同因。

## 验证

- `vp check` ✅（fmt + lint + typecheck）
- 277 单元测试 + 2 浏览器测试通过 ✅
- 覆盖率维持 100% ✅
- `vp pack`：size-limit 全部在预算内（index/core 11.29KB < 12KB），attw / publint 无问题 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)