### PR TITLE
docs: fix stale vp commands in CONTRIBUTING; align AGENTS peer dep

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 React hooks & component for Apache ECharts. CSR only — ECharts requires DOM access, no SSR/SSG.
 
-Peer deps: `react` 19.2+ (for stable `useEffectEvent`), `react-dom` 19+, `echarts` 6.x
+Peer deps: `react` 19.2+ (for stable `useEffectEvent`), `react-dom` 19.2+, `echarts` 6.x
 
 Distribution: ESM-only (since 1.3.0). Requires Node.js 22+ on the tooling side.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,22 +19,22 @@ Thanks for your interest in improving `react-use-echarts`!
 ## Development Commands
 
 - `vp dev` – run the Vite dev server with the examples under `examples/`.
-- `vp lint .` – run Oxlint to check for issues.
-- `vp check` – run format + lint + typecheck in one command.
-- `vp run typecheck` – run dedicated TypeScript type validation (`tsc -b`).
-- `vp test` – execute the Vitest suite (watch mode by default).
-- `vp test run --coverage` – generate coverage reports.
+- `vp lint` – run Oxlint to check for issues.
+- `vp check` – run format + lint + typecheck (via tsgolint) in one command.
+- `vp test` – execute the Vitest suite once (single run by default).
+- `vp test watch` – run the suite in watch mode while developing.
+- `vp test --coverage` – generate coverage reports.
 - `vp build` – build the examples application with Vite.
 - `vp pack` – build the library (ESM) and type declarations into `dist/`. Runs `publint` + `attw` automatically.
 
-Run `vp check && vp test run` before opening a pull request. This is the same set of checks we rely on for releases.
+Run `vp check && vp test` before opening a pull request. This is the same set of checks we rely on for releases.
 
 ## Pull Request Guidelines
 
 - Keep each PR focused on a single feature or fix.
 - Update documentation in **both** `README.md` **and** `README-zh_CN.md` (and `examples/`, API comments) when behavior or public APIs change.
 - Add or update tests in `src/__tests__` for any logic changes.
-- Ensure `vp check` and `vp test run` pass locally.
+- Ensure `vp check` and `vp test` pass locally.
 - Describe the motivation, solution, and validation steps in the PR body.
 - **Add a changeset** (`pnpm changeset`) for any user-visible change — pick `patch` for fixes, `minor` for additive features, `major` for breaking changes. Internal-only refactors that don't affect the published API may skip this with a note in the PR description.
 


### PR DESCRIPTION
## What

Fixes outdated/incorrect Vite+ (`vp`) commands in `CONTRIBUTING.md` that contradicted both `CLAUDE.md` and the actual CLI behavior, plus a peer-dep nit in `AGENTS.md`.

## Why

A contributor following `CONTRIBUTING.md` would hit a wall: `vp run typecheck` errors with `Task "typecheck" not found`, and `vp test` is described as watch-by-default when it's actually single-run.

## Changes

**CONTRIBUTING.md**
- Removed nonexistent `vp run typecheck` — typecheck runs inside `vp check` (via tsgolint), not `tsc -b`
- `vp test` is single-run by default since vite-plus 0.1.x (not watch); added a separate `vp test watch` entry
- Switched `vp test run` / `vp test run --coverage` → `vp test` / `vp test --coverage` to match `package.json` + `CLAUDE.md`
- Dropped the stray `.` in `vp lint .`

**AGENTS.md**
- `react-dom` peer dep `19+` → `19.2+` to match `package.json` (`^19.2.0`)

## Validation

Verified against the live CLI (`vp test --help`, `vp run typecheck`, `vp --help`). Docs-only change — no code, no changeset (does not affect the published artifact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)