### PR TITLE
chore: dependency updates — fix ws advisory, bump pnpm

### DIFF
--- a/.changeset/lazy-pandas-tap.md
+++ b/.changeset/lazy-pandas-tap.md
@@ -1,0 +1,5 @@
+---
+"react-use-echarts": patch
+---
+
+Dependency maintenance: bump transitive `ws` to 8.21.0 (fixes GHSA-58qx-3vcg-4xpx, moderate — test toolchain only) and update `packageManager` to pnpm 11.5.3. No runtime changes.

--- a/package.json
+++ b/package.json
@@ -144,5 +144,5 @@
   "engines": {
     "node": ">=22.0.0"
   },
-  "packageManager": "pnpm@11.5.1"
+  "packageManager": "pnpm@11.5.3"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2008,18 +2008,6 @@ packages:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
     engines: {node: '>=10'}
 
-  ws@8.20.0:
-    resolution: {integrity: sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==}
-    engines: {node: '>=10.0.0'}
-    peerDependencies:
-      bufferutil: ^4.0.1
-      utf-8-validate: '>=5.0.2'
-    peerDependenciesMeta:
-      bufferutil:
-        optional: true
-      utf-8-validate:
-        optional: true
-
   ws@8.21.0:
     resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
     engines: {node: '>=10.0.0'}
@@ -2823,7 +2811,7 @@ snapshots:
       tinyexec: 1.1.2
       tinyglobby: 0.2.16
       vite: '@voidzero-dev/vite-plus-core@0.1.24(@arethetypeswrong/core@0.18.3)(@types/node@25.9.2)(publint@0.3.21)(typescript@6.0.3)'
-      ws: 8.20.0
+      ws: 8.21.0
     optionalDependencies:
       '@types/node': 25.9.2
       '@vitest/coverage-v8': 4.1.8(@voidzero-dev/vite-plus-test@0.1.24)
@@ -3822,8 +3810,6 @@ snapshots:
       ansi-styles: 4.3.0
       string-width: 4.2.3
       strip-ansi: 6.0.1
-
-  ws@8.20.0: {}
 
   ws@8.21.0: {}
 


### PR DESCRIPTION
## Summary

Dependency check results: all 28 direct devDependencies are already at their latest published versions; the only actionable items were a transitive security fix and a pnpm patch bump.

- **Bump transitive `ws` 8.20.0 → 8.21.0** to fix [GHSA-58qx-3vcg-4xpx](https://github.com/advisories/GHSA-58qx-3vcg-4xpx) (moderate — uninitialized memory disclosure). Lockfile-only change within `@voidzero-dev/vite-plus-test`'s existing `^8.18.3` range; test-toolchain only, no impact on published artifacts. `pnpm audit` is now clean.
- **Bump `packageManager` to pnpm 11.5.3** (patch).

## Verification

- `vp check` — format, lint, typecheck all pass
- `vp test` — 290/290 jsdom unit tests pass (browser-mode tests can't run in this sandbox: Playwright Chromium download is blocked by network policy; unrelated to these changes)
- `pnpm install --frozen-lockfile` verified under pnpm 11.5.3 with no lockfile drift

https://claude.ai/code/session_01PFbHL2Qiq1RgSW22YWmTKs

---
_Generated by [Claude Code](https://claude.ai/code/session_01PFbHL2Qiq1RgSW22YWmTKs)_