### PR TITLE
[codex] add patch changeset for 3.0.3

### DIFF
--- a/.changeset/fresh-lamps-repair.md
+++ b/.changeset/fresh-lamps-repair.md
@@ -1,0 +1,5 @@
+---
+"react-use-echarts": patch
+---
+
+Publish maintenance updates for the Vite+ toolchain, pnpm package manager declaration, Shiki packages, and refreshed transitive dependency resolutions.


### PR DESCRIPTION
## Summary

- add a patch changeset for the maintenance updates merged after v3.0.2
- prepare the repository for the Changesets release PR that will bump react-use-echarts to 3.0.3

## Validation

- `vp check`
- `./node_modules/.bin/changeset status --since v3.0.2`
