### PR TITLE
chore: bump playwright, size-limit and pnpm

### DIFF
--- a/.changeset/plenty-owls-listen.md
+++ b/.changeset/plenty-owls-listen.md
@@ -1,0 +1,5 @@
+---
+"react-use-echarts": patch
+---
+
+Bump dev dependencies: playwright 1.62.0, size-limit 13.0.1, pnpm 11.17.0. No API changes — size budgets and browser smoke tests verified on the new versions.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,9 +24,9 @@ vp check                      # format + lint + typecheck (typecheck via tsgolin
 
 **Pre-PR checklist:** `vp check && vp test`
 
-### Vite+ 0.2.x toolchain (since #458; aligned to 0.2.5)
+### Vite+ 0.2.x toolchain (since #458; aligned to 0.2.6)
 
-Vite+ 0.2.5 bundles **Vite 8.1.4 + Rolldown 1.1.5 + Vitest 4.1.10 + Oxfmt 0.58.0 + Oxlint 1.73.0 + tsgolint 0.24.0 + tsdown 0.22.7** inside the `vite-plus` toolchain. The separate `@voidzero-dev/vite-plus-test` package is **dead** (no 0.2.x exists). Consequences for dep management:
+Vite+ 0.2.6 bundles **Vite 8.1.5 + Rolldown 1.2.0 + Vitest 4.1.10 + Oxfmt 0.60.0 + Oxlint 1.75.0 + oxlint-tsgolint 7.0.2001 + tsdown 0.22.13** inside the `vite-plus` toolchain (run `vp --version` for the current list — the bundled pins move with every Vite+ release). The separate `@voidzero-dev/vite-plus-test` package is **dead** (no 0.2.x exists). Consequences for dep management:
 
 - Dependency versions live in the root `pnpm-workspace.yaml` `catalog`. `package.json` uses `catalog:` for `vite`, `vite-plus`, `vitest`, `@vitest/browser-playwright`, and `@vitest/coverage-v8`.
 - Keep `pnpm-workspace.yaml` overrides for both `vite` → `@voidzero-dev/vite-plus-core` and `vitest` → the exact bundled Vitest version. This keeps Vite+ internals, browser providers, coverage, and `vp test` on one runner copy.
