### PR TITLE
fix: harden chart updates and release gating

### DIFF
--- a/.changeset/steady-chart-updates.md
+++ b/.changeset/steady-chart-updates.md
@@ -1,0 +1,9 @@
+---
+"react-use-echarts": minor
+---
+
+Apply every new `option` reference so nested ECharts data mutations exposed through a
+new top-level object are not skipped by shallow comparison.
+
+Forward native `div` attributes from `<EChart />` to its container, including ARIA,
+data attributes, focus properties, and DOM event handlers.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,9 +21,49 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  quality:
+    if: github.repository == 'chensid/react-use-echarts'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node: ["22", "24"]
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: voidzero-dev/setup-vp@v1
+        with:
+          node-version: ${{ matrix.node }}
+          cache: true
+
+      - name: Install dependencies
+        run: vp install --frozen-lockfile
+
+      - name: Static checks
+        run: vp check
+
+      - name: Build library
+        run: vp pack
+
+      - name: Test with coverage (unit project)
+        run: vp test run --coverage --project unit
+
+      - name: Install Playwright Chromium
+        if: matrix.node == '24'
+        run: vp exec playwright install --with-deps chromium
+
+      - name: Test (browser project)
+        if: matrix.node == '24'
+        run: vp test run --project browser
+
+      - name: Bundle size budget
+        if: matrix.node == '24'
+        run: vp run size
+
   release:
     # Only run on the canonical repo so forks don't try to publish.
     if: github.repository == 'chensid/react-use-echarts'
