### PR TITLE
fix: isolate visibilitychange subscribers; eventsEqual alloc + readonly config

### DIFF
--- a/.changeset/isolate-visibility-faster-events-equal.md
+++ b/.changeset/isolate-visibility-faster-events-equal.md
@@ -1,0 +1,21 @@
+---
+"react-use-echarts": patch
+---
+
+robustness + perf + type hardening:
+
+- visibility-coordinator: isolate each `visibilitychange` subscriber in its own
+  try/catch. The coordinator runs a single shared document listener for every
+  chart, so a callback that throws (e.g. a consumer `onError` that rethrows from
+  the resize path) previously aborted the loop and starved every later chart's
+  foreground resize resync. Mirrors merge-refs' per-callback isolation.
+- event-utils: `eventsEqual` now uses a two-pass key walk (mirroring
+  `shallowEqual`) instead of allocating a key-union `Set` per call. This path
+  runs on every render when `onEvents` is an inline object literal, so the change
+  removes a per-render allocation for charts with inline event handlers.
+  Behavior is identical (verified by the existing eventsEqual suite).
+- types: `EChartsEventConfig`'s object form marks `handler` / `query` / `context`
+  `readonly`, matching the library's `ReadonlyArray` / `ReadonlySet` house style.
+  Compile-time only — no runtime or usage change.
+
+vp check + test green (100% coverage, 282 pass), attw/publint pass, size-limit under budget.

--- a/src/__tests__/utils/visibility-coordinator.test.ts
+++ b/src/__tests__/utils/visibility-coordinator.test.ts
@@ -72,6 +72,42 @@ describe("visibility-coordinator", () => {
     }
   });
 
