### PR TITLE
fix: harden theme registry and chart-group bookkeeping

### DIFF
--- a/src/__tests__/hooks/use-echarts.test.ts
+++ b/src/__tests__/hooks/use-echarts.test.ts
@@ -1138,6 +1138,39 @@ describe("useEcharts", () => {
         expect(onError).toHaveBeenCalledWith(switchError);
       });
     });
+
+    it("should switch group by library intent even if instance.group was tampered with", async () => {
+      const element = document.createElement("div");
+      const mockInstance = createMockInstance(element);
+      (echarts.init as ReturnType<typeof vi.fn>).mockReturnValue(mockInstance);
+
+      const { rerender, result } = renderHook(
+        ({ group }) => useEcharts({ option: baseOption, group }),
+        { initialProps: { group: "g1" } },
+      );
+      act(() => {
+        result.current.ref(element);
+      });
+
+      await waitFor(() => {
+        expect(getGroupInstances("g1")).toContain(mockInstance);
+      });
+
+      // A consumer reaches into the live instance and overwrites the writable
+      // `group` property out from under the hook.
+      (mockInstance as unknown as { group: string }).group = "tampered";
+
+      rerender({ group: "g2" });
+
+      await waitFor(() => {
+        expect(getGroupInstances("g2")).toContain(mockInstance);
+      });
+      // Must have been removed from the group WE assigned ("g1"), not from the
+      // tampered id — otherwise it leaks in g1's bookkeeping. (Reading
+      // instance.group instead of lastGroupRef would removeFromGroup("tampered")
+      // and leave the instance stranded in g1.)
+      expect(getGroupInstances("g1")).not.toContain(mockInstance);
+    });
   });
 
   describe("setOption", () => {

--- a/src/__tests__/themes/index.test.ts
+++ b/src/__tests__/themes/index.test.ts
@@ -172,6 +172,37 @@ describe("themes utilities", () => {
     });
   });
 
