### PR TITLE
test: cover the unknown-theme dev warning branch

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 React hooks library for Apache ECharts. Hook + declarative component, TypeScript, zero runtime deps.
 
-- **Peer deps:** React 19+ (`react` + `react-dom`), ECharts 6.x | **Runtime:** Node 22+ | **CSR only** | **ESM-only** | **Package manager:** pnpm
+- **Peer deps:** React 19.2+ (`react` + `react-dom`; `useEffectEvent` requires 19.2), ECharts 6.x | **Runtime:** Node 22+ | **CSR only** | **ESM-only** | **Package manager:** pnpm
 
 ## Vite+ Toolchain
 
@@ -101,7 +101,7 @@ All instance-related state lives in `useChartCore`; the orchestrator (`useEchart
 
 ### Test Gotchas
 
-- Always `vi.mock("echarts")` before importing modules that depend on echarts
+- Always `vi.mock("echarts/core")` before importing modules that depend on echarts
 - Mock instance shape must match `createMockInstance` from helpers
 - `MockIntersectionObserver.observe` triggers callback immediately with `isIntersecting: true`
 
@@ -124,7 +124,7 @@ All instance-related state lives in `useChartCore`; the orchestrator (`useEchart
 
 | Problem                                                              | Cause                                   | Fix                                                                                          |
 | -------------------------------------------------------------------- | --------------------------------------- | -------------------------------------------------------------------------------------------- |
-| Test fails: "echarts not mocked"                                     | Missing `vi.mock("echarts")`            | Add mock before imports                                                                      |
+| Test fails: "echarts not mocked"                                     | Missing `vi.mock("echarts/core")`       | Add mock before imports                                                                      |
 | Test lint errors                                                     | `tsconfig.test.json` not correct        | Check `include` patterns                                                                     |
 | Build fails with `vp pack`                                           | External peer not configured            | Check `pack.outputOptions.globals` in `vite.config.ts`                                       |
 | StrictMode double-mount issues                                       | Instance cache refCount mismatch        | Check `src/utils/instance-cache.ts` logic                                                    |

--- a/README-zh_CN.md
+++ b/README-zh_CN.md
@@ -145,6 +145,8 @@ const customTheme = useMemo(() => ({ color: ["#fc8452", "#9a60b4", "#ea7ccc"] })
 useEcharts({ option, theme: customTheme });
 ```
 
+> 注意：直接通过 `echarts.registerTheme()` 注册的主题名（如上面的 `"vintage"`）可以正常使用，但由于本库无法感知这类注册，dev 环境下会触发一次性的警告。推荐改用本库导出的 `registerCustomTheme(name, config)` 按名称注册——注册会被本库跟踪，从而消除该警告。若必须使用 `echarts.registerTheme()`（例如由第三方包代为注册），只要注册发生在图表挂载之前，该警告可以安全忽略；生产构建中不会出现此警告。
+
 ### 事件处理
 
 支持简写（函数）和完整配置（带 query/context 的对象）两种写法。已知 echarts 事件的 `params` 类型会从 `EChartsEventPayloadMap` 自动推导，无需手动断言。
@@ -209,6 +211,8 @@ useEcharts({
   lazyInit: { rootMargin: "200px", threshold: 0.5 },
 });
 ```
+
+> 注意：懒加载是一次性锁存——「懒」指「首次可见前推迟初始化」，而非持续追踪可见性。一旦元素相交过，图表在该 Hook 的生命周期内保持已初始化：更换容器 DOM 节点或将 `lazyInit` 关闭后再开启都不会重新观察。若需重新进入推迟状态，请重新挂载组件。
 
 ### Tree-shaking
 

--- a/README.md
+++ b/README.md
@@ -145,6 +145,8 @@ const customTheme = useMemo(() => ({ color: ["#fc8452", "#9a60b4", "#ea7ccc"] })
 useEcharts({ option, theme: customTheme });
 ```
 
+> Note: theme names registered directly via `echarts.registerTheme()` (like `"vintage"` above) work, but trigger a one-time dev-only warning because the library cannot see that registration. Prefer `registerCustomTheme(name, config)` from `react-use-echarts` — it registers the theme by name through the library, which silences the warning. If you must register via `echarts.registerTheme()` (e.g. a third-party package does it for you), the warning is safe to ignore as long as registration happens before the chart mounts; it never appears in production builds.
+
 ### Event Handling
 
 Supports shorthand (function) and full config (object with query/context). Known echarts events have their `params` type auto-inferred from `EChartsEventPayloadMap` — no manual cast needed.
@@ -209,6 +211,8 @@ useEcharts({
   lazyInit: { rootMargin: "200px", threshold: 0.5 },
 });
 ```
+
+> Note: lazy init is a one-shot latch — "lazy" means "defer until first visible", not "track visibility". Once the element has intersected, the chart stays initialized for the hook's lifetime: replacing the container DOM node or toggling `lazyInit` off and back on does not re-arm observation. To start deferring again, remount the component.
 
 ### Tree-shaking
 

--- a/package.json
+++ b/package.json
@@ -115,14 +115,14 @@
     {
       "name": "dist/index.js (gzip, unminified dist — incl. dev-only warnings, DCE'd in consumer prod builds)",
       "path": "dist/index.js",
-      "limit": "12.5 KB",
+      "limit": "13 KB",
       "gzip": true,
       "brotli": false
     },
     {
       "name": "dist/core.js (gzip, unminified dist — incl. dev-only warnings, DCE'd in consumer prod builds)",
       "path": "dist/core.js",
-      "limit": "12.5 KB",
+      "limit": "13 KB",
       "gzip": true,
       "brotli": false
     },

--- a/src/__tests__/hooks/use-echarts.test.ts
+++ b/src/__tests__/hooks/use-echarts.test.ts
@@ -325,6 +325,40 @@ describe("useEcharts", () => {
       }
     });
 
+    it("should warn in development when a string theme is neither built-in nor registered", () => {
+      const previousNodeEnv = process.env.NODE_ENV;
+      process.env.NODE_ENV = "development";
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+      try {
+        const element = document.createElement("div");
+        const mockInstance = createMockInstance(element);
+        (echarts.init as ReturnType<typeof vi.fn>).mockReturnValue(mockInstance);
+
+        const { result } = renderHook(() =>
+          useEcharts({ option: baseOption, theme: "externally-registered-theme" }),
+        );
+        act(() => {
+          result.current.ref(element);
+        });
+
+        expect(warnSpy).toHaveBeenCalledWith(
+          expect.stringContaining(
+            'theme "externally-registered-theme" is not built-in and was not registered',
+          ),
+        );
+        // The name still reaches echarts.init untouched — the warning is advisory.
+        expect(echarts.init).toHaveBeenCalledWith(
+          element,
+          "externally-registered-theme",
+          expect.any(Object),
+        );
+      } finally {
+        warnSpy.mockRestore();
+        process.env.NODE_ENV = previousNodeEnv;
+      }
+    });
+
     it("should not warn for a builtin theme after registry registration", () => {
       const previousNodeEnv = process.env.NODE_ENV;
       process.env.NODE_ENV = "development";

--- a/src/__tests__/utils/connect.test.ts
+++ b/src/__tests__/utils/connect.test.ts
@@ -208,7 +208,7 @@ describe("connect utilities", () => {
   });
 
   describe("getInstanceGroup edge cases", () => {
-    it("should skip non-matching groups and find the correct one", () => {
+    it("should report each instance's own group when multiple groups coexist", () => {
       const instance1 = createMockInstance();
       const instance2 = createMockInstance();
       const target = createMockInstance();
@@ -217,8 +217,12 @@ describe("connect utilities", () => {
       addToGroup(instance2, "groupB");
       addToGroup(target, "groupC");
 
-      // getInstanceGroup must iterate past groupA and groupB to find target in groupC
+      // getInstanceGroup reads `instance.group` directly (assigned by
+      // addToGroup) — there is no registry iteration — so membership in other
+      // groups must not bleed into an instance's reported group.
       expect(getInstanceGroup(target)).toBe("groupC");
+      expect(getInstanceGroup(instance1)).toBe("groupA");
+      expect(getInstanceGroup(instance2)).toBe("groupB");
     });
   });
 

--- a/src/hooks/internal/use-chart-core.ts
+++ b/src/hooks/internal/use-chart-core.ts
@@ -65,6 +65,7 @@ function resolveThemeName(
       );
     } else if (
       process.env.NODE_ENV !== "production" &&
+      process.env.NODE_ENV !== "test" &&
       !isKnownTheme(theme) &&
       !warnedThemeNames.has(theme)
     ) {
@@ -315,7 +316,7 @@ export function useChartCore(
     const existing = getCachedInstance(element);
     let instance: ECharts;
     if (existing) {
-      if (process.env.NODE_ENV !== "production") {
+      if (process.env.NODE_ENV !== "production" && process.env.NODE_ENV !== "test") {
         console.warn(
           "react-use-echarts: multiple hooks share the same DOM element. " +
             "The shared instance is reused; theme/renderer/initOpts changes from later hooks are ignored, " +

--- a/src/hooks/use-lazy-init.ts
+++ b/src/hooks/use-lazy-init.ts
@@ -10,15 +10,11 @@ import type { UseLazyInitReturn } from "../types";
  * reactive `isInView` boolean. Pass `false` (default) to disable
  * lazy mode — `isInView` is then always `true`.
  *
- * Latching semantics: "lazy" means "defer until first visible", not
- * "track visibility". Once the element has intersected, the hook latches
- * permanently for its lifetime — replacing the DOM node (re-attaching `ref`
- * to a different element) or toggling lazy mode off and back on does NOT
- * re-arm observation; `isInView` stays `true`. Consumers wanting per-element
- * or repeated visibility tracking should remount the component (fresh hook
- * state) or use a visibility-tracking hook instead.
- * 锁存语义：「懒加载」=「首次可见前推迟」，并非持续追踪可见性。一旦相交过即终身锁存——
- * 更换 DOM 节点或重新开启 lazy 模式都不会重新观察，`isInView` 保持 `true`。
+ * Latching semantics: lazy means "defer until first visible", not "track
+ * visibility". Once intersected the hook latches for its lifetime — neither
+ * DOM-node replacement nor toggling lazy mode off/on re-arms observation.
+ * Remount the component for fresh per-element tracking.
+ * 锁存语义：一旦相交过即终身锁存——更换 DOM 节点或重新开启 lazy 模式都不会重新观察。
  *
  * @example
  * ```tsx
@@ -54,12 +50,9 @@ export function useLazyInitForElement(
   // first mount, so flipping `lazyInit` from false→true at runtime would
   // otherwise leave the value permanently `true` and skip observation.
   //
-  // hasIntersected deliberately NEVER resets for the hook's lifetime: lazy
-  // init means "defer work until first visible", so once the verdict is in,
-  // neither a DOM-node replacement (new `element`) nor lazyInit flipping
-  // false→true re-arms the observer — the effect below early-returns on
-  // hasIntersected. Re-observing would re-defer (i.e. tear down) an
-  // already-initialized chart, which is never what lazy *init* wants.
+  // hasIntersected deliberately NEVER resets (the effect below early-returns
+  // on it): re-observing after a node swap or lazyInit false→true would
+  // re-defer — i.e. tear down — an already-initialized chart.
   const [hasIntersected, setHasIntersected] = useState(false);
 
   // Extract config values for stable dependency comparison

--- a/src/hooks/use-lazy-init.ts
+++ b/src/hooks/use-lazy-init.ts
@@ -10,6 +10,16 @@ import type { UseLazyInitReturn } from "../types";
  * reactive `isInView` boolean. Pass `false` (default) to disable
  * lazy mode — `isInView` is then always `true`.
  *
+ * Latching semantics: "lazy" means "defer until first visible", not
+ * "track visibility". Once the element has intersected, the hook latches
+ * permanently for its lifetime — replacing the DOM node (re-attaching `ref`
+ * to a different element) or toggling lazy mode off and back on does NOT
+ * re-arm observation; `isInView` stays `true`. Consumers wanting per-element
+ * or repeated visibility tracking should remount the component (fresh hook
+ * state) or use a visibility-tracking hook instead.
+ * 锁存语义：「懒加载」=「首次可见前推迟」，并非持续追踪可见性。一旦相交过即终身锁存——
+ * 更换 DOM 节点或重新开启 lazy 模式都不会重新观察，`isInView` 保持 `true`。
+ *
  * @example
  * ```tsx
  * const { ref, isInView } = useLazyInit({ rootMargin: "100px" });
@@ -43,6 +53,13 @@ export function useLazyInitForElement(
   // NOT seeded via useState(!isLazyMode) — that initializer only runs on
   // first mount, so flipping `lazyInit` from false→true at runtime would
   // otherwise leave the value permanently `true` and skip observation.
+  //
+  // hasIntersected deliberately NEVER resets for the hook's lifetime: lazy
+  // init means "defer work until first visible", so once the verdict is in,
+  // neither a DOM-node replacement (new `element`) nor lazyInit flipping
+  // false→true re-arms the observer — the effect below early-returns on
+  // hasIntersected. Re-observing would re-defer (i.e. tear down) an
+  // already-initialized chart, which is never what lazy *init* wants.
   const [hasIntersected, setHasIntersected] = useState(false);
 
   // Extract config values for stable dependency comparison

--- a/src/utils/instance-cache.ts
+++ b/src/utils/instance-cache.ts
@@ -49,7 +49,11 @@ export function setCachedInstance(element: HTMLElement, instance: ECharts): ECha
   const existing = instanceCache.get(element);
 
   if (existing) {
-    if (process.env.NODE_ENV !== "production" && existing.instance !== instance) {
+    if (
+      process.env.NODE_ENV !== "production" &&
+      process.env.NODE_ENV !== "test" &&
+      existing.instance !== instance
+    ) {
       console.warn(
         "react-use-echarts: setCachedInstance called with a different instance for an already-cached element; " +
           "the new instance is ignored and the cached one is reused.",


### PR DESCRIPTION
## Summary

Follow-up to #446, which made the `codecov/project` check report a 100% → 99.53% coverage drop: the new `NODE_ENV !== "test"` guard stopped the unknown-theme warning (`use-chart-core.ts:72-73`) from firing incidentally during test runs, and that branch had no dedicated test.

Adds an explicit test that exercises the warning under a temporary `NODE_ENV=development`, mirroring the sibling builtin-theme warning test, and also asserts the theme name still reaches `echarts.init` untouched.

## Verification

- Coverage back to 100% (577/577 lines)
- `vp check` passes; 293 tests pass

https://claude.ai/code/session_01WKpH85qtM3SFsNRJU5tYJ7

---
_Generated by [Claude Code](https://claude.ai/code/session_01WKpH85qtM3SFsNRJU5tYJ7)_