@@ -96,7 +96,7 @@ All instance-related state lives in `useChartCore`; the orchestrator (`useEchart
 - `eventsEqual` on event rebinding — avoids unnecessary unbind/rebind when inline event objects have identical handlers
 - `setOption` / `showLoading` lifecycle attempts are recorded into `lastAppliedRef` / `lastLoadingRef` via `try/finally` even on failure — Option-Sync / Loading-Toggle dedup against the same (option, opts) pair instead of replaying a known-bad call and double-firing `onError`
 - Memoized return value — `useChartCore` manually wraps its imperative API in `useMemo([element])` (since React Compiler does not memoize this hook); `useEcharts` is compiler-cached, so `{ ref, ...chart }` is stable when `chart` is stable
-- React Compiler enabled via `@vitejs/plugin-react` + `@rolldown/plugin-babel` (`reactCompilerPreset()`). **TODO (native, Babel-free path):** the Rust port of React Compiler landed in oxc v0.135.0 (2026-06-08, oxc-project/oxc#22942), exposed as a `reactCompiler` transform option — still experimental. The **oxc ≥ 0.135 gate is cleared** (Vite+ 0.2.5 bundles Rolldown 1.1.5); the remaining gates are: (1) de-experimentalizing the transform and (2) `@vitejs/plugin-react` exposing it as a first-class option. Once both land, drop `@rolldown/plugin-babel` + `reactCompilerPreset()` (and `@babel/core`) in favor of the native transform. No upstream date is committed — watch oxc release notes, the `@vitejs/plugin-react` changelog, and the Vite+ changelog.
+- React Compiler enabled via `@vitejs/plugin-react` + `@rolldown/plugin-babel` (`reactCompilerPreset()`). **TODO (native, Babel-free path):** the Rust port of React Compiler landed in oxc v0.135.0 (2026-06-08, oxc-project/oxc#22942), exposed as a `reactCompiler` transform option — still experimental. The **oxc ≥ 0.135 gate is cleared** (Vite+ 0.2.6 bundles Rolldown 1.2.0); the remaining gates are: (1) de-experimentalizing the transform and (2) `@vitejs/plugin-react` exposing it as a first-class option. Once both land, drop `@rolldown/plugin-babel` + `reactCompilerPreset()` (and `@babel/core`) in favor of the native transform. No upstream date is committed — watch oxc release notes, the `@vitejs/plugin-react` changelog, and the Vite+ changelog.
 - `<EChart>` imperative handle exposes `EChartHandle = Omit<UseEchartsReturn, "ref">` — `ref` is intentionally stripped so external callers cannot reassign the container via `handle.ref(otherNode)`
 
 ## Testing

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "@rolldown/plugin-babel": "^0.2.3",
     "@shikijs/langs": "^4.3.1",
     "@shikijs/themes": "^4.3.1",
-    "@size-limit/file": "^12.1.0",
+    "@size-limit/file": "^13.0.1",
     "@testing-library/react": "^16.3.2",
     "@types/node": "^26.1.1",
     "@types/react": "^19.2.17",
@@ -91,13 +91,13 @@
     "babel-plugin-react-compiler": "^1.0.0",
     "echarts": "^6.1.0",
     "happy-dom": "^20.11.1",
-    "playwright": "^1.61.1",
+    "playwright": "^1.62.0",
     "publint": "^0.3.22",
     "react": "^19.2.8",
     "react-dom": "^19.2.8",
     "react-router-dom": "^7.18.1",
     "shiki": "^4.3.1",
-    "size-limit": "^12.1.0",
+    "size-limit": "^13.0.1",
     "typescript": "~6.0.3",
     "vite": "catalog:",
     "vite-plus": "catalog:",
@@ -134,5 +134,5 @@
   "engines": {
     "node": ">=22.13.0"
   },
-  "packageManager": "pnpm@11.15.1"
+  "packageManager": "pnpm@11.17.0"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -43,8 +43,8 @@ importers:
         specifier: ^4.3.1
         version: 4.3.1
       '@size-limit/file':
-        specifier: ^12.1.0
-        version: 12.1.0(size-limit@12.1.0)
+        specifier: ^13.0.1
+        version: 13.0.1(size-limit@13.0.1)
       '@testing-library/react':
         specifier: ^16.3.2
         version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -62,7 +62,7 @@ importers:
         version: 6.0.4(@rolldown/plugin-babel@0.2.3(@babel/core@8.0.1)(@babel/runtime@7.29.7)(@voidzero-dev/vite-plus-core@0.2.6(@arethetypeswrong/core@0.18.5)(@types/node@26.1.1)(publint@0.3.22)(typescript@6.0.3))(rolldown@1.1.4))(@voidzero-dev/vite-plus-core@0.2.6(@arethetypeswrong/core@0.18.5)(@types/node@26.1.1)(publint@0.3.22)(typescript@6.0.3))(babel-plugin-react-compiler@1.0.0)
       '@vitest/browser-playwright':
         specifier: 'catalog:'
-        version: 4.1.10(@voidzero-dev/vite-plus-core@0.2.6(@arethetypeswrong/core@0.18.5)(@types/node@26.1.1)(publint@0.3.22)(typescript@6.0.3))(playwright@1.61.1)(vitest@4.1.10)
+        version: 4.1.10(@voidzero-dev/vite-plus-core@0.2.6(@arethetypeswrong/core@0.18.5)(@types/node@26.1.1)(publint@0.3.22)(typescript@6.0.3))(playwright@1.62.0)(vitest@4.1.10)
       '@vitest/coverage-v8':
         specifier: 'catalog:'
         version: 4.1.10(@vitest/browser@4.1.10)(vitest@4.1.10)
@@ -76,8 +76,8 @@ importers:
         specifier: ^20.11.1
         version: 20.11.1
       playwright:
-        specifier: ^1.61.1
-        version: 1.61.1
+        specifier: ^1.62.0
+        version: 1.62.0
       publint:
         specifier: ^0.3.22
         version: 0.3.22
@@ -94,8 +94,8 @@ importers:
         specifier: ^4.3.1
         version: 4.3.1
       size-limit:
-        specifier: ^12.1.0
-        version: 12.1.0
+        specifier: ^13.0.1
+        version: 13.0.1
       typescript:
         specifier: ~6.0.3
         version: 6.0.3
@@ -777,11 +777,11 @@ packages:
     resolution: {integrity: sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==}
     engines: {node: '>=10'}
 
-  '@size-limit/file@12.1.0':
-    resolution: {integrity: sha512-eGwDcIufnNnvJRzv3liDOn6MAOGgmOTUdpeGQ2KuRTlgIgO54AJH1ilvktlJc6PIjNfwpYY0dOGyap1QgM1swQ==}
+  '@size-limit/file@13.0.1':
+    resolution: {integrity: sha512-qdbGUxRAjym5gnkYEjsNsdOfmkDUvDX06FLhLGUxQ0oJtIWDd2lsOmTMwh5JuAV1XmJCplbqpMJ2b5eIhHl7Lg==}
     engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
     peerDependencies:
-      size-limit: 12.1.0
+      size-limit: 13.0.1
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
@@ -1834,14 +1834,14 @@ packages:
     resolution: {integrity: sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==}
     engines: {node: '>=6'}
 
-  playwright-core@1.61.1:
-    resolution: {integrity: sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==}
-    engines: {node: '>=18'}
+  playwright-core@1.62.0:
+    resolution: {integrity: sha512-nsNRyq0r2zsG8AcRHWknc9QRA5XCueC7gWMrs+Gx2tlZn9hcl8zudfh00lhJPY1DE7NmZ6bDsT9g2yey8mXljA==}
+    engines: {node: '>=20'}
     hasBin: true
 
-  playwright@1.61.1:
-    resolution: {integrity: sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==}
-    engines: {node: '>=18'}
+  playwright@1.62.0:
+    resolution: {integrity: sha512-Z14dG305dgaLu6foB1TXQagFiW8JfSUIUaUuPaKQ6NtBPKF1P/qXcqfh6c6K/icPqdy37JmjbiBXf6JNg6Sylw==}
+    engines: {node: '>=20'}
     hasBin: true
 
   pngjs@7.0.0:
@@ -1978,15 +1978,10 @@ packages:
     resolution: {integrity: sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==}
     engines: {node: '>=18'}
 
-  size-limit@12.1.0:
-    resolution: {integrity: sha512-VnDS2fycANrJFVPQwjaD+h+hkISY7EB3LsPsYWje4lBCjQwwsZLxjwwRwVJKHrcj2ZqyG+DdXykWm9mbZklZrw==}
-    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+  size-limit@13.0.1:
+    resolution: {integrity: sha512-LKWgnVUfw79W5gcKGIHqjEqBMoZ+YgfYYzlDheYwbRJq1DaaRgOjotFm61YOI/4hbgh4V1Es0uGGp6HLktI3Vw==}
+    engines: {node: ^22.18.0 || ^24.0.0 || >=26.0.0}
     hasBin: true
-    peerDependencies:
-      jiti: ^2.0.0
-    peerDependenciesMeta:
-      jiti:
-        optional: true
 
   skin-tone@2.0.0:
     resolution: {integrity: sha512-kUMbT1oBJCpgrnKoSr0o6wPtvRWT9W9UKvGLwfJYO2WuahZRHOpEyL1ckyMGgMWh0UdpmaoFqKKD29WTomNEGA==}
@@ -2848,9 +2843,9 @@ snapshots:
 
   '@sindresorhus/is@4.6.0': {}
 
-  '@size-limit/file@12.1.0(size-limit@12.1.0)':
+  '@size-limit/file@13.0.1(size-limit@13.0.1)':
     dependencies:
-      size-limit: 12.1.0
+      size-limit: 13.0.1
 
   '@standard-schema/spec@1.1.0': {}
 
@@ -2939,11 +2934,11 @@ snapshots:
       '@rolldown/plugin-babel': 0.2.3(@babel/core@8.0.1)(@babel/runtime@7.29.7)(@voidzero-dev/vite-plus-core@0.2.6(@arethetypeswrong/core@0.18.5)(@types/node@26.1.1)(publint@0.3.22)(typescript@6.0.3))(rolldown@1.1.4)
       babel-plugin-react-compiler: 1.0.0
 
-  '@vitest/browser-playwright@4.1.10(@voidzero-dev/vite-plus-core@0.2.6(@arethetypeswrong/core@0.18.5)(@types/node@26.1.1)(publint@0.3.22)(typescript@6.0.3))(playwright@1.61.1)(vitest@4.1.10)':
+  '@vitest/browser-playwright@4.1.10(@voidzero-dev/vite-plus-core@0.2.6(@arethetypeswrong/core@0.18.5)(@types/node@26.1.1)(publint@0.3.22)(typescript@6.0.3))(playwright@1.62.0)(vitest@4.1.10)':
     dependencies:
       '@vitest/browser': 4.1.10(@voidzero-dev/vite-plus-core@0.2.6(@arethetypeswrong/core@0.18.5)(@types/node@26.1.1)(publint@0.3.22)(typescript@6.0.3))(vitest@4.1.10)
       '@vitest/mocker': 4.1.10(@voidzero-dev/vite-plus-core@0.2.6(@arethetypeswrong/core@0.18.5)(@types/node@26.1.1)(publint@0.3.22)(typescript@6.0.3))
-      playwright: 1.61.1
+      playwright: 1.62.0
       tinyrainbow: 3.1.0
       vitest: 4.1.10(@types/node@26.1.1)(@vitest/browser-playwright@4.1.10)(@vitest/browser-preview@4.1.10)(@vitest/coverage-v8@4.1.10)(@voidzero-dev/vite-plus-core@0.2.6(@arethetypeswrong/core@0.18.5)(@types/node@26.1.1)(publint@0.3.22)(typescript@6.0.3))(happy-dom@20.11.1)
     transitivePeerDependencies:
@@ -3761,11 +3756,11 @@ snapshots:
 
   pify@4.0.1: {}
 
-  playwright-core@1.61.1: {}
+  playwright-core@1.62.0: {}
 
-  playwright@1.61.1:
+  playwright@1.62.0:
     dependencies:
-      playwright-core: 1.61.1
+      playwright-core: 1.62.0
     optionalDependencies:
       fsevents: 2.3.2
 
@@ -3908,13 +3903,12 @@ snapshots:
       mrmime: 2.0.1
       totalist: 3.0.1
 
-  size-limit@12.1.0:
+  size-limit@13.0.1:
     dependencies:
       bytes-iec: 3.1.1
       lilconfig: 3.1.3
       nanospinner: 1.2.2
       picocolors: 1.1.1
-      tinyglobby: 0.2.17
 
   skin-tone@2.0.0:
     dependencies:
@@ -4069,7 +4063,7 @@ snapshots:
       oxlint-tsgolint: 7.0.2001
       vitest: 4.1.10(@types/node@26.1.1)(@vitest/browser-playwright@4.1.10)(@vitest/browser-preview@4.1.10)(@vitest/coverage-v8@4.1.10)(@voidzero-dev/vite-plus-core@0.2.6(@arethetypeswrong/core@0.18.5)(@types/node@26.1.1)(publint@0.3.22)(typescript@6.0.3))(happy-dom@20.11.1)
     optionalDependencies:
-      '@vitest/browser-playwright': 4.1.10(@voidzero-dev/vite-plus-core@0.2.6(@arethetypeswrong/core@0.18.5)(@types/node@26.1.1)(publint@0.3.22)(typescript@6.0.3))(playwright@1.61.1)(vitest@4.1.10)
+      '@vitest/browser-playwright': 4.1.10(@voidzero-dev/vite-plus-core@0.2.6(@arethetypeswrong/core@0.18.5)(@types/node@26.1.1)(publint@0.3.22)(typescript@6.0.3))(playwright@1.62.0)(vitest@4.1.10)
       '@voidzero-dev/vite-plus-darwin-arm64': 0.2.6
       '@voidzero-dev/vite-plus-darwin-x64': 0.2.6
       '@voidzero-dev/vite-plus-linux-arm64-gnu': 0.2.6
@@ -4133,7 +4127,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 26.1.1
-      '@vitest/browser-playwright': 4.1.10(@voidzero-dev/vite-plus-core@0.2.6(@arethetypeswrong/core@0.18.5)(@types/node@26.1.1)(publint@0.3.22)(typescript@6.0.3))(playwright@1.61.1)(vitest@4.1.10)
+      '@vitest/browser-playwright': 4.1.10(@voidzero-dev/vite-plus-core@0.2.6(@arethetypeswrong/core@0.18.5)(@types/node@26.1.1)(publint@0.3.22)(typescript@6.0.3))(playwright@1.62.0)(vitest@4.1.10)
       '@vitest/browser-preview': 4.1.10(@voidzero-dev/vite-plus-core@0.2.6(@arethetypeswrong/core@0.18.5)(@types/node@26.1.1)(publint@0.3.22)(typescript@6.0.3))(vitest@4.1.10)
       '@vitest/coverage-v8': 4.1.10(@vitest/browser@4.1.10)(vitest@4.1.10)
       happy-dom: 20.11.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,8 +9,10 @@ minimumReleaseAgeExclude:
   - "@arethetypeswrong/cli@0.18.5"
   - "@arethetypeswrong/core@0.18.5"
   - "@vitejs/plugin-react@6.0.4"
-  - playwright-core@1.61.1
-  - playwright@1.61.1
+  - playwright-core@1.62.0
+  - playwright@1.62.0
+  - "@size-limit/file@13.0.1"
+  - size-limit@13.0.1
   - "@types/node@26.1.1"
   - "@shikijs/core@4.3.1"
   - "@shikijs/engine-javascript@4.3.1"


### PR DESCRIPTION
## Summary

例行依赖检查后的可更新项。所有已在 latest 的包（vite-plus 0.2.6 / vitest 4.1.10 / react 19.2.8 / echarts 6.1.0 / @types/* 等 20 个）不动。

| 包 | 变更 | 性质 |
|---|---|---|
| `playwright` | 1.61.1 → 1.62.0 | minor（chromium 151.0.7922.34） |
| `size-limit` + `@size-limit/file` | 12.1.0 → 13.0.1 | **major** |
| `pnpm` (`packageManager`) | 11.15.1 → 11.17.0 | minor |

### size-limit 13 的两点说明

- changelog 很小：移除 Node 20 支持、去掉 `tinyglobby` + `jiti` 依赖、加 npm provenance。13.0.0 发布失败已撤，直接上 13.0.1。
- `engines` 收紧为 `^22.18.0 || ^24.0.0 || >=26.0.0`，略窄于本仓库的 `engines.node >=22.13.0`。这是 dev-only 工具，CI 的 node matrix 用 `22`（取 22.x 最新）与 `24`，均满足；**未改动 `engines.node`**，以免缩小 consumer 的兼容面。
- gzip 预算三项数值与 12.x 完全一致：`dist/index.js` 12.35 kB / `themes/registry.js` 2.45 kB / `preset-full.js` 989 B。

### 顺带修正文档

`CLAUDE.md` 的 "Vite+ 0.2.x toolchain" 段落还停留在 0.2.5 的旧版本表（#502 升到 0.2.6 时漏更），已刷新为实际 bundled 版本：Vite 8.1.5、Rolldown 1.2.0、Oxfmt 0.60.0、Oxlint 1.75.0、oxlint-tsgolint 7.0.2001、tsdown 0.22.13，并补一句"以 `vp --version` 为准"。React Compiler 原生路径 TODO 里的 Rolldown 版本一并对齐。

### TypeScript 保持 ~6.0.3

7.0.2 的 dts-emit 门槛自 #502 实测以来无变化（`vp check` 过、`vp pack` 的 `.d.ts` 生成仍失败，tsgo 无稳定 API），本次不动。

## Test plan

- [x] `vp check` — 132 文件格式通过，89 文件无 lint/type 错误
- [x] `vp test` — 294 passed / 1 skipped（skip 项为既有的 `visibility.test.tsx` browser 用例）
- [x] `vp test --project browser` — 真实 chromium 151 下 2 passed，验证 playwright 1.62 provider 正常
- [x] `vp pack` — attw + publint 均无问题
- [x] `pnpm size` — size-limit 13 下三项预算全过

🤖 Generated with [Claude Code](https://claude.com/claude-code)