+  describe("shared global registry state", () => {
+    it("keeps mutable registry state on a globalThis singleton so duplicate library copies share it", () => {
+      const theme = { color: ["#shared"] };
+      const name = getOrRegisterCustomTheme(theme);
+
+      // A second bundled copy of the library would read this same global key
+      // and continue the same counter sequence instead of restarting at
+      // __custom_theme_0 and colliding in echarts' shared theme registry.
+      const globalState = (globalThis as Record<string, unknown>)[
+        "__react_use_echarts_theme_state__"
+      ] as
+        | {
+            customThemeCounter: number;
+            knownThemeNames: Set<string>;
+            contentHashCache: Map<string, string>;
+          }
+        | undefined;
+
+      expect(globalState).toBeDefined();
+      expect(globalState!.knownThemeNames.has(name)).toBe(true);
+      expect(globalState!.customThemeCounter).toBeGreaterThan(0);
+      expect(globalState!.contentHashCache.size).toBeGreaterThan(0);
+
+      // The state object is a persistent singleton: a further registration
+      // mutates the SAME object (not a freshly recreated one).
+      const counterBefore = globalState!.customThemeCounter;
+      getOrRegisterCustomTheme({ color: ["#shared-2"] });
+      expect(globalState!.customThemeCounter).toBe(counterBefore + 1);
+    });
+  });
+
   describe("__clearThemeCacheForTesting__", () => {
     it("should reset counter so next theme gets __custom_theme_0", () => {
       getOrRegisterCustomTheme({ reset: ["#000"] });

--- a/src/__tests__/utils/connect.test.ts
+++ b/src/__tests__/utils/connect.test.ts
@@ -275,6 +275,43 @@ describe("connect utilities", () => {
     });
   });
 
+  describe("externally-disposed group reclamation", () => {
+    it("reclaims an orphaned group (all members disposed externally) on the next addToGroup", () => {
+      const orphan = createMockInstance();
+      addToGroup(orphan, "orphanGroup");
+      expect(echarts.connect).toHaveBeenCalledWith("orphanGroup");
+
+      // Consumer disposes the instance directly, bypassing removeFromGroup, so
+      // it stays stranded (disposed) in groupMembers["orphanGroup"].
+      orphan.isDisposed.mockReturnValue(true);
+      vi.clearAllMocks();
+
+      // Activity on ANY other group sweeps the orphan: disconnect + drop it.
+      const other = createMockInstance();
+      addToGroup(other, "otherGroup");
+
+      expect(echarts.disconnect).toHaveBeenCalledWith("orphanGroup");
+      expect(getGroupInstances("orphanGroup")).toHaveLength(0);
+
+      // Fully torn down, so re-adding to the same id reconnects.
+      const fresh = createMockInstance();
+      addToGroup(fresh, "orphanGroup");
+      expect(echarts.connect).toHaveBeenCalledWith("orphanGroup");
+    });
+
+    it("does not disconnect a group that still has live members during the sweep", () => {
+      const alive = createMockInstance();
+      addToGroup(alive, "liveGroup");
+      vi.clearAllMocks();
+
+      const other = createMockInstance();
+      addToGroup(other, "otherGroup");
+
+      expect(echarts.disconnect).not.toHaveBeenCalled();
+      expect(getGroupInstances("liveGroup")).toContain(alive);
+    });
+  });
+
   describe("clearGroups", () => {
     it("should disconnect all groups and clear registry", () => {
       const instance1 = createMockInstance();

--- a/src/hooks/internal/use-chart-core.ts
+++ b/src/hooks/internal/use-chart-core.ts
@@ -14,7 +14,7 @@ import {
   setCachedInstance,
   releaseCachedInstance,
 } from "../../utils/instance-cache";
-import { updateGroup, getInstanceGroup } from "../../utils/connect";
+import { updateGroup } from "../../utils/connect";
 import {
   getOrRegisterCustomTheme,
   isBuiltinTheme,
@@ -265,6 +265,11 @@ export function useChartCore(
   const lastBoundRef = useRef<EChartsEvents | undefined>(undefined);
   const lastAppliedRef = useRef<LastApplied | null>(null);
   const lastLoadingRef = useRef<LastLoading | null>(null);
+  // The group this hook last assigned the instance to — the single source of
+  // truth for *our* group intent. Read by the Group Switch effect to dedup
+  // instead of the externally-writable `instance.group`, so a consumer mutating
+  // that property can't desync groupMembers bookkeeping.
+  const lastGroupRef = useRef<string | undefined>(undefined);
 
   // Reactive view of the current instance. Set inside the lifecycle effect
   // after init/share succeeds and cleared on cleanup, so downstream consumers
@@ -382,6 +387,11 @@ export function useChartCore(
         handleEffectError(error, "ECharts group assignment failed:");
       }
     }
+    // Record what this fresh instance was assigned to (including `undefined`),
+    // so the Group Switch effect dedups against our own intent. A structural
+    // recreation captures the latest `group` here; a plain group-prop change
+    // (no recreation) is handled by the Group Switch effect updating this ref.
+    lastGroupRef.current = group;
 
     setLiveInstance(instance);
 
@@ -524,13 +534,23 @@ export function useChartCore(
     const instance = getCachedInstance(element);
     if (!instance) return;
 
-    const currentGroup = getInstanceGroup(instance);
+    // Dedup against the group WE last assigned (lastGroupRef), not the live
+    // instance.group: that property is writable at runtime, so a consumer
+    // mutating it would otherwise make updateGroup removeFromGroup the wrong id
+    // and desync groupMembers. lastGroupRef is our single source of truth.
+    const currentGroup = lastGroupRef.current;
     if (currentGroup === group) return;
 
     try {
       updateGroup(instance, currentGroup, group);
     } catch (error) {
       handleEffectError(error, "ECharts group switch failed:");
+    } finally {
+      // Record the attempt even on failure: updateGroup may have partially
+      // moved the instance before throwing, so lastGroupRef must reflect the
+      // new intent to avoid removeFromGroup-ing a stale id next time (mirrors
+      // the Option-Sync / Loading-Toggle try/finally dedup pattern).
+      lastGroupRef.current = group;
     }
   }, [element, group]);
 

--- a/src/themes/index.ts
+++ b/src/themes/index.ts
@@ -7,46 +7,71 @@ import { resetDevWarnings } from "../utils/dev-warnings";
  * 内置主题名称硬编码集合（不依赖 JSON 数据）
  */
 const BUILTIN_THEME_NAMES: ReadonlySet<string> = new Set<string>(["light", "dark", "macarons"]);
-const REGISTERED_BUILTIN_THEME_NAMES_KEY = "__react_use_echarts_registered_builtin_theme_names__";
 
 /**
- * Names known to be registered via this library's API. Used by `isKnownTheme`
- * for dev-time validation. External `echarts.registerTheme(...)` calls are
- * invisible here — route through `registerCustomTheme` to suppress warnings.
- * 通过本库 API 注册过的主题名。外部直接调用 `echarts.registerTheme` 的名字不会被记录，
- * 若要消除 dev 警告请改用 `registerCustomTheme`。
- */
-const knownThemeNames: Set<string> = new Set<string>();
-type ThemeGlobal = typeof globalThis & {
-  [REGISTERED_BUILTIN_THEME_NAMES_KEY]?: Set<BuiltinTheme>;
-};
-const themeGlobal = globalThis as ThemeGlobal;
-const registeredBuiltinThemeNames: Set<BuiltinTheme> =
-  themeGlobal[REGISTERED_BUILTIN_THEME_NAMES_KEY] ?? new Set<BuiltinTheme>();
-themeGlobal[REGISTERED_BUILTIN_THEME_NAMES_KEY] = registeredBuiltinThemeNames;
-
-/**
- * Cache for custom theme names (theme object -> registered theme name)
- * 自定义主题名称缓存（主题对象 -> 已注册的主题名称）
- * Uses WeakMap to allow garbage collection of theme objects
- */
-const customThemeCache = new WeakMap<object, string>();
-
-/**
- * Content-based cache for custom theme deduplication
- * 基于内容的缓存，用于自定义主题去重
- * Prevents ECharts global registry from growing when different
- * object references carry identical theme content.
- * Capped at MAX_CONTENT_CACHE_SIZE — oldest entries evicted on overflow (FIFO).
+ * Maximum entries kept in the content-hash cache before FIFO eviction.
+ * 内容哈希缓存的上限，超出后按 FIFO 淘汰最旧条目。
  */
 const MAX_CONTENT_CACHE_SIZE = 100;
-const contentHashCache = new Map<string, string>();
+
+const THEME_STATE_KEY = "__react_use_echarts_theme_state__";
 
 /**
- * Counter for generating unique custom theme names
- * 用于生成唯一自定义主题名称的计数器
+ * All mutable theme-registry state, kept in one object so it can live as a
+ * single `globalThis` singleton. echarts' theme registry is a process-wide
+ * singleton, so two bundled copies of this library MUST share this state —
+ * otherwise each keeps its own `customThemeCounter` starting at 0 and both emit
+ * `echarts.registerTheme("__custom_theme_0", ...)` for different objects, the
+ * second silently clobbering the first. Sharing `knownThemeNames` /
+ * `contentHashCache` likewise keeps dev warnings and content dedup coherent
+ * across copies. Extends the rationale that previously kept only the built-in
+ * registration set global.
+ * 所有可变主题状态收进一个对象，作为单一 globalThis 单例。echarts 主题注册表是进程级
+ * 单例，两份打包的库副本必须共享此状态，否则各自的 customThemeCounter 都从 0 开始，会
+ * 向共享注册表写入同名的 `__custom_theme_0`，后者静默覆盖前者；共享 knownThemeNames /
+ * contentHashCache 也让 dev 警告与内容去重在多副本间保持一致。
  */
-let customThemeCounter = 0;
+interface ThemeRegistryState {
+  /** Built-in theme names registered via the registry subpath. */
+  registeredBuiltinThemeNames: Set<BuiltinTheme>;
+  /**
+   * Names known to be registered via this library's API. Used by `isKnownTheme`
+   * for dev-time validation. External `echarts.registerTheme(...)` calls are
+   * invisible here — route through `registerCustomTheme` to suppress warnings.
+   * 通过本库 API 注册过的主题名。外部直接调用 `echarts.registerTheme` 的名字不会被
+   * 记录，若要消除 dev 警告请改用 `registerCustomTheme`。
+   */
+  knownThemeNames: Set<string>;
+  /**
+   * Custom theme name cache (theme object -> registered name). Uses WeakMap to
+   * allow garbage collection of theme objects.
+   * 自定义主题名称缓存（主题对象 -> 已注册名称）；WeakMap 以允许主题对象被回收。
+   */
+  customThemeCache: WeakMap<object, string>;
+  /**
+   * Content-based cache for custom theme deduplication. Prevents ECharts global
+   * registry from growing when different object references carry identical
+   * content. Capped at MAX_CONTENT_CACHE_SIZE — oldest evicted on overflow (FIFO).
+   * 基于内容的去重缓存，避免不同引用、相同内容重复注册；FIFO，上限 100。
+   */
+  contentHashCache: Map<string, string>;
+  /** Monotonic counter for generated custom theme names. */
+  customThemeCounter: number;
+}
+
+type ThemeGlobal = typeof globalThis & {
+  [THEME_STATE_KEY]?: ThemeRegistryState;
+};
+const themeGlobal = globalThis as ThemeGlobal;
+const state: ThemeRegistryState =
+  themeGlobal[THEME_STATE_KEY] ??
+  (themeGlobal[THEME_STATE_KEY] = {
+    registeredBuiltinThemeNames: new Set<BuiltinTheme>(),
+    knownThemeNames: new Set<string>(),
+    customThemeCache: new WeakMap<object, string>(),
+    contentHashCache: new Map<string, string>(),
+    customThemeCounter: 0,
+  });
 
 /**
  * Check if a theme name is a built-in theme
@@ -66,7 +91,7 @@ export function isBuiltinTheme(themeName: string): themeName is BuiltinTheme {
  * `echarts.registerTheme` 注册的名称会返回 `false`。
  */
 export function isKnownTheme(themeName: string): boolean {
-  return BUILTIN_THEME_NAMES.has(themeName) || knownThemeNames.has(themeName);
+  return BUILTIN_THEME_NAMES.has(themeName) || state.knownThemeNames.has(themeName);
 }
 
 /**
@@ -74,14 +99,14 @@ export function isKnownTheme(themeName: string): boolean {
  * Used internally for dev-time warnings without importing preset JSON.
  */
 export function isBuiltinThemeRegistered(themeName: BuiltinTheme): boolean {
-  return registeredBuiltinThemeNames.has(themeName);
+  return state.registeredBuiltinThemeNames.has(themeName);
 }
 
 /**
  * Mark a built-in theme as registered by the optional registry entry.
  */
 export function markBuiltinThemeRegistered(themeName: BuiltinTheme): void {
-  registeredBuiltinThemeNames.add(themeName);
+  state.registeredBuiltinThemeNames.add(themeName);
 }
 
 /**
@@ -92,7 +117,7 @@ export function markBuiltinThemeRegistered(themeName: BuiltinTheme): void {
  */
 export function registerCustomTheme(themeName: string, themeConfig: object): void {
   echarts.registerTheme(themeName, themeConfig);
-  knownThemeNames.add(themeName);
+  state.knownThemeNames.add(themeName);
 }
 
 /**
@@ -114,7 +139,7 @@ export function registerCustomTheme(themeName: string, themeConfig: object): voi
  */
 export function getOrRegisterCustomTheme(themeConfig: object, precomputedHash?: string): string {
   // Fast path: same object reference
-  const cachedName = customThemeCache.get(themeConfig);
+  const cachedName = state.customThemeCache.get(themeConfig);
   if (cachedName) {
     return cachedName;
   }
@@ -131,26 +156,26 @@ export function getOrRegisterCustomTheme(themeConfig: object, precomputedHash?: 
   }
 
   if (contentHash) {
-    const existingName = contentHashCache.get(contentHash);
+    const existingName = state.contentHashCache.get(contentHash);
     if (existingName) {
       // Cache the reference for fast lookup next time
-      customThemeCache.set(themeConfig, existingName);
+      state.customThemeCache.set(themeConfig, existingName);
       return existingName;
     }
   }
 
   // Register new theme
-  const themeName = `__custom_theme_${customThemeCounter++}`;
+  const themeName = `__custom_theme_${state.customThemeCounter++}`;
   echarts.registerTheme(themeName, themeConfig);
-  knownThemeNames.add(themeName);
-  customThemeCache.set(themeConfig, themeName);
+  state.knownThemeNames.add(themeName);
+  state.customThemeCache.set(themeConfig, themeName);
   if (contentHash) {
-    if (contentHashCache.size >= MAX_CONTENT_CACHE_SIZE) {
+    if (state.contentHashCache.size >= MAX_CONTENT_CACHE_SIZE) {
       // Evict oldest entry (first inserted key in Map iteration order)
-      const oldest = contentHashCache.keys().next().value!;
-      contentHashCache.delete(oldest);
+      const oldest = state.contentHashCache.keys().next().value!;
+      state.contentHashCache.delete(oldest);
     }
-    contentHashCache.set(contentHash, themeName);
+    state.contentHashCache.set(contentHash, themeName);
   }
 
   return themeName;
@@ -166,9 +191,9 @@ export function getOrRegisterCustomTheme(themeConfig: object, precomputedHash?: 
  * @internal Test hook; not part of the public API.
  */
 export function __clearThemeCacheForTesting__(): void {
-  contentHashCache.clear();
-  knownThemeNames.clear();
-  registeredBuiltinThemeNames.clear();
-  customThemeCounter = 0;
+  state.contentHashCache.clear();
+  state.knownThemeNames.clear();
+  state.registeredBuiltinThemeNames.clear();
+  state.customThemeCounter = 0;
   resetDevWarnings();
 }

--- a/src/utils/connect.ts
+++ b/src/utils/connect.ts
@@ -37,12 +37,39 @@ function pruneDisposed(group: Set<ECharts>): void {
 }
 
 /**
+ * Best-effort sweep: drop disposed instances from every group and tear down any
+ * left empty (disconnect + bookkeeping). The normal unmount path already cleans
+ * up via leaveGroup, but a consumer that disposes an instance directly
+ * (bypassing the cache) strands it in `groupMembers`; running this on every join
+ * bounds that leak. It can't reclaim a group after ALL group activity stops —
+ * that needs WeakRef/FinalizationRegistry, overkill for a misuse edge case.
+ * 尽力清扫：剔除各组已 dispose 的实例并拆除空组。正常卸载路径已能清理；消费者绕过缓存直接
+ * dispose 会留下孤儿，此清扫把泄漏限定在「应用彻底停止组活动」之前。
+ */
+function sweepDisposedGroups(): void {
+  for (const [groupId, members] of groupMembers) {
+    pruneDisposed(members);
+    if (members.size > 0) continue;
+    // Deleting the current key mid-iteration is safe for a Map; disconnect is
+    // bare like removeFromGroup / clearGroups.
+    groupMembers.delete(groupId);
+    connectedGroupIds.delete(groupId);
+    echarts.disconnect(groupId);
+  }
+}
+
+/**
  * Add chart instance to group
  * 将图表实例添加到组
  * @param instance ECharts instance
  * @param groupId Group ID
  */
 export function addToGroup(instance: ECharts, groupId: string): void {
+  // Reclaim groups orphaned by a cache-bypassing instance.dispose() before we
+  // add (see sweepDisposedGroups). May drop+recreate this groupId, correctly
+  // forcing a fresh echarts.connect below.
+  sweepDisposedGroups();
+
   let members = groupMembers.get(groupId);
   if (!members) {
     members = new Set();


### PR DESCRIPTION
## 背景

起于一次「深入 bug 审查」:通读全部源码 + 三路对抗式 agent 复核,核心逻辑没有可触发的 bug。剩下三条**理论边界**(都需异常前提),按需修复。

## 改动

### 1. theme registry 状态迁 `globalThis` 单例(库副本计数器碰撞)
echarts 主题注册表是进程级单例。原先 `customThemeCounter` 等是模块级,两份打包的库副本各自从 0 计数,会向共享注册表写入同名 `__custom_theme_0` 互相覆盖。现将全部可变状态(`customThemeCounter` / `knownThemeNames` / `contentHashCache` / `customThemeCache`)收进一个 `globalThis` 单例(扩展了原本只有内置主题名走 global 的做法)。

### 2. connect 加 `sweepDisposedGroups`(外部 dispose 孤儿组泄漏)
消费者绕过缓存直接 `instance.dispose()` 会把已 dispose 的实例遗留在 `groupMembers`。新增 best-effort 清扫(在 `addToGroup` 时运行),把泄漏窗口限定在「应用彻底停止一切组活动」之前。注:**非根治**——根治需 WeakRef/FinalizationRegistry,对消费者误用场景属过度设计。

### 3. group switch 用 `lastGroupRef`(`instance.group` 被篡改)
GROUP SWITCH effect 改用库自管的 `lastGroupRef` 作为「当前组」真相源,不再读可被外部写改的 `instance.group`,避免消费者篡改该属性导致 `groupMembers` 失同步。

> 均为内部健壮性改动,**无公共 API 变更**。

## 测试 & 验证
- **+4 回归测试**(`instance.group` tamper 守卫做过反向验证:临时改回旧逻辑,该测试如期失败)
- `vp check` 干净;**291 tests passed**;`vp pack` 的 attw + publint 通过
- **size-limit**:初版改动一度超预算 136 B,根因是*未压缩 dist 保留注释*、新增的双语 JSDoc 过长;精简注释(逻辑不动)后回到 **12.39 kB**(预算 12.5 kB)

🤖 Generated with [Claude Code](https://claude.com/claude-code)