### PR TITLE
[codex] docs: align docs and examples

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,12 +29,12 @@ All `useEcharts` options as props + `style` (default `{ width: '100%', height: '
 - `registerBuiltinThemes()` — from `'react-use-echarts/themes/registry'` (separate entry, ~20KB theme JSON)
 - `registerEchartsFull()` — from `'react-use-echarts/preset-full'`; one-line registrar that calls `echarts.use(...)` with every built-in chart, component, renderer and feature. Call once at app entry.
 - `useLazyInit(options)` → `{ ref, isInView }` — standalone lazy-init hook
-- `'react-use-echarts/core'` — **deprecated since v2.1**, plain alias of the default entry (both are now modular). Will be removed in v4.
 
 ## Gotchas
 
 - **Container needs explicit width/height** — chart won't render in a zero-size div
 - **ECharts modules must be registered before first render** — the library is fully modular and does **not** auto-register anything. Call `registerEchartsFull()` (from `'react-use-echarts/preset-full'`) at app entry for an everything-included experience, or call `echarts.use([...])` selectively for tree-shake-friendly builds. Forgetting this shows up as `Renderer 'undefined' is not imported` or a silently blank chart.
+- **Legacy `/core` imports are gone in v3** — use `from 'react-use-echarts'`; the old `react-use-echarts/core` alias was removed.
 - **`option` is reactive** — changes auto-trigger `setOption`, no manual call needed
 - **Custom theme objects must be memoized** — use `useMemo` to avoid instance recreation
 - **`initOpts` changes recreate the instance** — don't pass inline objects

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@ vp install                    # Install dependencies
 vp dev                        # Dev server (localhost:3000, serves examples/)
 vp build                      # Build examples app
 vp pack                       # Library build → dist/
-vp test                       # Single run (default since vite-plus 0.1.x)
+vp test                       # Single run
 vp test watch                 # Watch mode
 vp test --coverage            # Coverage report (v8)
 vp lint                       # Oxlint
@@ -35,8 +35,7 @@ Vite+ 0.2.x bundles **Vite 8 + Rolldown 1.1.1 + Vitest 4.1.9** inside a single `
 
 ```
 src/
-├── index.ts                    # Package entry, re-exports everything. Modular — does NOT side-effect-import "echarts" (since v2.1; previously did, but Rolldown/Oxc DCE breaks that path)
-├── core.ts                     # DEPRECATED alias of index.ts (removed in v4); identical re-exports for v2.0-era `from "react-use-echarts/core"` imports
+├── index.ts                    # Package entry, re-exports everything. Modular — does NOT side-effect-import "echarts" (legacy `/core` subpath was removed in v3)
 ├── preset-full.ts              # `registerEchartsFull()` sugar — one-call namespace-spread of echarts/charts + components + renderers + features, registered via `echarts.use(...)`. Consumer-side replacement for `import "echarts"`.
 ├── components/EChart.tsx       # Declarative component wrapping useEcharts
 ├── hooks/
@@ -117,7 +116,7 @@ All instance-related state lives in `useChartCore`; the orchestrator (`useEchart
 - **Commit format:** `feat|fix|docs|test|refactor|chore: <subject>`
 - **Types-first:** define types in `src/types/index.ts` before implementing
 - **Paired cleanup:** all side effects must have cleanup functions
-- **Build outputs:** `dist/{index,core,preset-full}.js` + `.d.ts` (ESM), `dist/themes/registry.js` + `.d.ts` (theme subpath). `publint` + `attw` (`esm-only` profile) run automatically via `vp pack`.
+- **Build outputs:** `dist/index.js`, `dist/preset-full.js`, and `dist/themes/registry.js` + matching `.d.ts` files (ESM). `publint` + `attw` (`esm-only` profile) run automatically via `vp pack`.
 - **ECharts registration is the consumer's responsibility** — this library does NOT auto-register charts/components/renderers/features. Apps call `registerEchartsFull()` (from `react-use-echarts/preset-full`) for the everything-included path, or `echarts.use([...])` selectively. Mirrors `vue-echarts` / `nuxt-echarts` / `react-chartjs-2`. See `src/preset-full.ts` for the why.
 
 ## Anti-patterns
@@ -125,6 +124,7 @@ All instance-related state lives in `useChartCore`; the orchestrator (`useEchart
 - **DO NOT** create effects without paired cleanup functions
 - **DO NOT** pass un-memoized theme objects (two-level cache is a safety net, not a guarantee)
 - **DO NOT** duplicate API reference from `README.md` into this file
+- **DO NOT** re-add the removed `react-use-echarts/core` subpath — v3 consumers should import from `react-use-echarts`.
 - **DO NOT** re-add `import "echarts"` to `src/index.ts` — production minifiers DCE its top-level `use([...])` registrations. Registration belongs in consumer-side code (their app entry or `registerEchartsFull()`).
 - **DO NOT** add a `vitest` / `@voidzero-dev/vite-plus-test` dependency or override — Vite+ 0.2.x bundles Vitest. A stale `vitest` alias shadows the bundled runner and breaks `vp test` (`Could not find 'vitest' bin entry`).
 

--- a/README-zh_CN.md
+++ b/README-zh_CN.md
@@ -473,7 +473,9 @@ return <div ref={mergeRefs(ref, myRef)} style={{ height: 400 }} />;
 
 ## 从 v2.x 迁移
 
-本库已完全 modular，与 `vue-echarts` / `nuxt-echarts` / `react-chartjs-2` 立场一致。默认入口不会副作用 import `"echarts"`；只需在应用入口**加一行**：
+v3 移除了旧的 `react-use-echarts/core` 子入口。如果你的代码已经从 `react-use-echarts` 导入，并且已经在首个图表渲染前注册 ECharts 模块，则无需改动。
+
+如果你是从 v2.0 的全量默认入口升级，或应用仍依赖 `import "echarts"` 的副作用注册，请在应用入口**加一次注册调用**：
 
 ```ts
 // 应用入口（如 main.tsx, index.tsx）
@@ -481,9 +483,9 @@ import { registerEchartsFull } from "react-use-echarts/preset-full";
 registerEchartsFull();
 ```
 
-该调用与 v2.0 的自动 `import "echarts"` 等价，同样的 ~290KB-gzip 全套体验。生产构建若只渲染少数图表类型，请改用 `echarts.use([...])` 按需注册 —— 参见 [Tree-shaking](#tree-shaking)。
+该调用与 v2.0 的自动 ECharts 注册等价，同样的 ~290KB-gzip 全套体验。生产构建若只渲染少数图表类型，请改用 `echarts.use([...])` 按需注册 —— 参见 [Tree-shaking](#tree-shaking)。
 
-旧的 `react-use-echarts/core` 子入口已移除。它自 v2.1 起只是默认 modular 入口的废弃别名；请把所有 `from "react-use-echarts/core"` 替换为 `from "react-use-echarts"`。
+请把所有残留的 `from "react-use-echarts/core"` 替换为 `from "react-use-echarts"`。
 
 ## 从 v1 迁移
 

--- a/README.md
+++ b/README.md
@@ -475,7 +475,9 @@ Side-by-side example:
 
 ## Migrating from v2.x
 
-The library is fully modular, matching `vue-echarts` / `nuxt-echarts` / `react-chartjs-2`. It does not side-effect-import `"echarts"` from the default entry; add **one line** at your application entry:
+v3 removes the legacy `react-use-echarts/core` subpath. If you already import from `react-use-echarts` and already register ECharts modules before the first chart render, no code changes are needed.
+
+If you are upgrading from v2.0's everything-included default entry, or from an app that still relied on `import "echarts"` side effects, add **one registration call** at your application entry:
 
 ```ts
 // app entry (e.g. main.tsx, index.tsx)
@@ -483,9 +485,9 @@ import { registerEchartsFull } from "react-use-echarts/preset-full";
 registerEchartsFull();
 ```
 
-That call is equivalent to v2.0's automatic `import "echarts"` and gives you the same ~290KB-gzip everything-included experience. For production builds that only render a few chart types, replace it with a selective `echarts.use([...])` — see [Tree-shaking](#tree-shaking).
+That call is equivalent to v2.0's automatic ECharts registration and gives you the same ~290KB-gzip everything-included experience. For production builds that only render a few chart types, replace it with a selective `echarts.use([...])` — see [Tree-shaking](#tree-shaking).
 
-The old `react-use-echarts/core` subpath has been removed. It was only a deprecated alias of the default modular entry since v2.1, so replace any `from "react-use-echarts/core"` imports with `from "react-use-echarts"`.
+Replace any remaining `from "react-use-echarts/core"` imports with `from "react-use-echarts"`.
 
 ## Migrating from v1
 

--- a/examples/components/StatsStrip.tsx
+++ b/examples/components/StatsStrip.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { featureItems } from "../data/features";
 import { CHART_COUNT } from "../data/gallery";
 import { BUNDLE_SIZE } from "../data/meta";
 import styles from "./StatsStrip.module.css";
@@ -16,7 +17,11 @@ const STATS: readonly Stat[] = [
     value: String(CHART_COUNT),
     note: "bar, line, radar, gauge, ohlc, heat, funnel, treemap",
   },
-  { label: "Features", value: "8", note: "themes, renderer, linkage, lazy, events, ref…" },
+  {
+    label: "Features",
+    value: String(featureItems.length),
+    note: "themes, renderer, linkage, lazy, events, ref, errors…",
+  },
   { label: "TypeScript", value: "100%", note: "strict mode · full ECharts option types" },
 ];
 

--- a/examples/pages/FeaturesIndex.tsx
+++ b/examples/pages/FeaturesIndex.tsx
@@ -10,7 +10,7 @@ const FeaturesIndex: React.FC = () => {
       <PageHeader
         eyebrow="Features"
         title="Library capabilities"
-        description="Reactivity, themes, renderer choice, chart linkage, events, loading, ref API, and lazy init — eight things people commonly hand-roll."
+        description={`${featureItems.length} capabilities for common ECharts work: reactivity, themes, renderer choice, chart linkage, events, loading, refs, export flows, lazy init, error handling, and selective registration.`}
         meta={
           <>
             <span>{featureItems.length}</span> features

--- a/examples/pages/GalleryIndex.tsx
+++ b/examples/pages/GalleryIndex.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo, useState } from "react";
 import PageHeader from "./PageHeader";
 import ThumbCard from "../components/ThumbCard";
-import { galleryItems } from "../data/gallery";
+import { CHART_COUNT, galleryItems } from "../data/gallery";
 import { thumbOptions } from "../data/thumbs";
 import styles from "./GalleryIndex.module.css";
 
@@ -24,7 +24,7 @@ const GalleryIndex: React.FC = () => {
     <>
       <PageHeader
         eyebrow="Gallery"
-        title="8 chart types"
+        title={`${CHART_COUNT} chart types`}
         description="Single-component examples for the most common ECharts series. Click any card for full source."
         meta={
           <>

--- a/examples/pages/Home.tsx
+++ b/examples/pages/Home.tsx
@@ -23,8 +23,8 @@ const Home: React.FC = () => (
           <span className={styles.kicker}>Capabilities</span>
           <h2 className={styles.sectionTitle}>Built for real ECharts use</h2>
           <p className={styles.sectionLead}>
-            Eight features cover the gaps people fill manually: reactivity, themes, renderer choice,
-            group linkage, events, loading, ref API, and lazy initialization.
+            {featureItems.length} features cover the gaps people fill manually: reactivity, themes,
+            renderer choice, group linkage, events, loading, ref API, and lazy initialization.
           </p>
         </div>
         <Link to="/features" className={styles.headLink}>


### PR DESCRIPTION
## Summary
- align v3 migration docs around the removed `react-use-echarts/core` subpath
- refresh agent/development docs so build outputs and anti-patterns match the current package exports
- make examples feature/chart counts derive from shared data instead of stale hard-coded copy

## Impact
Documentation now reflects the current v3 package surface, and the examples site is less likely to drift when features or gallery entries change.

## Validation
- `vp check`
- `vp build`