### PR TITLE
chore: bump actions/checkout to v7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       matrix:
         node: ["22", "24"]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - uses: voidzero-dev/setup-vp@v1
         with:

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -18,7 +18,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - uses: voidzero-dev/setup-vp@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
       NPM_CONFIG_PROVENANCE: "true"
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
## What

Bump `actions/checkout@v6 → @v7` across all three workflows (`ci.yml`, `pages.yml`, `release.yml`).

## Why

`actions/checkout` v7.0.0 (released 2026-06-18) is the current major. Its only breaking change blocks fork-PR checkout for **`pull_request_target`** / **`workflow_run`** events — none of this repo's workflows use those triggers (they run on `pull_request` / `push`), so they are unaffected.

This just gets ahead of the dependabot github-actions weekly batch.

## Verification

- All three workflow triggers reviewed — no `pull_request_target` / `workflow_run` usage.
- v7.0.0 confirmed stable (not a prerelease), full changelog: https://github.com/actions/checkout/compare/v6.0.3...v7.0.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)