### PR TITLE
perf: strippable dev warnings, fewer allocations, dead-code cleanup

### DIFF
--- a/.changeset/strippable-dev-warnings.md
+++ b/.changeset/strippable-dev-warnings.md
@@ -1,0 +1,5 @@
+---
+"react-use-echarts": patch
+---
+
+Dev-mode console warnings are now strippable from consumer production bundles. The published entries (`index`, `core`, `preset-full`) preserve `process.env.NODE_ENV` instead of baking the library's build-time value, so each consumer's bundler dead-code-eliminates the dev-only warnings in their production build (~0.6 KB gzip) while keeping them in development. Also trims a per-render allocation in the chart hook's imperative-API ref sync, collapses the deprecated `core` entry to a thin re-export of the default entry, and removes an unused internal `isInGroup` helper. No public API changes.

--- a/src/__tests__/utils/connect.test.ts
+++ b/src/__tests__/utils/connect.test.ts
@@ -6,7 +6,6 @@ import {
   updateGroup,
   getGroupInstances,
   getInstanceGroup,
-  isInGroup,
   clearGroups,
 } from "../../utils/connect";
 import { createMockInstance as createBaseMockInstance } from "../helpers";
@@ -190,20 +189,6 @@ describe("connect utilities", () => {
     it("should return undefined for instance not in any group", () => {
       const instance = createMockInstance();
       expect(getInstanceGroup(instance)).toBeUndefined();
-    });
-  });
-
-  describe("isInGroup", () => {
-    it("should return true for instance in group", () => {
-      const instance = createMockInstance();
-      addToGroup(instance, "group1");
-
-      expect(isInGroup(instance)).toBe(true);
-    });
-
-    it("should return false for instance not in any group", () => {
-      const instance = createMockInstance();
-      expect(isInGroup(instance)).toBe(false);
     });
   });
 

--- a/src/core.ts
+++ b/src/core.ts
@@ -17,63 +17,12 @@
  * @deprecated v2.1 起此入口与默认 `react-use-echarts` 入口完全等价（默认入口
  * 也已 modular 化）。请改用默认入口，本别名将在 v4 移除。
  *
+ * Implemented as a single `export *` re-export so the two entries cannot drift:
+ * every value and type exported from `./index` is forwarded verbatim. The
+ * `core.test.ts` drift-guard asserts `Object.keys` parity between the two.
+ * 以单条 `export *` 转发，确保两入口不会分叉；core.test.ts 守卫二者 key 一致。
+ *
  * @packageDocumentation
  */
 
-/**
- * Main hook for using ECharts in React components
- * 在 React 组件中使用 ECharts 的主要 Hook
- */
-export { useEcharts } from "./hooks/use-echarts";
-
-/**
- * Declarative EChart component
- * 声明式 EChart 组件
- */
-export { EChart } from "./components/EChart";
-
-/**
- * Lazy initialization hook
- * 懒加载初始化 Hook
- */
-export { useLazyInit } from "./hooks/use-lazy-init";
-
-/**
- * Type definitions for the library
- * 库的类型定义
- */
-export type {
-  UseEchartsOptions,
-  UseEchartsReturn,
-  UseLazyInitReturn,
-  EChartsEvents,
-  EChartsEventConfig,
-  EChartsEventHandler,
-  EChartsEventPayloadMap,
-  EChartsInitOpts,
-  EChartProps,
-  EChartHandle,
-  BuiltinTheme,
-  LoadingOption,
-  ChartFinder,
-  ChartScaleValue,
-} from "./types";
-
-/**
- * Re-exported ECharts `Payload` type — useful when annotating arguments to
- * the imperative `dispatchAction` returned from `useEcharts`.
- * 转出的 ECharts `Payload` 类型，便于在调用 `dispatchAction` 时显式标注参数。
- */
-export type { Payload } from "echarts/core";
-
-/**
- * Theme utilities (lightweight, no JSON bundled)
- * 主题工具函数（轻量，不含 JSON）
- */
-export { isBuiltinTheme, isKnownTheme, registerCustomTheme } from "./themes";
-
-/**
- * Merge multiple React refs into one callback ref
- * 将多个 React ref 合并为单一 callback ref
- */
-export { mergeRefs } from "./utils/merge-refs";
+export * from "./index";

