### PR TITLE
chore: add release changeset

### DIFF
--- a/.changeset/release-tooling-maintenance.md
+++ b/.changeset/release-tooling-maintenance.md
@@ -1,0 +1,5 @@
+---
+"react-use-echarts": patch
+---
+
+Publish maintenance updates for the Vite+ 0.2 toolchain, CI workflows, and dev dependency metadata.


### PR DESCRIPTION
## Summary
- add a patch changeset for the Vite+ 0.2 toolchain, CI workflow, and dev dependency maintenance updates since v2.2.1

## Validation
- pnpm changeset status
- vp check