+    needs: quality
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,7 @@ Options: `option` (required), `theme`, `renderer` (`'canvas'`|`'svg'`), `lazyIni
 
 ### `<EChart />` Component
 
-All `useEcharts` options as props + `style` (default `{ width: '100%', height: '100%' }`), `className`, `ref` (typed `Ref<EChartHandle>` — same imperative surface as `UseEchartsReturn` minus the container `ref` field, which `<EChart>` owns)
+All `useEcharts` options as props + native `div` attributes (`id`, `role`, `aria-*`, `data-*`, DOM events, etc.; excluding `children` and `dangerouslySetInnerHTML`) + `style` (default `{ width: '100%', height: '100%' }`), `className`, `ref` (typed `Ref<EChartHandle>` — same imperative surface as `UseEchartsReturn` minus the container `ref` field, which `<EChart>` owns)
 
 ### Other Exports
 

--- a/README-zh_CN.md
+++ b/README-zh_CN.md
@@ -323,6 +323,10 @@ export default function Page() {
 | `className` | `string`              | —                                   | 容器 CSS 类名                                                                                                     |
 | `ref`       | `Ref<EChartHandle>`   | —                                   | 以 `EChartHandle`（`Omit<UseEchartsReturn, 'ref'>` —— 容器 ref 由 `<EChart>` 自管，不再暴露给外部）暴露命令式 API |
 
+其余原生 `div` 属性会透传到图表容器，包括 `id`、`role`、`aria-*`、`data-*`、
+`tabIndex` 和 DOM 事件。由于 ECharts 自行管理容器内容，`children` 和
+`dangerouslySetInnerHTML` 不被接受；`onError` 仍表示图表错误处理器。
+
 ### `useEcharts(options)`
 
 #### Options
@@ -356,13 +360,13 @@ export default function Page() {
 
 **生命周期 / 更新**
 
-| 方法             | 类型                                                                                 | 说明                                                                                                                 |
-| ---------------- | ------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------- |
-| `setOption`      | `(option: EChartsOption, opts?: SetOptionOpts) => void`                              | 动态更新图表配置                                                                                                     |
-| `dispatchAction` | `(payload: Payload, opt?: boolean \| { silent?: boolean; flush?: boolean }) => void` | 派发 ECharts 动作（`highlight`、`downplay`、`showTip` 等）                                                           |
-| `clear`          | `() => void`                                                                         | 清空当前图表内容                                                                                                     |
-| `resize`         | `(opts?: ResizeOpts) => void`                                                        | 手动触发 resize；`ResizeOpts` 支持 `width`/`height`/`animation`/`silent`                                             |
-| `appendData`     | `(params: { seriesIndex: number; data: ArrayLike<unknown> }) => void`                | 向 series 流式追加数据。带漂移感知：会清掉去重缓存，使下次浅相等但新引用的 `option` rerender 重新调用 setOption 同步 |
+| 方法             | 类型                                                                                 | 说明                                                                                     |
+| ---------------- | ------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------- |
+| `setOption`      | `(option: EChartsOption, opts?: SetOptionOpts) => void`                              | 动态更新图表配置                                                                         |
+| `dispatchAction` | `(payload: Payload, opt?: boolean \| { silent?: boolean; flush?: boolean }) => void` | 派发 ECharts 动作（`highlight`、`downplay`、`showTip` 等）                               |
+| `clear`          | `() => void`                                                                         | 清空当前图表内容                                                                         |
+| `resize`         | `(opts?: ResizeOpts) => void`                                                        | 手动触发 resize；`ResizeOpts` 支持 `width`/`height`/`animation`/`silent`                 |
+| `appendData`     | `(params: { seriesIndex: number; data: ArrayLike<unknown> }) => void`                | 向 series 流式追加数据；会使 prop 同步记录失效，以便下一次相关的响应式更新恢复声明式状态 |
 
 **读取 / 内省**
 
@@ -436,7 +440,7 @@ return <div ref={mergeRefs(ref, myRef)} style={{ height: 400 }} />;
 | `style`                   | `style`                                   | `<EChart />` 默认 `{ width: '100%', height: '100%' }`，父容器仍需显式高度                                                                          |
 | `className`               | `className`                               | 一致                                                                                                                                               |
 | `lazyUpdate`（顶层）      | `setOptionOpts: { lazyUpdate: true }`     | 见 `notMerge` 行                                                                                                                                   |
-| `shouldSetOption`         | 在父组件中自行控制 `option`               | 顶层键自动经 `shallowEqual` 去重；如需自定义判断（深比较、节流、按应用状态门控），请在父组件中 memoize 或跳过 `option` prop                        |
+| `shouldSetOption`         | 在父组件中自行控制 `option`               | 新的 `option` 引用会触发 `setOption`；如需自定义判断（深比较、节流、按应用状态门控），请在父组件中 memoize 或跳过 `option` prop                    |
 | `autoResize`（4.x）       | `autoResize`                              | 默认值同为 `true`；底层使用 ResizeObserver + RAF                                                                                                   |
 | _无_                      | `lazyInit`                                | 新增：容器进入视口时再初始化                                                                                                                       |
 | _无_                      | `group`                                   | 新增：通过组 ID 实现图表联动                                                                                                                       |

--- a/README.md
+++ b/README.md
@@ -324,6 +324,11 @@ Declarative component wrapping `useEcharts`. Accepts all hook options as props p
 | `className` | `string`              | —                                   | Container CSS class                                                                                                              |
 | `ref`       | `Ref<EChartHandle>`   | —                                   | Exposes the imperative API as `EChartHandle` (`Omit<UseEchartsReturn, 'ref'>` — the container ref is owned by `<EChart>` itself) |
 
+All other native `div` attributes are forwarded to the chart container, including `id`,
+`role`, `aria-*`, `data-*`, `tabIndex`, and DOM event handlers. `children` and
+`dangerouslySetInnerHTML` are excluded because ECharts owns the container contents;
+`onError` remains the chart error handler.
+
 ### `useEcharts(options)`
 
 #### Options
@@ -357,13 +362,13 @@ Declarative component wrapping `useEcharts`. Accepts all hook options as props p
 
 **Lifecycle / updates**
 
-| Method           | Type                                                                                 | Description                                                                                                                                           |
-| ---------------- | ------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `setOption`      | `(option: EChartsOption, opts?: SetOptionOpts) => void`                              | Update chart configuration                                                                                                                            |
-| `dispatchAction` | `(payload: Payload, opt?: boolean \| { silent?: boolean; flush?: boolean }) => void` | Dispatch an ECharts action (`highlight`, `downplay`, `showTip`, etc.)                                                                                 |
-| `clear`          | `() => void`                                                                         | Clear current chart content                                                                                                                           |
-| `resize`         | `(opts?: ResizeOpts) => void`                                                        | Manually trigger chart resize. `ResizeOpts` accepts `width`/`height`/`animation`/`silent`                                                             |
-| `appendData`     | `(params: { seriesIndex: number; data: ArrayLike<unknown> }) => void`                | Append data to a series (streaming). Drift-aware: drops dedup memory so a subsequent shallow-equal-but-new-ref `option` rerender re-applies setOption |
+| Method           | Type                                                                                 | Description                                                                                                                               |
+| ---------------- | ------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| `setOption`      | `(option: EChartsOption, opts?: SetOptionOpts) => void`                              | Update chart configuration                                                                                                                |
+| `dispatchAction` | `(payload: Payload, opt?: boolean \| { silent?: boolean; flush?: boolean }) => void` | Dispatch an ECharts action (`highlight`, `downplay`, `showTip`, etc.)                                                                     |
+| `clear`          | `() => void`                                                                         | Clear current chart content                                                                                                               |
+| `resize`         | `(opts?: ResizeOpts) => void`                                                        | Manually trigger chart resize. `ResizeOpts` accepts `width`/`height`/`animation`/`silent`                                                 |
+| `appendData`     | `(params: { seriesIndex: number; data: ArrayLike<unknown> }) => void`                | Append data to a series (streaming). Invalidates prop-sync bookkeeping so the next relevant reactive update can restore declarative state |
 
 **Read / introspect**
 
@@ -424,25 +429,25 @@ return <div ref={mergeRefs(ref, myRef)} style={{ height: 400 }} />;
 
 Most props map 1:1; a few are folded into existing options. Quick reference:
 
-| `echarts-for-react`       | `react-use-echarts`                       | Notes                                                                                                                                                                                  |
-| ------------------------- | ----------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `option`                  | `option`                                  | Same                                                                                                                                                                                   |
-| `theme`                   | `theme`                                   | Same; built-in themes need `registerBuiltinThemes()` first (see [Themes](#themes))                                                                                                     |
-| `notMerge` / `lazyUpdate` | `setOptionOpts: { notMerge, lazyUpdate }` | Folded into a single object passed to `setOption`                                                                                                                                      |
-| `showLoading`             | `showLoading`                             | Same                                                                                                                                                                                   |
-| `loadingOption`           | `loadingOption`                           | Same                                                                                                                                                                                   |
-| `onEvents`                | `onEvents`                                | Same shape; also accepts `{ handler, query?, context? }` for query/context binding                                                                                                     |
-| `onChartReady`            | Subscribe to the reactive `instance`      | `useEffect(() => { if (instance) onReady(instance); }, [instance])` — the returned `instance` is `undefined` before init and re-renders when init/dispose completes                    |
-| `opts.renderer`           | `renderer: 'canvas' \| 'svg'`             | Promoted to a top-level option                                                                                                                                                         |
-| `opts` (rest)             | `initOpts`                                | Same shape (`devicePixelRatio`, `locale`, `width`, `height`, `useDirtyRect`, etc.)                                                                                                     |
-| `style`                   | `style`                                   | `<EChart />` defaults to `{ width: '100%', height: '100%' }` so the parent needs size                                                                                                  |
-| `className`               | `className`                               | Same                                                                                                                                                                                   |
-| `lazyUpdate` (top-level)  | `setOptionOpts: { lazyUpdate: true }`     | See `notMerge` row                                                                                                                                                                     |
-| `shouldSetOption`         | Gate the `option` prop yourself           | Top-level keys are deduped via `shallowEqual` automatically; for custom predicates (deep compare, throttling, app-state gating) memoize/skip the `option` prop in the parent component |
-| `autoResize` (4.x)        | `autoResize`                              | Same default (`true`); resize uses ResizeObserver + RAF                                                                                                                                |
-| _none_                    | `lazyInit`                                | New: defer init until the container scrolls into viewport                                                                                                                              |
-| _none_                    | `group`                                   | New: chart linkage via shared group ID                                                                                                                                                 |
-| _none_                    | `onError`                                 | New: route chart operation errors through a callback (`init`, `setOption`, events, loading, resize, group linkage, and imperative calls)                                               |
+| `echarts-for-react`       | `react-use-echarts`                       | Notes                                                                                                                                                                           |
+| ------------------------- | ----------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `option`                  | `option`                                  | Same                                                                                                                                                                            |
+| `theme`                   | `theme`                                   | Same; built-in themes need `registerBuiltinThemes()` first (see [Themes](#themes))                                                                                              |
+| `notMerge` / `lazyUpdate` | `setOptionOpts: { notMerge, lazyUpdate }` | Folded into a single object passed to `setOption`                                                                                                                               |
+| `showLoading`             | `showLoading`                             | Same                                                                                                                                                                            |
+| `loadingOption`           | `loadingOption`                           | Same                                                                                                                                                                            |
+| `onEvents`                | `onEvents`                                | Same shape; also accepts `{ handler, query?, context? }` for query/context binding                                                                                              |
+| `onChartReady`            | Subscribe to the reactive `instance`      | `useEffect(() => { if (instance) onReady(instance); }, [instance])` — the returned `instance` is `undefined` before init and re-renders when init/dispose completes             |
+| `opts.renderer`           | `renderer: 'canvas' \| 'svg'`             | Promoted to a top-level option                                                                                                                                                  |
+| `opts` (rest)             | `initOpts`                                | Same shape (`devicePixelRatio`, `locale`, `width`, `height`, `useDirtyRect`, etc.)                                                                                              |
+| `style`                   | `style`                                   | `<EChart />` defaults to `{ width: '100%', height: '100%' }` so the parent needs size                                                                                           |
+| `className`               | `className`                               | Same                                                                                                                                                                            |
+| `lazyUpdate` (top-level)  | `setOptionOpts: { lazyUpdate: true }`     | See `notMerge` row                                                                                                                                                              |
+| `shouldSetOption`         | Gate the `option` prop yourself           | A new `option` reference triggers `setOption`; for custom predicates (deep comparison, throttling, app-state gating), memoize or skip the `option` prop in the parent component |
+| `autoResize` (4.x)        | `autoResize`                              | Same default (`true`); resize uses ResizeObserver + RAF                                                                                                                         |
+| _none_                    | `lazyInit`                                | New: defer init until the container scrolls into viewport                                                                                                                       |
+| _none_                    | `group`                                   | New: chart linkage via shared group ID                                                                                                                                          |
+| _none_                    | `onError`                                 | New: route chart operation errors through a callback (`init`, `setOption`, events, loading, resize, group linkage, and imperative calls)                                        |
 
 Side-by-side example:
 

--- a/src/__tests__/components/EChart.test.tsx
+++ b/src/__tests__/components/EChart.test.tsx
@@ -1,11 +1,11 @@
 import { describe, it, expect, vi, beforeEach } from "vite-plus/test";
-import { render } from "@testing-library/react";
+import { fireEvent, render } from "@testing-library/react";
 import { createRef } from "react";
 import * as echarts from "echarts/core";
 import { EChart } from "../../components/EChart";
 import { clearInstanceCache, getCachedInstance } from "../../utils/instance-cache";
 import { clearGroups } from "../../utils/connect";
-import type { EChartHandle } from "../../types";
+import type { EChartHandle, EChartProps } from "../../types";
 import { createMockInstance, MockResizeObserver, MockIntersectionObserver } from "../helpers";
 
 // Mock ECharts
@@ -85,6 +85,57 @@ describe("EChart component", () => {
 
     const div = container.firstChild as HTMLDivElement;
     expect(div.className).toBe("my-chart");
+  });
+
+  it("should forward native div attributes and DOM event handlers", () => {
+    (echarts.init as ReturnType<typeof vi.fn>).mockImplementation((el: HTMLElement) =>
+      createMockInstance(el),
+    );
+    const onClick = vi.fn();
+
+    const { container } = render(
+      <EChart
+        option={{ series: [{ type: "line", data: [1, 2, 3] }] }}
+        id="sales-chart"
+        role="img"
+        aria-label="Quarterly sales"
+        data-chart-kind="line"
+        tabIndex={0}
+        onClick={onClick}
+      />,
+    );
+
+    const div = container.firstChild as HTMLDivElement;
+    expect(div.id).toBe("sales-chart");
+    expect(div.getAttribute("role")).toBe("img");
+    expect(div.getAttribute("aria-label")).toBe("Quarterly sales");
+    expect(div.getAttribute("data-chart-kind")).toBe("line");
+    expect(div.tabIndex).toBe(0);
+
+    fireEvent.click(div);
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("should discard out-of-type container content props at runtime", () => {
+    (echarts.init as ReturnType<typeof vi.fn>).mockImplementation((el: HTMLElement) =>
+      createMockInstance(el),
+    );
+    const UnsafeEChart = EChart as unknown as React.ComponentType<
+      Omit<EChartProps, "children" | "dangerouslySetInnerHTML"> & {
+        children?: React.ReactNode;
+        dangerouslySetInnerHTML?: { __html: string };
+      }
+    >;
+
+    const option = { series: [{ type: "line" as const, data: [1, 2, 3] }] };
+    const first = render(<UnsafeEChart option={option}>unexpected child</UnsafeEChart>);
+    expect((first.container.firstChild as HTMLDivElement).innerHTML).toBe("");
+    first.unmount();
+
+    const second = render(
+      <UnsafeEChart option={option} dangerouslySetInnerHTML={{ __html: "<span>unsafe</span>" }} />,
+    );
+    expect((second.container.firstChild as HTMLDivElement).innerHTML).toBe("");
   });
 
   it("should expose chart methods via ref", () => {

--- a/src/__tests__/hooks/use-echarts.test.ts
+++ b/src/__tests__/hooks/use-echarts.test.ts
@@ -1260,7 +1260,7 @@ describe("useEcharts", () => {
       });
     });
 
-    it("should skip setOption when rerender option is shallow-equal", async () => {
+    it("should apply a new option reference even when it is shallow-equal", async () => {
       const element = document.createElement("div");
       const mockInstance = createMockInstance(element);
       (echarts.init as ReturnType<typeof vi.fn>).mockReturnValue(mockInstance);
@@ -1283,22 +1283,18 @@ describe("useEcharts", () => {
       rerender({ option: option2 });
 
       await waitFor(() => {
-        expect(mockInstance.setOption).toHaveBeenCalledTimes(1);
+        expect(mockInstance.setOption).toHaveBeenCalledTimes(2);
+        expect(mockInstance.setOption).toHaveBeenLastCalledWith(option2, undefined);
       });
     });
 
-    it("should skip setOption for shallow-equal option with multiple top-level keys", async () => {
+    it("should apply nested mutations exposed through a new top-level option reference", async () => {
       const element = document.createElement("div");
       const mockInstance = createMockInstance(element);
       (echarts.init as ReturnType<typeof vi.fn>).mockReturnValue(mockInstance);
 
-      const multiKeyOption: EChartsOption = {
-        xAxis: { type: "category", data: ["Mon", "Tue", "Wed"] },
-        yAxis: { type: "value" },
-        series: [{ type: "line", data: [1, 2, 3] }],
-      };
-      const option1: EChartsOption = { ...multiKeyOption };
-      const option2: EChartsOption = { ...multiKeyOption };
+      const series = [{ type: "line" as const, data: [1, 2, 3] }];
+      const option1: EChartsOption = { series };
 
       const { rerender, result } = renderHook(({ option }) => useEcharts({ option }), {
         initialProps: { option: option1 },
@@ -1311,10 +1307,13 @@ describe("useEcharts", () => {
         expect(mockInstance.setOption).toHaveBeenCalledTimes(1);
       });
 
+      series[0]!.data.push(4);
+      const option2: EChartsOption = { series };
       rerender({ option: option2 });
 
       await waitFor(() => {
-        expect(mockInstance.setOption).toHaveBeenCalledTimes(1);
+        expect(mockInstance.setOption).toHaveBeenCalledTimes(2);
+        expect(mockInstance.setOption).toHaveBeenLastCalledWith(option2, undefined);
       });
     });
 
@@ -1346,7 +1345,7 @@ describe("useEcharts", () => {
         expect(mockInstance.setOption).toHaveBeenCalledTimes(1);
       });
 
-      // Control: changing setOptionOpts value (not shallow-equal) must trigger setOption again
+      // Control: changing setOptionOpts value (not shallow-equal) must trigger setOption again.
       rerender({ option: stableOption, opts: { notMerge: true } });
       await waitFor(() => {
         expect(mockInstance.setOption).toHaveBeenCalledTimes(2);
@@ -1363,12 +1362,13 @@ describe("useEcharts", () => {
 
       const sharedSeries = baseOption.series;
       const propOptionA: EChartsOption = { series: sharedSeries };
-      const propOptionAEqual: EChartsOption = { series: sharedSeries };
       const imperativeOption: EChartsOption = { series: [{ type: "bar", data: [9] }] };
+      const stableOpts = { notMerge: false };
 
-      const { result, rerender } = renderHook(({ option }) => useEcharts({ option }), {
-        initialProps: { option: propOptionA },
-      });
+      const { result, rerender } = renderHook(
+        ({ option, opts }) => useEcharts({ option, setOptionOpts: opts }),
+        { initialProps: { option: propOptionA, opts: stableOpts } },
+      );
       act(() => {
         result.current.ref(element);
       });
@@ -1390,15 +1390,16 @@ describe("useEcharts", () => {
         );
       });
 
-      // 3. Re-render with a fresh prop ref shallow-equal to propOptionA.
-      //    Without the fix: lastAppliedRef stale at A → shallowEqual(A, A_new)
-      //    skips, chart keeps the imperative option (silently wrong).
-      //    With the fix: lastAppliedRef holds the imperative option → diff
-      //    against the new prop → re-applies the prop option, restoring it.
-      rerender({ option: propOptionAEqual });
+      // 3. Re-render with the same prop option and a fresh but shallow-equal
+      //    opts object. Without updating lastAppliedRef, the stable-option fast
+      //    path would skip and leave the imperative option active. Recording B
+      //    makes the option comparison differ and restores declarative A.
+      rerender({ option: propOptionA, opts: { notMerge: false } });
       await waitFor(() => {
         expect(mockInstance.setOption).toHaveBeenCalledTimes(3);
-        expect(mockInstance.setOption).toHaveBeenLastCalledWith(propOptionAEqual, undefined);
+        expect(mockInstance.setOption).toHaveBeenLastCalledWith(propOptionA, {
+          notMerge: false,
+        });
       });
     });
   });
@@ -1719,7 +1720,7 @@ describe("useEcharts", () => {
       }).toThrow("clear boom");
     });
 
-    it("should re-apply prop option after imperative clear when rerender is shallow-equal", async () => {
+    it("should re-apply prop option after imperative clear on the next prop sync", async () => {
       // Without resetting lastAppliedRef inside clear(), the option-sync
       // effect's dedup fast path sees an unchanged option vs lastApplied and
       // skips setOption, leaving the chart blank after clear(). Resetting
@@ -1730,11 +1731,12 @@ describe("useEcharts", () => {
 
       const sharedSeries = baseOption.series;
       const propOptionA: EChartsOption = { series: sharedSeries };
-      const propOptionAEqual: EChartsOption = { series: sharedSeries };
+      const stableOpts = { notMerge: false };
 
-      const { result, rerender } = renderHook(({ option }) => useEcharts({ option }), {
-        initialProps: { option: propOptionA },
-      });
+      const { result, rerender } = renderHook(
+        ({ option, opts }) => useEcharts({ option, setOptionOpts: opts }),
+        { initialProps: { option: propOptionA, opts: stableOpts } },
+      );
       act(() => {
         result.current.ref(element);
       });
@@ -1750,13 +1752,15 @@ describe("useEcharts", () => {
       });
       expect(mockInstance.clear).toHaveBeenCalledTimes(1);
 
-      // 3. Rerender with a fresh ref shallow-equal to propOptionA. The dedup
-      //    fast path would skip without the fix; with the fix lastAppliedRef
-      //    is null, so setOption is invoked again to restore the chart.
-      rerender({ option: propOptionAEqual });
+      // 3. Keep the same option ref, but use a fresh shallow-equal opts wrapper
+      //    to trigger the sync effect. Without clearing lastAppliedRef, the
+      //    stable-option fast path skips; with it cleared, the chart restores.
+      rerender({ option: propOptionA, opts: { notMerge: false } });
       await waitFor(() => {
         expect(mockInstance.setOption).toHaveBeenCalledTimes(2);
-        expect(mockInstance.setOption).toHaveBeenLastCalledWith(propOptionAEqual, undefined);
+        expect(mockInstance.setOption).toHaveBeenLastCalledWith(propOptionA, {
+          notMerge: false,
+        });
       });
     });
   });
@@ -1788,19 +1792,21 @@ describe("useEcharts", () => {
       }).not.toThrow();
     });
 
-    it("should reset dedup memory so a shallow-equal-new-ref rerender re-applies setOption", async () => {
+    it("should reset sync memory so the next relevant prop sync re-applies setOption", async () => {
       // Same drift mechanic as clear(): appendData mutates instance state
-      // outside the declarative option, so the next prop rerender that is
-      // shallow-equal but a new reference must NOT be skipped by dedup.
+      // outside the declarative option, so the next relevant prop sync must
+      // not be skipped by the stable-option fast path.
       const element = document.createElement("div");
       const mockInstance = createMockInstance(element);
       (echarts.init as ReturnType<typeof vi.fn>).mockReturnValue(mockInstance);
 
       const propA = { series: baseOption.series } as EChartsOption;
+      const stableOpts = { notMerge: false };
 
-      const { result, rerender } = renderHook(({ option }) => useEcharts({ option }), {
-        initialProps: { option: propA },
-      });
+      const { result, rerender } = renderHook(
+        ({ option, opts }) => useEcharts({ option, setOptionOpts: opts }),
+        { initialProps: { option: propA, opts: stableOpts } },
+      );
       act(() => {
         result.current.ref(element);
       });
@@ -1813,9 +1819,12 @@ describe("useEcharts", () => {
       });
       expect(mockInstance.appendData).toHaveBeenCalledTimes(1);
 
-      rerender({ option: { series: baseOption.series } });
+      rerender({ option: propA, opts: { notMerge: false } });
       await waitFor(() => {
         expect(mockInstance.setOption).toHaveBeenCalledTimes(2);
+        expect(mockInstance.setOption).toHaveBeenLastCalledWith(propA, {
+          notMerge: false,
+        });
       });
     });
 

--- a/src/components/EChart.tsx
+++ b/src/components/EChart.tsx
@@ -16,11 +16,40 @@ import type { EChartHandle, EChartProps } from "../types";
  */
 export function EChart({
   ref,
+  option,
+  theme,
+  renderer,
+  lazyInit,
+  group,
+  setOptionOpts,
+  showLoading,
+  loadingOption,
+  onEvents,
+  autoResize,
+  initOpts,
+  onError,
   style,
   className,
-  ...options
+  children: _children,
+  dangerouslySetInnerHTML: _dangerouslySetInnerHTML,
+  ...containerProps
 }: EChartProps & { ref?: Ref<EChartHandle> }) {
-  const chart = useEcharts(options);
+  // Runtime JS callers can bypass the TypeScript exclusions; discard both
+  // content-owning props so React never competes with ECharts for this div.
+  const chart = useEcharts({
+    option,
+    theme,
+    renderer,
+    lazyInit,
+    group,
+    setOptionOpts,
+    showLoading,
+    loadingOption,
+    onEvents,
+    autoResize,
+    initOpts,
+    onError,
+  });
   // Strip the container `ref` field from the imperative handle so external
   // callers can't reassign the chart's DOM element via `handle.ref(otherNode)`.
   // The handle only exposes the reactive `instance` + imperative methods.
@@ -30,6 +59,7 @@ export function EChart({
   }, [chart]);
   return (
     <div
+      {...containerProps}
       ref={chart.ref}
       style={{ width: "100%", height: "100%", ...style }}
       className={className}

--- a/src/hooks/internal/use-chart-core.ts
+++ b/src/hooks/internal/use-chart-core.ts
@@ -431,8 +431,10 @@ export function useChartCore(
   // OPTION SYNC
   //
   // Uses lastAppliedRef to skip the first run after the lifecycle effect
-  // (which already applied the same option). shallowEqual prevents
-  // unnecessary setOption when user creates new wrapper objects.
+  // (which already applied the same option). A new option reference always
+  // triggers setOption, even when its top-level keys are shallow-equal: the
+  // caller may have mutated shared nested ECharts data before cloning the
+  // wrapper, and shallow comparison cannot observe that change safely.
   // =====================================================================
   useEffect(() => {
     if (!element) return;
@@ -440,10 +442,11 @@ export function useChartCore(
     if (!instance) return;
 
     const last = lastAppliedRef.current;
-    if (last) {
-      // Fast path: identical refs skip shallowEqual's typeof/keys dispatch
-      if (last.option === option && last.opts === setOptionOpts) return;
-      if (shallowEqual(last.option, option) && shallowEqual(last.opts, setOptionOpts)) return;
+    if (last?.option === option) {
+      // Keep stable option references cheap. setOptionOpts is configuration
+      // metadata rather than chart data, so shallow-equal wrapper objects are
+      // safe to deduplicate here.
+      if (last.opts === setOptionOpts || shallowEqual(last.opts, setOptionOpts)) return;
     }
 
     try {
@@ -562,9 +565,8 @@ export function useChartCore(
   // contract. When the instance throws: with onError, route the error and
   // return the fallback; without onError, rethrow (readers do NOT silently
   // log-and-default — same policy as setOption / dispatchAction). clear()
-  // and appendData() additionally drop lastAppliedRef so a subsequent
-  // shallow-equal prop rerender re-applies setOption (the instance state
-  // has drifted from props).
+  // and appendData() additionally drop lastAppliedRef so a later prop-sync
+  // run re-applies setOption (the instance state has drifted from props).
   //
   // Wrapped in `useMemo([element])` so method identities stay stable across
   // renders for a given container. Mutables (lastAppliedRef, latestRef) are
@@ -600,9 +602,9 @@ export function useChartCore(
       clear: () =>
         withInstance((instance) => {
           instance.clear();
-          // Drop dedup memory: instance is now blank, so a subsequent prop
-          // rerender with a shallow-equal-but-new option ref must re-apply
-          // it instead of being skipped by Option-Sync Effect's fast path.
+          // Drop dedup memory: instance is now blank, so the next relevant
+          // prop-sync run must re-apply it instead of being skipped by the
+          // Option-Sync Effect's stable-option fast path.
           lastAppliedRef.current = null;
         }, undefined),
 
@@ -631,8 +633,8 @@ export function useChartCore(
         withInstance((instance) => {
           instance.appendData(params);
           // appendData drifts the instance from declarative `option`, same as
-          // clear(): drop dedup memory so the next shallow-equal-new-ref
-          // option prop re-applies setOption to resync.
+          // clear(): drop dedup memory so the next relevant option-prop sync
+          // re-applies setOption.
           lastAppliedRef.current = null;
         }, undefined),
     } satisfies Omit<ChartCoreReturn, "instance">;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -16,7 +16,7 @@ import type {
 // EChartsOption is the full pre-composed option type; only the full "echarts"
 // package exports it (echarts/core ships ComposeOption / EChartsCoreOption).
 import type { EChartsOption } from "echarts";
-import type { CSSProperties, RefCallback } from "react";
+import type { ComponentPropsWithoutRef, RefCallback } from "react";
 
 /**
  * Model finder accepted by `convertToPixel` / `convertFromPixel` / `containPixel`.
@@ -473,11 +473,10 @@ export interface UseEchartsReturn {
 
   /**
    * Append data to a series; useful for streaming. After a successful append,
-   * the chart's data has drifted from the declarative `option` — the next
-   * shallow-equal-but-new-reference `option` rerender re-applies setOption to
-   * resync.
+   * prop-sync bookkeeping is invalidated so the next relevant reactive update
+   * can restore the declarative option.
    * 向 series 追加数据，常用于流式更新。追加后内部数据会与声明式 option 偏离，
-   * 下一次浅相等但新引用的 option rerender 会重新应用 setOption 进行同步。
+   * 同步记录会失效，以便下一次相关的响应式更新恢复声明式状态。
    * @see https://echarts.apache.org/en/api.html#echartsInstance.appendData
    */
   appendData: (params: Parameters<ECharts["appendData"]>[0]) => void;
@@ -494,19 +493,21 @@ export interface UseEchartsReturn {
 export type EChartHandle = Omit<UseEchartsReturn, "ref">;
 
 /**
- * Props for the EChart declarative component
- * EChart 声明式组件的属性
+ * Props for the EChart declarative component. Accepts every chart option plus
+ * native `div` attributes such as `id`, `role`, `aria-*`, `data-*`, `tabIndex`
+ * and DOM event handlers. `children` is intentionally excluded because ECharts
+ * owns the container contents; conflicting native names (notably `onError`)
+ * retain their chart-option meaning.
+ *
+ * EChart 声明式组件的属性。除全部图表选项外，也接受 `id`、`role`、`aria-*`、
+ * `data-*`、`tabIndex` 和 DOM 事件等原生 div 属性。由于 ECharts 自行管理容器内容，
+ * `children` 被有意排除；冲突名称（尤其是 `onError`）保持图表选项语义。
  */
-export interface EChartProps extends UseEchartsOptions {
-  /**
-   * Inline style for the container div
-   * 容器 div 的内联样式
-   */
-  style?: CSSProperties;
-
-  /**
-   * CSS class name for the container div
-   * 容器 div 的 CSS 类名
-   */
-  className?: string;
-}
+export type EChartProps = UseEchartsOptions &
+  Omit<
+    ComponentPropsWithoutRef<"div">,
+    keyof UseEchartsOptions | "children" | "dangerouslySetInnerHTML"
+  > & {
+    children?: never;
+    dangerouslySetInnerHTML?: never;
+  };


### PR DESCRIPTION
## Summary
- gate releases behind the full Node 22/24 quality matrix before Changesets can publish
- apply every new `option` reference so nested data changes are not hidden by shallow comparison
- forward safe native `div` attributes from `<EChart />` while excluding container-owned content props
- update English/Chinese docs and add a minor changeset

## Root cause
The release workflow ran independently from CI, option synchronization deduplicated distinct top-level objects using shallow equality, and `<EChart />` separated chart props from its container without forwarding native DOM attributes.

## Validation
- `CI=true vp install --frozen-lockfile`
- `vp check`
- `vp pack` (publint and Are The Types Wrong pass)
- `vp test run --coverage` (292 passed, 1 skipped; 100% statements/branches/functions/lines)
- `pnpm run size` (main entry 12.33 kB gzip, limit 13 kB)
- real Chromium browser project included in the full test run