--- a/src/hooks/internal/use-chart-core.ts
+++ b/src/hooks/internal/use-chart-core.ts
@@ -80,10 +80,16 @@ function resolveThemeName(
 }
 
 function warnZeroSizeContainer(element: HTMLElement): void {
+  // NODE_ENV checks come FIRST so a consumer's production build folds the guard
+  // to `if (true) return;` and dead-code-eliminates the whole dev-only body
+  // (including the warning string). With the `warnedZeroSizeContainers.has(...)`
+  // call leading the `||` chain, minifiers can't prove the early-return is
+  // unconditional and leave the string in the bundle. Order is behavior-neutral
+  // in dev (Set.has is side-effect-free; `||` result is identical).
   if (
-    warnedZeroSizeContainers.has(element) ||
     process.env.NODE_ENV === "production" ||
-    process.env.NODE_ENV === "test"
+    process.env.NODE_ENV === "test" ||
+    warnedZeroSizeContainers.has(element)
   ) {
     return;
   }
@@ -189,8 +195,15 @@ export function useChartCore(
     latestRef.current = { setOptionOpts, onError };
   }
 
+  // Sync the two fields every render via a layout effect — keeps the committed
+  // timing the imperative API depends on (the closure only reads latestRef
+  // post-commit, from event handlers / imperative calls). Mutate the existing
+  // object in place rather than allocating a fresh `{ setOptionOpts, onError }`
+  // each render: the ref identity is stable and never read during render, so
+  // in-place writes are sufficient and save one allocation per render per chart.
   useLayoutEffect(() => {
-    latestRef.current = { setOptionOpts, onError };
+    latestRef.current.setOptionOpts = setOptionOpts;
+    latestRef.current.onError = onError;
   });
 
   // --- Effect-context error routing. `useEffectEvent` reads the latest

--- a/src/utils/connect.ts
+++ b/src/utils/connect.ts
@@ -139,16 +139,6 @@ export function getInstanceGroup(instance: ECharts): string | undefined {
 }
 
 /**
- * Check if instance is in any group
- * 检查实例是否在任何组中
- * @param instance ECharts instance
- * @returns True if in a group
- */
-export function isInGroup(instance: ECharts): boolean {
-  return getInstanceGroup(instance) !== undefined;
-}
-
-/**
  * Clear all groups (for testing/cleanup)
  * 清除所有组（用于测试/清理）
  */

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,6 +8,25 @@ import { playwright } from "vite-plus/test/browser/providers/playwright";
 const repositoryName = process.env.GITHUB_REPOSITORY?.split("/")[1];
 const base = process.env.GITHUB_ACTIONS === "true" && repositoryName ? `/${repositoryName}/` : "/";
 
+// Preserve `process.env.NODE_ENV` references verbatim in the packed bundle
+// instead of inlining the library's own build-time value. The dev-only console
+// warnings in use-chart-core / instance-cache are guarded by
+// `NODE_ENV !== "production"`; without this identity-define the pack build folds
+// those guards to the build-time value (dev), baking the warnings permanently
+// into the shipped bundle so consumers can neither strip them nor silence them
+// in production. Keeping the token lets each consumer's bundler DCE the dev
+// branches in their own production build (and keep them in dev) — the standard
+// library pattern (see Vite "Building for Production › Library Mode").
+//
+// IMPORTANT: keep this scoped to the pack (library) entries below — do NOT
+// hoist it to a top-level `define`, which would also rewrite the examples app
+// (`vp dev`/`vp build`) and leave `process.env.NODE_ENV` undefined at runtime
+// there. Applied uniformly to every JS-logic entry (index, its alias core, and
+// preset-full) — not only the two that emit warnings today — so a dev warning
+// added to any of them later is automatically consumer-strippable instead of
+// silently baked in. themes/registry is pure preset JSON with no guarded code.
+const preserveProcessEnvNodeEnv = { "process.env.NODE_ENV": "process.env.NODE_ENV" };
+
 // https://viteplus.dev/config/
 export default defineConfig({
   base,
@@ -63,6 +82,7 @@ export default defineConfig({
       publint: true,
       attw: { profile: "esm-only" },
       platform: "browser",
+      define: preserveProcessEnvNodeEnv,
       plugins: [babel({ presets: [reactCompilerPreset()] })],
     },
     {
@@ -73,6 +93,7 @@ export default defineConfig({
       format: ["esm"],
       dts: { build: true },
       platform: "browser",
+      define: preserveProcessEnvNodeEnv,
       plugins: [babel({ presets: [reactCompilerPreset()] })],
     },
     {
@@ -87,6 +108,7 @@ export default defineConfig({
       format: ["esm"],
       dts: { build: true },
       platform: "browser",
+      define: preserveProcessEnvNodeEnv,
       plugins: [babel({ presets: [reactCompilerPreset()] })],
     },
   ],


### PR DESCRIPTION
## Summary

An optimization pass driven by a multi-agent analysis (6 dimensions → adversarial verification → synthesis; 40 candidate findings, 7 survived, 4 acted on). All changes are internal/packaging — **no public API changes**.

## Highlight — dev warnings were shipping baked-in & unstrippable

`vp pack` was inlining the library's *build-time* `process.env.NODE_ENV`, folding the `NODE_ENV !== "production"` guards to a constant. Result: the 5 dev-only console warnings in `use-chart-core` / `instance-cache` were **permanently baked into `dist/index.js` (+`core.js`)** — consumers could neither strip them nor silence them in production, and they fired at runtime in prod.

**Fix:** an identity-`define` (`{ "process.env.NODE_ENV": "process.env.NODE_ENV" }`) on the library pack entries preserves the token so each consumer's bundler DCEs the dev branches in their own production build (and keeps them in dev) — the standard library pattern. Verified with a rolldown consumer-prod simulation:

| Consumer build of `dist/index.js` | gzip | dev-warning strings |
|---|---|---|
| `NODE_ENV=development` | 4166 B | 7 |
| `NODE_ENV=production` | 3570 B | 2 (only the intentional `mergeRefs` error logs) |

→ **~596 B gzip + all 5 dev warnings stripped** from every consumer's production bundle. Previously impossible (token was baked).

`warnZeroSizeContainer`'s guard is reordered so the `NODE_ENV` checks lead the `||` chain — otherwise the leading `Set.has()` call blocks minifiers from folding the early-return, leaving the warning string in the bundle.

⚠️ **Tradeoff (approved):** the published bundle now references `process.env.NODE_ENV`, i.e. consumers' bundlers must define it (the React-ecosystem norm; every major bundler does). Faithful to the source guards' original intent. The `define` is **scoped to the library pack entries only** — never hoisted to a top-level `define`, which would break the examples app build.

## Other changes

- **perf(`use-chart-core`):** sync the imperative-API `latestRef` by mutating its two fields in place instead of allocating a fresh object every render — saves one allocation/render/chart while keeping the committed-timing the imperative API relies on (layout effect retained).
- **refactor(`core.ts`):** collapse the deprecated alias (~60 lines of named re-exports) to a single `export * from "./index"`. The existing `core.test.ts` drift-guard already asserts export parity.
- **refactor(`connect`):** remove the unused, non-exported `isInGroup` helper + its two tests (unreachable to consumers — not in the exports map).

## Verification

- `vp check` — format / lint / typecheck clean
- `vp test` — 281 pass / 1 skipped, **100% coverage** (statements/branches/functions/lines)
- `vp pack` — attw + publint pass; `size-limit` all under budget (`index.js` 11.50 / 12 KB)
- Consumer-prod stripping verified via rolldown (vite-plus toolchain; no esbuild in this project)

🤖 Generated with [Claude Code](https://claude.com/claude-code)