### PR TITLE
chore: update pnpm to 11.14.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -134,5 +134,5 @@
   "engines": {
     "node": ">=22.13.0"
   },
-  "packageManager": "pnpm@11.13.0"
+  "packageManager": "pnpm@11.14.0"
 }


### PR DESCRIPTION
## What

Bump the declared package manager from `pnpm@11.13.0` to `pnpm@11.14.0` in `package.json`'s `packageManager` field.

## Why

Dependency-freshness audit (`pnpm outdated` + `npm-check-updates`) found the toolchain otherwise fully up to date — catalog pins (`vite-plus`/`vite`/`vitest` @ 0.2.5 / 4.1.10), `echarts` 6.1.0, React 19.2.7, and all other devDeps are at latest. The only safe update available was this pnpm minor bump. (TypeScript 6→7 is also available but deferred: it's a major, native-compiler release that needs tsgolint compatibility validation.)

## Risk

Low. Only the `packageManager` version declaration changes — no source, dependency ranges, or lockfile content. CI reads the version via corepack from this field; no CI pins reference the old version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011zMiTtHzmufRuhjBKau6nD

---
_Generated by [Claude Code](https://claude.ai/code/session_011zMiTtHzmufRuhjBKau6nD)_