### PR TITLE
chore: add changeset for lazy-init fallback docs

### DIFF
--- a/.changeset/lazy-init-fallback-docs.md
+++ b/.changeset/lazy-init-fallback-docs.md
@@ -1,0 +1,9 @@
+---
+"react-use-echarts": patch
+---
+
+Document the `useLazyInit` fallback for malformed observer options. An out-of-range `threshold`, a unit-less `rootMargin`, or a non-Element `root` makes the `IntersectionObserver` constructor throw; the hook catches it, logs via `console.error`, and degrades to eager init so the chart still renders instead of staying blank. This was already the behavior — it is now described in the published type declarations and in both READMEs.
+
+Also widened the `mergeRefs` description in the shipped `AGENTS.md` to cover React 19 cleanup-returning callback refs and the skipped `null` / `undefined` entries.
+
+Documentation only — no runtime behavior change.


### PR DESCRIPTION
## Motivation

#518 landed documentation improvements without a changeset, on the grounds that it was doc-only. That call was too strict: the change does reach the published artifact.

- The new `useLazyInit` JSDoc is emitted into `dist/index.d.ts` — verified by rebuilding with `vp pack` and reading the declaration file, so it shows up in consumers' IDE tooltips.
- `AGENTS.md` ships with the package via the `files` field.
- `README.md` is what renders on the npm page.

`main` and npm are both on `3.1.5`, and `.changeset/` is empty, so the release automation currently has nothing to do and those improvements would sit unpublished indefinitely.

## Changes

Adds a single patch changeset describing the documented `useLazyInit` fallback (malformed `IntersectionObserverInit` → `console.error` + degrade to eager init) and the widened `mergeRefs` description in `AGENTS.md`.

No source changes — this is purely the release bookkeeping that #518 skipped.

## Release path

Merging this triggers `changesets/action` on the push-to-`main` CI run, which opens the `chore: release` PR bumping the package to `3.1.6` and writing the CHANGELOG entry. Merging that second PR is what publishes to npm via OIDC trusted publishing.

## Validation

`vp check` — 133 files formatted, 89 files with no lint or type errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TCTcH1RoX7neHxoYuc8K9W

---
_Generated by [Claude Code](https://claude.ai/code/session_01TCTcH1RoX7neHxoYuc8K9W)_