### PR TITLE
refactor: prune disposed group members in a single pass

### DIFF
--- a/src/utils/connect.ts
+++ b/src/utils/connect.ts
@@ -25,14 +25,15 @@ const groupMembers = new Map<string, Set<ECharts>>();
 const connectedGroupIds = new Set<string>();
 
 function pruneDisposed(group: Set<ECharts>): void {
-  const disposed: ECharts[] = [];
+  // Deleting the current element mid-iteration is spec-safe for a Set (the slot
+  // is tombstoned and the iterator skips it — no missed or revisited entries),
+  // so prune in a single pass. Avoids allocating a scratch array on every call,
+  // and this runs on each group join/leave/query. Same safety relied on by
+  // sweepDisposedGroups' mid-iteration Map delete.
   for (const inst of group) {
     if (inst.isDisposed()) {
-      disposed.push(inst);
+      group.delete(inst);
     }
-  }
-  for (const inst of disposed) {
-    group.delete(inst);
   }
 }
 


### PR DESCRIPTION
## What

`pruneDisposed` (`src/utils/connect.ts`) collected disposed instances into a scratch array, then deleted them in a second loop — allocating an array on **every call**, even in the common "nothing disposed" case.

Deleting the current element mid-iteration is spec-safe for a `Set` (the slot is tombstoned and the iterator skips it — no missed or revisited entries), so we can prune in a single pass with zero allocation.

```diff
 function pruneDisposed(group: Set<ECharts>): void {
-  const disposed: ECharts[] = [];
   for (const inst of group) {
-    if (inst.isDisposed()) {
-      disposed.push(inst);
-    }
-  }
-  for (const inst of disposed) {
-    group.delete(inst);
+    if (inst.isDisposed()) {
+      group.delete(inst);
+    }
   }
 }
```

## Why

- `pruneDisposed` runs on every group **join / leave / `getGroupInstances`** call, so the saving lands on chart-group linkage paths (e.g. a dashboard mounting N linked charts).
- **Behavior is identical** — the same members are removed.
- The same mid-iteration delete safety is **already relied on** by `sweepDisposedGroups` in this module (which deletes Map keys mid-iteration), so this also removes an internal inconsistency.

## Verification

- `vp check` — format / lint / typecheck all pass
- `vp test` — 291 passed, 1 skipped, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)