### PR TITLE
chore: prune matured minimumReleaseAgeExclude entries

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,37 +5,15 @@ overrides:
 allowBuilds:
   esbuild: true
 
+# pnpm applies a built-in 24h `minimumReleaseAge` gate. In its default loose mode it
+# auto-appends any version younger than that to this list and proceeds, so entries
+# accumulate on their own. Once a listed version is older than 24h its entry is a no-op
+# and can be deleted; only keep versions still inside the window, because
+# `vp install --frozen-lockfile` (CI) re-validates the lockfile against the gate and
+# aborts with ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION on an unexcluded immature version.
 minimumReleaseAgeExclude:
-  - "@arethetypeswrong/cli@0.18.5"
-  - "@arethetypeswrong/core@0.18.5"
-  - "@vitejs/plugin-react@6.0.4"
   - playwright-core@1.62.0
   - playwright@1.62.0
-  - "@size-limit/file@13.0.1"
-  - size-limit@13.0.1
-  - "@types/node@26.1.1"
-  - "@shikijs/core@4.3.1"
-  - "@shikijs/engine-javascript@4.3.1"
-  - "@shikijs/engine-oniguruma@4.3.1"
-  - "@shikijs/langs@4.3.1"
-  - "@shikijs/primitive@4.3.1"
-  - "@shikijs/themes@4.3.1"
-  - "@shikijs/types@4.3.1"
-  - shiki@4.3.1
-  - react-router-dom@7.18.1
-  - react-router@7.18.1
-  - "@voidzero-dev/vite-plus-core@0.2.4 || 0.2.5 || 0.2.6"
-  - "@voidzero-dev/vite-plus-darwin-arm64@0.2.4 || 0.2.5 || 0.2.6"
-  - "@voidzero-dev/vite-plus-darwin-x64@0.2.4 || 0.2.5 || 0.2.6"
-  - "@voidzero-dev/vite-plus-linux-arm64-gnu@0.2.4 || 0.2.5 || 0.2.6"
-  - "@voidzero-dev/vite-plus-linux-arm64-musl@0.2.4 || 0.2.5 || 0.2.6"
-  - "@voidzero-dev/vite-plus-linux-x64-gnu@0.2.4 || 0.2.5 || 0.2.6"
-  - "@voidzero-dev/vite-plus-linux-x64-musl@0.2.4 || 0.2.5 || 0.2.6"
-  - "@voidzero-dev/vite-plus-win32-arm64-msvc@0.2.4 || 0.2.5 || 0.2.6"
-  - "@voidzero-dev/vite-plus-win32-x64-msvc@0.2.4 || 0.2.5 || 0.2.6"
-  - vite-plus@0.2.4 || 0.2.5 || 0.2.6
-  - react-dom@19.2.8
-  - react@19.2.8
 catalog:
   vite: npm:@voidzero-dev/vite-plus-core@0.2.6
   vitest: 4.1.10


### PR DESCRIPTION
## Summary

`pnpm-workspace.yaml` 的 `minimumReleaseAgeExclude` 攒到了 30 条，绝大多数已是 no-op。**30 → 2 条。**

### 机制（之前理解有误，这里记录清楚）

pnpm 11 有**内置的 24 小时 `minimumReleaseAge` 门槛**，默认走 loose 模式：解析到发布不满 24 小时的版本时，它会**自动把该版本追加进 `minimumReleaseAgeExclude`** 然后让安装继续。所以这个列表是 pnpm 自己攒出来的、只增不减 —— 这也解释了为什么本仓库没有 `minimumReleaseAge` 字段却有一长串 exclude（`vite-plus` 的 migrator 反而只在显式设置了 `minimumReleaseAge` 时才会往里加，因此它一条都没写过）。

一旦某条对应的版本超过 24 小时，该条就变成 no-op，可以删。

### 逐条按发布时间判定，而非凭感觉

拿 registry 的 `time` 字段算出每条对应版本距 cutoff 的年龄：

| 条目 | 年龄 | 处置 |
|---|---|---|
| `playwright@1.62.0`、`playwright-core@1.62.0` | **18.0h** | **保留** |
| `size-limit@13.0.1`、`@size-limit/file@13.0.1` | 26.5h | 删 |
| `vite-plus@0.2.6` + 9 × `@voidzero-dev/vite-plus-*` | 57.5h | 删 |
| `@vitejs/plugin-react@6.0.4` | 83.7h | 删 |
| `react@19.2.8`、`react-dom@19.2.8` | 96.3h | 删 |
| `@arethetypeswrong/{cli,core}@0.18.5` | 377.5h | 删 |
| `@types/node@26.1.1` | 417.2h | 删 |
| `shiki` + 7 × `@shikijs/*@4.3.1` | 530.1h | 删 |
| `react-router@7.18.1`、`react-router-dom@7.18.1` | 621.2h | 删 |

`playwright{,-core}@1.62.0`（#504 引入）必须留：CI 跑 `vp install --frozen-lockfile`，它会把 lockfile 里每个版本重新过一遍门槛。

顺便加了注释，说明这个列表为什么会自己长大、以及一条什么时候可以安全删除 —— 免得下次又要重新推一遍机制。

## Test plan

- [x] `vp install --frozen-lockfile` — 460 条策略**重新**验证通过（policy 变更使缓存 verdict 失效，实测 4.5s 真跑），`pnpm-lock.yaml` 零变动
- [x] **反向对照**：把 playwright 两条也删掉后 `vp install --frozen-lockfile` 如预期失败，报 `ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION`，pnpm 打印的 cutoff 为 `2026-07-24T15:58:25Z`（正好 24 小时前）—— 门槛值与"必须保留这两条"均被实证，随后已恢复
- [x] `vp check` — 133 文件格式通过，89 文件零 lint/type 错误

无 changeset：纯 dev 配置改动，不影响发布产物。

🤖 Generated with [Claude Code](https://claude.com/claude-code)