### PR TITLE
chore: bump pnpm to 11.21.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -134,5 +134,5 @@
   "engines": {
     "node": "^22.18.0 || ^24.11.0 || >=26.0.0"
   },
-  "packageManager": "pnpm@11.20.0"
+  "packageManager": "pnpm@11.21.0"
 }


### PR DESCRIPTION
## Summary

- update the declared pnpm version from 11.20.0 to 11.21.0
- keep TypeScript on the existing 6.0.x line
- refresh the local install against the unchanged frozen lockfile

## Why

Use the latest backwards-compatible pnpm 11 minor release while avoiding an unrelated TypeScript 7 major upgrade.

## Impact

No runtime or published-library behavior changes. The update only affects the repository package-manager version selected by Corepack.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm check`
- `pnpm test` (294 passed, 1 skipped)