### PR TITLE
chore: bump pnpm to 11.20.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -134,5 +134,5 @@
   "engines": {
     "node": ">=22.13.0"
   },
-  "packageManager": "pnpm@11.18.0"
+  "packageManager": "pnpm@11.20.0"
 }


### PR DESCRIPTION
## Summary

- update the `packageManager` declaration from pnpm 11.18.0 to 11.20.0
- keep the existing lockfile unchanged because pnpm 11.20.0 accepts it as frozen and up to date

## Why

pnpm 11.20.0 is the current backwards-compatible minor release. Its Node.js requirement remains `>=22.13`, matching this repository's tooling engine.

## Impact

Tooling-only update; there are no runtime or public API changes.

## Validation

- `CI=true pnpm install --frozen-lockfile` using pnpm 11.20.0
- `vp check`
- `vp pack` (publint + attw)
- `vp test run --coverage` — 294 passed, 1 skipped, 100% coverage
- `vp run size`