### PR TITLE
docs: align documentation with current implementation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@ Distribution: ESM-only (since 1.3.0). Requires Node.js 22.13+ on the tooling sid
 
 ### `useEcharts(options)` → `{ ref, instance, setOption, resize, ... }`
 
-Options: `option` (required), `theme`, `renderer` (`'canvas'`|`'svg'`), `lazyInit`, `group`, `setOptionOpts`, `showLoading`, `loadingOption`, `onEvents`, `autoResize` (default `true`), `initOpts`, `onError`
+Options: `option` (required), `theme`, `renderer` (`'canvas'`|`'svg'`, default `'canvas'`), `lazyInit` (default `false`), `group`, `setOptionOpts`, `showLoading` (default `false`), `loadingOption`, `onEvents`, `autoResize` (default `true`), `initOpts`, `onError`
 
 - `ref` — `RefCallback<HTMLDivElement>` to attach to the container
 - `instance` — `ECharts | undefined` (reactive — defined after init, undefined before/after dispose)
@@ -28,7 +28,7 @@ All `useEcharts` options as props + native `div` attributes (`id`, `role`, `aria
 - `mergeRefs(...refs)` — compose multiple refs (RefObject or RefCallback) into one callback ref; isolates throws per-ref so a misbehaving 3rd-party ref can't strand the chart
 - `registerBuiltinThemes()` — from `'react-use-echarts/themes/registry'` (separate entry, ~20KB theme JSON)
 - `registerEchartsFull()` — from `'react-use-echarts/preset-full'`; one-line registrar that calls `echarts.use(...)` with every built-in chart, component, renderer and feature. Call once at app entry.
-- `useLazyInit(options)` → `{ ref, isInView }` — standalone lazy-init hook
+- `useLazyInit(options)` → `{ ref, isInView }` — standalone lazy-init hook; enabled mode defaults to `rootMargin: '50px'` and `threshold: 0.1`
 
 ## Gotchas
 

--- a/README-zh_CN.md
+++ b/README-zh_CN.md
@@ -231,6 +231,10 @@ useEcharts({
 });
 ```
 
+启用懒加载后，未提供的观察器配置默认使用 `root: null`、
+`rootMargin: "50px"` 和 `threshold: 0.1`。独立导出的 `useLazyInit(options)`
+使用相同默认值，并返回自己的 `{ ref, isInView }` callback-ref 组合。
+
 > 注意：懒加载是一次性锁存——「懒」指「首次可见前推迟初始化」，而非持续追踪可见性。一旦元素相交过，图表在该 Hook 的生命周期内保持已初始化：更换容器 DOM 节点或将 `lazyInit` 关闭后再开启都不会重新观察。若需重新进入推迟状态，请重新挂载组件。
 
 ### Tree-shaking
@@ -342,7 +346,7 @@ export default function Page() {
 | `group`         | `string`                              | —          | 图表联动组 ID                                                                                       |
 | `setOptionOpts` | `SetOptionOpts`                       | —          | `setOption` 的默认选项                                                                              |
 | `showLoading`   | `boolean`                             | `false`    | 是否显示加载指示器                                                                                  |
-| `loadingOption` | `object`                              | —          | 加载指示器配置                                                                                      |
+| `loadingOption` | `LoadingOption`                       | —          | 加载指示器配置                                                                                      |
 | `onEvents`      | `EChartsEvents`                       | —          | 事件处理器（`fn` 或 `{ handler, query?, context? }`）                                               |
 | `autoResize`    | `boolean`                             | `true`     | 通过 ResizeObserver 自动 resize                                                                     |
 | `initOpts`      | `EChartsInitOpts`                     | —          | 传递给 `echarts.init()`（devicePixelRatio、locale 等）                                              |

--- a/README.md
+++ b/README.md
@@ -231,6 +231,11 @@ useEcharts({
 });
 ```
 
+When lazy mode is enabled, omitted observer settings default to `root: null`,
+`rootMargin: "50px"`, and `threshold: 0.1`. The standalone `useLazyInit(options)`
+export uses the same defaults and returns its own `{ ref, isInView }`
+callback-ref pair.
+
 > Note: lazy init is a one-shot latch — "lazy" means "defer until first visible", not "track visibility". Once the element has intersected, the chart stays initialized for the hook's lifetime: replacing the container DOM node or toggling `lazyInit` off and back on does not re-arm observation. To start deferring again, remount the component.
 
 ### Tree-shaking
@@ -344,7 +349,7 @@ All other native `div` attributes are forwarded to the chart container, includin
 | `group`         | `string`                              | —          | Chart linkage group ID                                                                                                                       |
 | `setOptionOpts` | `SetOptionOpts`                       | —          | Default options for `setOption` calls                                                                                                        |
 | `showLoading`   | `boolean`                             | `false`    | Show loading indicator                                                                                                                       |
-| `loadingOption` | `object`                              | —          | Loading indicator configuration                                                                                                              |
+| `loadingOption` | `LoadingOption`                       | —          | Loading indicator configuration                                                                                                              |
 | `onEvents`      | `EChartsEvents`                       | —          | Event handlers (`fn` or `{ handler, query?, context? }`)                                                                                     |
 | `autoResize`    | `boolean`                             | `true`     | Auto-resize via ResizeObserver                                                                                                               |
 | `initOpts`      | `EChartsInitOpts`                     | —          | Passed to `echarts.init()` (devicePixelRatio, locale, width, etc.)                                                                           |

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -156,7 +156,7 @@ export interface EChartsEvents extends KnownEChartsEvents {
 export interface UseLazyInitReturn {
   /** Callback ref to attach to the element you want to lazily initialize. */
   ref: RefCallback<Element>;
-  /** Whether the element is currently in (or past) the viewport. */
+  /** Whether eager mode is active or the element has intersected at least once. */
   isInView: boolean;
 }
 
@@ -180,13 +180,13 @@ export type EChartsInitOpts = Omit<RawEChartsInitOpts, "renderer" | "ssr">;
 export interface LoadingOption {
   /** Loading text. Default: 'loading' */
   text?: string;
-  /** Loading animation color. Default: '#c23531' */
+  /** Loading animation color. ECharts 6.1 default: '#5070dd' */
   color?: string;
-  /** Text color. Default: '#000' */
+  /** Text color. ECharts 6.1 default: '#3c3c41' */
   textColor?: string;
-  /** Mask background color. Default: 'rgba(255, 255, 255, 0.8)' */
+  /** Mask background color. Default: 'rgba(255,255,255,0.8)' */
   maskColor?: string;
-  /** Z-level of the loading component */
+  /** Z-level of the loading component. Default: 0 */
   zlevel?: number;
   /** Font size. Default: 12 */
   fontSize?: number;
@@ -196,11 +196,11 @@ export interface LoadingOption {
   spinnerRadius?: number;
   /** Spinner line width. Default: 5 */
   lineWidth?: number;
-  /** Font weight */
+  /** Font weight. Default: 'normal' */
   fontWeight?: string | number;
-  /** Font style */
+  /** Font style. Default: 'normal' */
   fontStyle?: string;
-  /** Font family */
+  /** Font family. Default: 'sans-serif' */
   fontFamily?: string;
   /** Extensibility for custom loading types */
   [key: string]: unknown;
@@ -244,6 +244,7 @@ export interface UseEchartsOptions {
   /**
    * Lazy initialization: only init when container enters viewport
    * 懒加载：仅当容器进入视口时初始化
+   * @default false
    */
   lazyInit?: boolean | IntersectionObserverInit;
 


### PR DESCRIPTION
## Summary

- document the actual lazy-init observer defaults and latching semantics in the English and Chinese READMEs
- use the public `LoadingOption` type in the API tables and correct its ECharts 6.1 default-value documentation
- align the agent API quick reference with the implementation defaults

## Why

The implementation had moved ahead of parts of the documentation: lazy-init fallback settings were implicit, `loadingOption` was described only as `object`, and loading colors still reflected older ECharts defaults. This keeps the published API docs and generated declaration comments consistent with the current code.

## Impact

Documentation and type-comment corrections only; there is no runtime behavior change.

## Validation

- `CI=true vp install --frozen-lockfile`
- `vp check`
- `vp pack` (publint + attw)
- `vp test run --coverage` — 294 passed, 1 skipped, 100% coverage
- `vp run size`