### PR TITLE
[codex] split showcase build output

### DIFF
--- a/.changeset/split-showcase-output.md
+++ b/.changeset/split-showcase-output.md
@@ -1,0 +1,5 @@
+---
+"react-use-echarts": patch
+---
+
+Move the examples/showcase build output to `site-dist/` so it no longer shares `dist/` with the published library build.

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v5
         with:
-          path: ./dist
+          path: ./site-dist
 
   deploy:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ lerna-debug.log*
 
 node_modules
 dist
+site-dist
 dist-ssr
 *.local
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ Project-specific commands:
 ```bash
 vp install                    # Install dependencies
 vp dev                        # Dev server (localhost:3000, serves examples/)
-vp build                      # Build examples app
+vp build                      # Build examples app → site-dist/
 vp pack                       # Library build → dist/
 vp test                       # Single run
 vp test watch                 # Watch mode

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ Thanks for your interest in improving `react-use-echarts`!
 - `vp test` – execute the Vitest suite once (single run by default).
 - `vp test watch` – run the suite in watch mode while developing.
 - `vp test --coverage` – generate coverage reports.
-- `vp build` – build the examples application with Vite.
+- `vp build` – build the examples application with Vite into `site-dist/`.
 - `vp pack` – build the library (ESM) and type declarations into `dist/`. Runs `publint` + `attw` automatically.
 
 Run `vp check && vp test` before opening a pull request. This is the same set of checks we rely on for releases.

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -31,13 +31,16 @@ const preserveProcessEnvNodeEnv = { "process.env.NODE_ENV": "process.env.NODE_EN
 // https://viteplus.dev/config/
 export default defineConfig({
   base,
+  build: {
+    outDir: "site-dist",
+  },
   lint: {
     plugins: ["oxc", "typescript", "unicorn", "react", "promise", "import"],
     categories: {
       correctness: "error",
     },
     env: { builtin: true },
-    ignorePatterns: ["dist", "coverage"],
+    ignorePatterns: ["dist", "site-dist", "coverage"],
     overrides: [
       {
         files: ["**/*.{ts,tsx}"],


### PR DESCRIPTION
## Summary
- move the Vite showcase/example build output from `dist/` to `site-dist/`
- update GitHub Pages artifact upload to publish `site-dist/`
- document the split between `vp build` (`site-dist/`) and `vp pack` (`dist/`)

## Why
`vp build` and `vp pack` were both writing to `dist/`, which made it easy for a docs/example build to replace the library output locally. Splitting the directories keeps the Vite+ library path (`vp pack -> dist/`) clean while keeping the showcase build separate.

## Validation
- `pnpm build`
- `pnpm run pack`
- `pnpm pack --dry-run`
- `pnpm check`
- `pnpm test` (rerun outside sandbox because the browser runner needs a loopback listener)