### PR TITLE
docs: document isKnownTheme export; fix zh theme type/default

### DIFF
--- a/README-zh_CN.md
+++ b/README-zh_CN.md
@@ -296,7 +296,7 @@ export default function Page() {
 | 选项            | 类型                                  | 默认值     | 说明                                                                                   |
 | --------------- | ------------------------------------- | ---------- | -------------------------------------------------------------------------------------- |
 | `option`        | `EChartsOption`                       | （必需）   | ECharts 配置选项                                                                       |
-| `theme`         | `string \| object \| null`            | `null`     | 任意已注册主题名或自定义主题对象                                                       |
+| `theme`         | `string \| object`                    | —          | 任意已注册主题名或自定义主题对象                                                       |
 | `renderer`      | `'canvas' \| 'svg'`                   | `'canvas'` | 渲染器类型                                                                             |
 | `lazyInit`      | `boolean \| IntersectionObserverInit` | `false`    | 基于 IntersectionObserver 的懒加载                                                     |
 | `group`         | `string`                              | —          | 图表联动组 ID                                                                          |
@@ -364,7 +364,7 @@ export default function Page() {
 ```tsx
 import { useLazyInit } from "react-use-echarts"; // 独立的懒加载 Hook -> { ref, isInView }
 import { mergeRefs } from "react-use-echarts"; // 将多个 ref 合并为一个 callback ref
-import { isBuiltinTheme, registerCustomTheme } from "react-use-echarts"; // 主题工具（不含 JSON）
+import { isBuiltinTheme, isKnownTheme, registerCustomTheme } from "react-use-echarts"; // 主题工具（不含 JSON）
 import { registerBuiltinThemes } from "react-use-echarts/themes/registry"; // 内置主题 JSON（~20KB）
 import { registerEchartsFull } from "react-use-echarts/preset-full"; // 一行注册全套（参见「注册 ECharts 模块」）
 

--- a/README.md
+++ b/README.md
@@ -365,7 +365,7 @@ Declarative component wrapping `useEcharts`. Accepts all hook options as props p
 ```tsx
 import { useLazyInit } from "react-use-echarts"; // standalone lazy init hook -> { ref, isInView }
 import { mergeRefs } from "react-use-echarts"; // compose multiple refs into one callback ref
-import { isBuiltinTheme, registerCustomTheme } from "react-use-echarts"; // theme utils (no JSON)
+import { isBuiltinTheme, isKnownTheme, registerCustomTheme } from "react-use-echarts"; // theme utils (no JSON)
 import { registerBuiltinThemes } from "react-use-echarts/themes/registry"; // ~20KB theme JSON
 import { registerEchartsFull } from "react-use-echarts/preset-full"; // one-line full-set registrar (see Register ECharts modules)
 


### PR DESCRIPTION
## What

Two doc/code alignment fixes found while auditing README ↔ source ↔ examples. No code changes — examples were already fully aligned.

### 1. `isKnownTheme` was undocumented
`src/index.ts` exports `isBuiltinTheme, isKnownTheme, registerCustomTheme`, but the "Other Exports" snippet in both READMEs listed only the two siblings. Added `isKnownTheme` to both.

### 2. `README-zh_CN` `theme` row was wrong
The Chinese table documented `theme` as `string | object | null` with default `null`. The actual `UseEchartsOptions.theme` type is `BuiltinTheme | (string & {}) | object` — optional, no `null`. This also disagreed with the English README. Aligned to `string | object` / `—`.

## Verification
- `src/index.ts` value exports (7) and type exports (18) now fully covered in both locales.
- `theme` type consistent across code, README.md, and README-zh_CN.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)