### PR TITLE
docs: align test-env docs with happy-dom + browser project

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,7 +53,7 @@ src/
 │   ├── dev-warnings.ts         # Shared dev-mode warning sets (unknown theme, zero-size container)
 │   └── visibility-coordinator.ts # Module-level `document.visibilitychange` coordinator — single shared DOM listener serving all charts (`subscribeVisibilityResume`); attaches on first subscriber, detaches on last
 ├── types/index.ts              # All type definitions
-└── __tests__/                  # Mirror structure: components/, hooks/, themes/, utils/
+└── __tests__/                  # Mirror structure: components/, hooks/, themes/, utils/ + browser/ (real-chromium smoke tests)
 ```
 
 ## Architecture
@@ -93,7 +93,7 @@ All instance-related state lives in `useChartCore`; the orchestrator (`useEchart
 
 ## Testing
 
-- Vitest + jsdom, ECharts API fully mocked
+- Two Vitest projects (`test.projects` in `vite.config.ts`): **`unit`** — happy-dom + ECharts API fully mocked (`src/__tests__/**`, excludes `browser/`); **`browser`** — real chromium via the playwright provider (`src/__tests__/browser/**`), for what happy-dom can't simulate (IntersectionObserver/ResizeObserver + RAF in a real viewport, real layout). Smoke level: assert effects are observable, not exact frame counts.
 - Tests in `src/__tests__/` mirror `src/` layout
 - Shared mocks in `src/__tests__/helpers.ts`: `createMockInstance`, `MockResizeObserver`, `MockIntersectionObserver`
 - Config: `test` block in `vite.config.ts` — `clearMocks` / `mockReset` / `restoreMocks` all enabled

--- a/src/__tests__/browser/lazy-init.test.tsx
+++ b/src/__tests__/browser/lazy-init.test.tsx
@@ -1,6 +1,6 @@
 /**
  * Browser smoke test: lazy initialization triggered by IntersectionObserver.
- * jsdom can't simulate viewport/scroll geometry, so this exercises the real
+ * happy-dom can't simulate viewport/scroll geometry, so this exercises the real
  * IntersectionObserver against a chromium frame.
  *
  * Smoke-level: assert that scrolling the chart into view causes

--- a/src/__tests__/browser/resize.test.tsx
+++ b/src/__tests__/browser/resize.test.tsx
@@ -1,6 +1,6 @@
 /**
  * Browser smoke test: ResizeObserver-driven auto-resize.
- * jsdom doesn't run a real layout, so its ResizeObserver mock can't observe
+ * happy-dom doesn't run a real layout, so its ResizeObserver mock can't observe
  * actual size changes. Real chromium does — this verifies the RAF-throttled
  * resize loop is wired up end-to-end.
  *

--- a/src/__tests__/hooks/use-echarts.test.ts
+++ b/src/__tests__/hooks/use-echarts.test.ts
@@ -2526,7 +2526,7 @@ describe("useEcharts", () => {
         });
 
         // Reset resize calls from initial mount (e.g. from ResizeObserver firing
-        // on observe() in jsdom).
+        // on observe() in happy-dom).
         mockInstance.resize.mockClear();
 
         hiddenValue = true;


### PR DESCRIPTION
## What

Aligns the test-environment documentation with the actual dependency/config reality.

## Why

While checking deps against the docs, the test-environment description was out of sync:

- **`CLAUDE.md` said the unit test env was `jsdom`** — but the actual environment is **`happy-dom`** (`vite.config.ts` → `test.projects[unit].environment`), and there is **no `jsdom` dependency** at all (the project depends on `happy-dom`, recently bumped in #451).
- **The second Vitest project was undocumented** — `vite.config.ts` defines a `browser` project running **real chromium via the playwright provider** (`src/__tests__/browser/**`), covering what happy-dom can't simulate (IntersectionObserver / ResizeObserver + RAF in a real viewport, real layout). Neither the Testing section nor the codebase-structure tree mentioned it.
- **Stale `jsdom` comments** in three test files (`browser/resize.test.tsx`, `browser/lazy-init.test.tsx`, `hooks/use-echarts.test.ts`) referenced jsdom; updated to `happy-dom`.

## Changes

- `CLAUDE.md`: structure tree notes `__tests__/browser/` (real-chromium smoke tests); Testing section now describes both Vitest projects (`unit` = happy-dom + mocked ECharts; `browser` = real chromium via playwright).
- Test-file comments: `jsdom` → `happy-dom`.

Docs/comments only — no code logic or test behavior changes. `grep` confirms zero remaining `jsdom` references in the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)