### PR TITLE
chore: release v3.1.1

### DIFF
--- a/.changeset/quiet-axes-align.md
+++ b/.changeset/quiet-axes-align.md
@@ -1,5 +1,0 @@
----
-"react-use-echarts": patch
----
-
-Correct axis-break event typings so action names are no longer advertised as events, and widen `convertToPixel` input typing to match ECharts coordinate tuples with nested or nullish values.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # react-use-echarts
 
+## 3.1.1
+
+### Patch Changes
+
+- c968606: Correct axis-break event typings so action names are no longer advertised as events, and widen `convertToPixel` input typing to match ECharts coordinate tuples with nested or nullish values.
+
 ## 3.1.0
 
 ### Minor Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-use-echarts",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "private": false,
   "description": "React hooks & component for Apache ECharts — TypeScript, auto-resize, themes, lazy init",
   "keywords": [


### PR DESCRIPTION
## Release

Publish `react-use-echarts@3.1.1`.

### Changes

- correct axis-break event typings so action names are not advertised as events
- widen `convertToPixel` input typing to match ECharts nested/nullish coordinate tuples

### Generated updates

- bump `package.json` from 3.1.0 to 3.1.1
- add the 3.1.1 changelog entry
- consume the release changeset
