### PR TITLE
fix: harden onEvents and useLazyInit against nullish/malformed inputs

### DIFF
--- a/src/__tests__/hooks/event-utils.test.ts
+++ b/src/__tests__/hooks/event-utils.test.ts
@@ -128,6 +128,36 @@ describe("eventsEqual", () => {
       false,
     );
   });
+
+  // An explicit-undefined value means "no listener" (bindEvents/unbindEvents
+  // both skip it), so it must be equivalent to the key being absent. Comparing
+  // raw key counts would treat these as different and force a redundant
+  // unbind/rebind on every render for code like
+  //   onEvents={{ click: h, hover: enabled ? hoverFn : undefined }}
+  it("treats an explicit-undefined entry as equivalent to an absent key", () => {
+    const h = handler();
+    expect(eventsEqual({ click: h }, { click: h, hover: undefined })).toBe(true);
+    expect(eventsEqual({ click: h, hover: undefined }, { click: h })).toBe(true);
+    // Differing undefined-only keys are still equivalent (both effectively {click:h}).
+    expect(eventsEqual({ click: h, a: undefined }, { click: h, b: undefined })).toBe(true);
+    // A defined extra listener is a real difference and must NOT compare equal.
+    expect(eventsEqual({ click: h }, { click: h, hover: h })).toBe(false);
+  });
+
+  // JS callers can land an out-of-type `null` under a key (the index signature
+  // is `EChartsEventConfig | undefined`). null must behave exactly like
+  // undefined / an absent key ("no listener"); before the nullish guard in
+  // eventConfigEqual, comparing it against a defined config dereferenced
+  // `null.handler` and crashed.
+  it("treats an explicit-null entry like undefined (no listener)", () => {
+    const h = handler();
+    const withNull = { click: h, hover: null } as unknown as Parameters<typeof eventsEqual>[0];
+    expect(() => eventsEqual(withNull, { click: h })).not.toThrow();
+    expect(eventsEqual(withNull, { click: h })).toBe(true);
+    expect(eventsEqual(withNull, { click: h, hover: undefined })).toBe(true);
+    // null vs a defined listener is a real difference.
+    expect(eventsEqual(withNull, { click: h, hover: h })).toBe(false);
+  });
 });
 
 describe("bindEvents", () => {
@@ -200,6 +230,23 @@ describe("bindEvents", () => {
     expect(on).toHaveBeenCalledTimes(1);
     expect(on).toHaveBeenCalledWith("click", clickHandler, undefined);
   });
+
+  // Parity with the eventsEqual nullish guard: a JS caller can land an
+  // out-of-type `null` under a key. Bind must skip it instead of destructuring
+  // null (which throws), exactly as it skips undefined.
+  it("skips entries whose value is null", () => {
+    const on = vi.fn();
+    const instance = { on, off: vi.fn() } as unknown as ECharts;
+    const clickHandler = handler();
+
+    bindEvents(instance, {
+      click: clickHandler,
+      hover: null,
+    } as unknown as Parameters<typeof bindEvents>[1]);
+
+    expect(on).toHaveBeenCalledTimes(1);
+    expect(on).toHaveBeenCalledWith("click", clickHandler, undefined);
+  });
 });
 
 describe("unbindEvents", () => {
@@ -234,6 +281,22 @@ describe("unbindEvents", () => {
     const clickHandler = handler();
 
     unbindEvents(instance, { click: clickHandler, hover: undefined });
+
+    expect(off).toHaveBeenCalledTimes(1);
+    expect(off).toHaveBeenCalledWith("click", clickHandler);
+  });
+
+  // Mirror of the bindEvents guard — explicit-null values must be skipped
+  // instead of reading `.handler` off null.
+  it("skips entries whose value is null", () => {
+    const off = vi.fn();
+    const instance = { on: vi.fn(), off } as unknown as ECharts;
+    const clickHandler = handler();
+
+    unbindEvents(instance, {
+      click: clickHandler,
+      hover: null,
+    } as unknown as Parameters<typeof unbindEvents>[1]);
 
     expect(off).toHaveBeenCalledTimes(1);
     expect(off).toHaveBeenCalledWith("click", clickHandler);

--- a/src/__tests__/hooks/use-lazy-init.test.ts
+++ b/src/__tests__/hooks/use-lazy-init.test.ts
@@ -57,6 +57,55 @@ describe("useLazyInit", () => {
     expect(mockObserve).not.toHaveBeenCalled();
   });
 
+  // The public type forbids null, but a JS caller can still pass it (e.g.
+  // useEcharts({ lazyInit: null }) — the `= false` default only fills undefined).
+  // `typeof null === "object"` previously made the option reads deref null and
+  // throw during render. null must be treated like false (lazy disabled).
+  it("treats null options like false (lazy disabled) instead of throwing", () => {
+    const element = document.createElement("div");
+
+    const { result } = renderHook(() => useLazyInit(null as unknown as boolean));
+    act(() => {
+      result.current.ref(element);
+    });
+
+    expect(result.current.isInView).toBe(true);
+    expect(mockObserve).not.toHaveBeenCalled();
+  });
+
+  // A malformed IntersectionObserverInit (out-of-range threshold here) makes the
+  // native constructor throw synchronously. Without the effect's try/catch this
+  // escaped useEffect and tore down the React tree. It must instead degrade to
+  // eager init (visible) — these values are type-valid, so TS callers hit it too.
+  it("falls back to eager init (visible) instead of throwing on invalid options", () => {
+    class ThrowingObserver {
+      constructor(_cb: IntersectionObserverCallback, options?: IntersectionObserverInit) {
+        const t = options?.threshold;
+        if (typeof t === "number" && (Number.isNaN(t) || t < 0 || t > 1)) {
+          throw new RangeError("Failed to construct 'IntersectionObserver': invalid threshold.");
+        }
+      }
+      observe = vi.fn();
+      disconnect = vi.fn();
+      unobserve = vi.fn();
+    }
+    globalThis.IntersectionObserver = ThrowingObserver as unknown as typeof IntersectionObserver;
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const element = document.createElement("div");
+
+    const { result } = renderHook(() => useLazyInit({ threshold: 1.5 }));
+    expect(() => {
+      act(() => {
+        result.current.ref(element);
+      });
+    }).not.toThrow();
+
+    // Degraded to eager init: visible despite the construction failure.
+    expect(result.current.isInView).toBe(true);
+    expect(errorSpy).toHaveBeenCalled();
+    errorSpy.mockRestore();
+  });
+
   it("should return false initially when lazy mode is enabled", () => {
     const element = document.createElement("div");
 

--- a/src/hooks/internal/event-utils.ts
+++ b/src/hooks/internal/event-utils.ts
@@ -8,7 +8,10 @@ import type { EChartsEvents, EChartsEventConfig } from "../../types";
 export function bindEvents(instance: ECharts, events: EChartsEvents | undefined): void {
   if (!events) return;
   for (const [eventName, config] of Object.entries(events)) {
-    if (config === undefined) continue;
+    // null/undefined both mean "no listener". undefined is the in-type sentinel
+    // (`EChartsEventConfig | undefined`); a JS caller can also land an out-of-type
+    // null. Skip both — destructuring null below would throw.
+    if (config == null) continue;
     if (typeof config === "function") {
       instance.on(eventName, config, undefined);
       continue;
@@ -26,21 +29,23 @@ export function bindEvents(instance: ECharts, events: EChartsEvents | undefined)
  * Compare two event config values for equality.
  * Reads handler/query/context directly without allocating normalized objects;
  * shorthand (function) form is treated as `{ handler, query: undefined, context: undefined }`.
- * `undefined` is allowed on either side — only equal to another `undefined`.
+ * `null`/`undefined` are allowed on either side and treated as "no listener" —
+ * a nullish value is only equal to another nullish value.
  * 比较两个事件配置值是否相等。直接读取字段，避免分配标准化对象；
  * 函数简写形式视作 `{ handler, query: undefined, context: undefined }`。
- * 任意一侧为 undefined 时，仅当另一侧也为 undefined 才相等。
+ * 任意一侧为 null/undefined（均表示无监听）时，仅当另一侧也为 null/undefined 才相等。
  */
 function eventConfigEqual(
   a: EChartsEventConfig | undefined,
   b: EChartsEventConfig | undefined,
 ): boolean {
   if (a === b) return true;
-  // After the strict-equal check, "either side undefined" implies the
-  // other side is defined → never equal. Returning here also guards the
-  // property reads below (`a.handler`, `b.handler`) from null-deref when
-  // an EChartsEvents entry is explicitly assigned `undefined`.
-  if (a === undefined || b === undefined) return false;
+  // Treat null/undefined uniformly as "no listener" (bindEvents/unbindEvents
+  // skip both): two nullish values are equal, a nullish vs a defined config is
+  // not. This also guards the property reads below (`a.handler`, `b.handler`)
+  // from a nullish deref — undefined is the in-type sentinel, and JS callers can
+  // additionally land an out-of-type `null` under an EChartsEvents key.
+  if (a == null || b == null) return a == null && b == null;
   if (typeof a === "function") {
     if (typeof b === "function") return false;
     return a === b.handler && b.query === undefined && b.context === undefined;
@@ -58,16 +63,19 @@ function eventConfigEqual(
  */
 export function eventsEqual(a: EChartsEvents | undefined, b: EChartsEvents | undefined): boolean {
   if (a === b) return true;
-  const keysA = a ? Object.keys(a) : [];
-  const keysB = b ? Object.keys(b) : [];
-  if (keysA.length !== keysB.length) return false;
-  if (keysA.length === 0) return true;
-  for (const key of keysA) {
-    if (!Object.prototype.hasOwnProperty.call(b!, key)) return false;
-    // EChartsEvents' index signature is `EChartsEventConfig<any> | undefined`,
-    // so a/b may contain an explicit-undefined value. eventConfigEqual handles
-    // undefined on either side.
-    if (!eventConfigEqual(a![key], b![key])) return false;
+  // Compare effective (non-undefined) listeners, not raw key counts. A key
+  // whose value is `undefined` means "no listener" (bindEvents/unbindEvents
+  // both skip it), so `{ click: h }` and `{ click: h, hover: undefined }` must
+  // be equivalent — comparing key counts would treat them as different and
+  // trigger a redundant unbind/rebind. The union of keys is walked through
+  // eventConfigEqual, which already treats undefined on either side as equal
+  // to undefined and unequal to any defined config (an absent key reads back
+  // as undefined here, matching an explicit-undefined value).
+  const keys = new Set<string>();
+  if (a) for (const key of Object.keys(a)) keys.add(key);
+  if (b) for (const key of Object.keys(b)) keys.add(key);
+  for (const key of keys) {
+    if (!eventConfigEqual(a?.[key], b?.[key])) return false;
   }
   return true;
 }
@@ -83,7 +91,9 @@ export function eventsEqual(a: EChartsEvents | undefined, b: EChartsEvents | und
 export function unbindEvents(instance: ECharts, events: EChartsEvents | undefined): void {
   if (!events) return;
   for (const [eventName, config] of Object.entries(events)) {
-    if (config === undefined) continue;
+    // Mirror bindEvents: skip null/undefined ("no listener"); `config.handler`
+    // on a nullish value would throw.
+    if (config == null) continue;
     const handler = typeof config === "function" ? config : config.handler;
     instance.off(eventName, handler);
   }

--- a/src/hooks/use-lazy-init.ts
+++ b/src/hooks/use-lazy-init.ts
@@ -32,7 +32,12 @@ export function useLazyInitForElement(
   element: Element | null,
   options: boolean | IntersectionObserverInit = false,
 ): boolean {
-  const isLazyMode = options !== false;
+  // Public type forbids null, but JS callers can still pass it; treat null like
+  // false (lazy disabled / instant visible), matching the `= false` default and
+  // resolveThemeName's identical typeof-null guard (use-chart-core.ts). Without
+  // the `!== null` check on isObject below, `typeof null === "object"` would make
+  // the option reads deref null and throw during render on every pass.
+  const isLazyMode = options != null && options !== false;
   // State holds ONLY the observer's "has fired with isIntersecting" verdict.
   // Initial visibility (when lazy mode is disabled) is derived at return,
   // NOT seeded via useState(!isLazyMode) — that initializer only runs on
@@ -42,7 +47,7 @@ export function useLazyInitForElement(
 
   // Extract config values for stable dependency comparison
   // 提取配置值用于稳定的依赖比较
-  const isObject = typeof options === "object";
+  const isObject = typeof options === "object" && options !== null;
   const optRoot = isObject ? options.root : null;
   const optRootMargin = isObject ? options.rootMargin : undefined;
   const optThreshold = isObject ? options.threshold : undefined;
@@ -56,24 +61,42 @@ export function useLazyInitForElement(
     // 如果禁用了懒加载模式或已经可见，则跳过
     if (!isLazyMode || hasIntersected || !element) return;
 
-    const observer = new IntersectionObserver(
-      (entries) => {
-        const [entry] = entries;
-        if (entry?.isIntersecting) {
-          setHasIntersected(true);
-          // Once visible, stop observing
-          // 一旦可见，就停止观察
-          observer.disconnect();
-        }
-      },
-      {
-        root: optRoot ?? null,
-        rootMargin: optRootMargin ?? "50px",
-        threshold: optThreshold ?? 0.1,
-      },
-    );
-
-    observer.observe(element);
+    let observer: IntersectionObserver;
+    try {
+      observer = new IntersectionObserver(
+        (entries) => {
+          const [entry] = entries;
+          if (entry?.isIntersecting) {
+            setHasIntersected(true);
+            // Once visible, stop observing
+            // 一旦可见，就停止观察
+            observer.disconnect();
+          }
+        },
+        {
+          root: optRoot ?? null,
+          rootMargin: optRootMargin ?? "50px",
+          threshold: optThreshold ?? 0.1,
+        },
+      );
+      observer.observe(element);
+    } catch (error) {
+      // A malformed IntersectionObserverInit makes the constructor throw
+      // synchronously — out-of-range/NaN threshold (RangeError), unit-less
+      // rootMargin (SyntaxError), or non-Element root (TypeError). These are all
+      // type-valid per `IntersectionObserverInit`, so even TS callers can hit it.
+      // Mirror useResizeObserver's construction try/catch: never let it escape
+      // the effect and tear down the React tree. Degrade to eager init (treat as
+      // visible) so the chart still renders — matching this file's null-guard
+      // "don't throw, fall back to visible" philosophy. onError is intentionally
+      // not plumbed into this hook, so we log rather than route.
+      console.error(
+        "useLazyInit: invalid IntersectionObserver options; falling back to eager init.",
+        error,
+      );
+      setHasIntersected(true);
+      return;
+    }
 
     return () => {
       observer.disconnect();


### PR DESCRIPTION
## Summary

Robustness fixes surfaced by a two-pass adversarial audit of the library. All four are low-severity edge-input / defensive hardening — no behavior change on the happy path. Each comes with a regression test; coverage stays at 100%.

### `eventsEqual` — redundant rebind on conditional handlers
`eventsEqual` compared raw key counts, so `{ click: h }` vs `{ click: h, hover: undefined }` were treated as different and forced an `off()`/`on()` rebind on **every render** for code like `onEvents={{ click: h, hover: enabled ? fn : undefined }}`. Rewritten to compare the union of both maps' keys via `eventConfigEqual`, so undefined-valued keys are equivalent to absent ones.

### event-utils — out-of-type `null` values crashed
`bindEvents` / `unbindEvents` / `eventConfigEqual` only skipped `undefined`. A JS caller passing `{ click: null }` (out-of-type) crashed by destructuring `null` / reading `null.handler`. They now skip `null` too (`config == null`) — `null`/`undefined` uniformly mean "no listener".

### `useLazyInit` — `null` options crashed at render
`typeof null === "object"` made a `null` options object deref `null` at render (e.g. `useEcharts({ lazyInit: null })`; the `= false` default only fills `undefined`). Now treated like `false` (eager init), matching `resolveThemeName`'s identical typeof-null guard.

### `useLazyInit` — malformed `IntersectionObserverInit` tore down the tree
A type-valid but invalid `IntersectionObserverInit` (out-of-range/NaN `threshold`, unit-less `rootMargin`, non-Element `root`) makes the constructor throw synchronously inside the effect, escaping `useEffect`. Now wrapped in try/catch that degrades to eager init (visible), mirroring `useResizeObserver`'s construction try/catch.

## Testing
- `vp test --coverage` → 283 passed | 1 skipped — **100% statements / branches / functions / lines**
- `vp check` → format + lint + typecheck all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)