+  it("isolates a throwing subscriber so later subscribers still fire", () => {
+    const ownDescriptor = Object.getOwnPropertyDescriptor(document, "hidden");
+    let hidden = true;
+    Object.defineProperty(document, "hidden", {
+      configurable: true,
+      get: () => hidden,
+    });
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    try {
+      const throwing = vi.fn(() => {
+        throw new Error("subscriber boom");
+      });
+      const after = vi.fn();
+      // Insertion order = iteration order, so `throwing` runs before `after`.
+      subscribeVisibilityResume(throwing);
+      subscribeVisibilityResume(after);
+
+      hidden = false;
+      // The dispatch itself must not throw, and the throwing subscriber must
+      // not starve the one registered after it.
+      expect(() => document.dispatchEvent(new Event("visibilitychange"))).not.toThrow();
+
+      expect(throwing).toHaveBeenCalledTimes(1);
+      expect(after).toHaveBeenCalledTimes(1);
+      expect(errorSpy).toHaveBeenCalled();
+    } finally {
+      errorSpy.mockRestore();
+      if (ownDescriptor) {
+        Object.defineProperty(document, "hidden", ownDescriptor);
+      } else {
+        delete (document as unknown as { hidden?: boolean }).hidden;
+      }
+    }
+  });
+
   it("__resetForTesting__ detaches an active listener", () => {
     const removeSpy = vi.spyOn(document, "removeEventListener");
 

--- a/src/hooks/internal/event-utils.ts
+++ b/src/hooks/internal/event-utils.ts
@@ -67,15 +67,26 @@ export function eventsEqual(a: EChartsEvents | undefined, b: EChartsEvents | und
   // whose value is `undefined` means "no listener" (bindEvents/unbindEvents
   // both skip it), so `{ click: h }` and `{ click: h, hover: undefined }` must
   // be equivalent — comparing key counts would treat them as different and
-  // trigger a redundant unbind/rebind. The union of keys is walked through
-  // eventConfigEqual, which already treats undefined on either side as equal
-  // to undefined and unequal to any defined config (an absent key reads back
-  // as undefined here, matching an explicit-undefined value).
-  const keys = new Set<string>();
-  if (a) for (const key of Object.keys(a)) keys.add(key);
-  if (b) for (const key of Object.keys(b)) keys.add(key);
-  for (const key of keys) {
-    if (!eventConfigEqual(a?.[key], b?.[key])) return false;
+  // trigger a redundant unbind/rebind. eventConfigEqual already treats
+  // undefined on either side as equal to undefined and unequal to any defined
+  // config (an absent key reads back as undefined, matching an explicit one).
+  //
+  // Two-pass key walk (mirrors shallowEqual) — avoids allocating a key-union
+  // Set on a path that runs every render when `onEvents` is an inline object
+  // literal (the Event Rebinding effect calls this as its dedup fast path).
+  // Pass 1: every key in `a` must match `b` (covers keys present in both).
+  if (a) {
+    for (const key of Object.keys(a)) {
+      if (!eventConfigEqual(a[key], b?.[key])) return false;
+    }
+  }
+  // Pass 2: keys present only in `b` (the `a` side reads back as undefined).
+  // Keys in both were already compared in pass 1, so skip them.
+  if (b) {
+    for (const key of Object.keys(b)) {
+      if (a && Object.prototype.hasOwnProperty.call(a, key)) continue;
+      if (!eventConfigEqual(undefined, b[key])) return false;
+    }
   }
   return true;
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -67,9 +67,9 @@ export type EChartsEventHandler<TParams = unknown> = (params: TParams) => void;
 export type EChartsEventConfig<TParams = unknown> =
   | EChartsEventHandler<TParams>
   | {
-      handler: EChartsEventHandler<TParams>;
-      query?: string | object;
-      context?: object;
+      readonly handler: EChartsEventHandler<TParams>;
+      readonly query?: string | object;
+      readonly context?: object;
     };
 
 /**

--- a/src/utils/visibility-coordinator.ts
+++ b/src/utils/visibility-coordinator.ts
@@ -11,7 +11,17 @@ let attached = false;
 
 function onVisibilityChange(): void {
   if (document.hidden) return;
-  for (const cb of subscribers) cb();
+  // Isolate each subscriber: a throwing callback (e.g. a chart whose consumer
+  // `onError` rethrows from the resize path) must not abort the loop and starve
+  // every other chart's foreground resize resync — they share this one
+  // document listener. Mirrors merge-refs' per-callback try/catch isolation.
+  for (const cb of subscribers) {
+    try {
+      cb();
+    } catch (error) {
+      console.error("react-use-echarts: visibilitychange subscriber threw", error);
+    }
+  }
 }
 
 /**


### PR DESCRIPTION
## 概述

一轮针对成熟代码库的优化：通过多 agent 扫描 6 个维度（perf/bundle/简化/correctness/types/tests）发现并经对抗式验证、再人工复核后,采纳 3 处真实改进。

## 改动

### 1. visibility-coordinator 订阅者错误隔离（correctness，主要修复）
协调器为所有 chart 共用**单个** `document.visibilitychange` listener。此前订阅循环 `for (const cb of subscribers) cb()` 无隔离——某个 chart 的回调抛出（例如消费者 `onError` 从 resize 路径重抛）会**中断整个循环**，饿死其后所有 chart 的前台 resize resync。现为每个回调加 try/catch + `console.error`，与 `merge-refs` 既有的逐回调隔离模式一致。新增隔离测试。

### 2. eventsEqual 去除 Set 分配（perf）
`eventsEqual` 改用 `shallowEqual` 同款双遍历，替代每次调用分配的 key 并集 `Set`。该函数在 `onEvents` 为内联对象字面量时**每帧 render** 都会执行（事件重绑 effect 的去重快路径），故此改动消除了带内联事件处理器的图表的每帧分配。行为完全一致——现有 50+ 断言覆盖全部边界（显式 undefined / null 哨兵 / 简写与完整配置等价等）。

### 3. EChartsEventConfig 加 readonly（types）
对象形式的 `handler`/`query`/`context` 标记 `readonly`，对齐库内 `ReadonlyArray`/`ReadonlySet` 风格。仅编译期，零运行时影响，不改变文档化的公共 API 用法。

## 验证

- `vp check` 全绿（格式 / lint / 类型零问题）
- `vp test`：**282 通过**（+1 隔离测试）/ 1 跳过
- 覆盖率：Statements/Branches/Functions/Lines **均 100%**
- `vp pack`：attw + publint 通过
- size-limit：index/core 11.52 KB（< 12 KB 预算），全部达标
- 已附 patch 级 changeset

🤖 Generated with [Claude Code](https://claude.com/claude-code)