### PR TITLE
docs: deduplicate README quick start and trim redundant notes

### DIFF
--- a/README-zh_CN.md
+++ b/README-zh_CN.md
@@ -82,20 +82,9 @@ registerEchartsFull();
 
 ## 快速开始
 
-### 1. 注册 ECharts 一次
+注册好 ECharts 模块（上一节）之后，一个组件或一个 Hook 就能渲染图表。
 
-最快上手方式是在应用入口注册 ECharts 全量能力：
-
-```ts
-// main.tsx / index.tsx
-import { registerEchartsFull } from "react-use-echarts/preset-full";
-
-registerEchartsFull();
-```
-
-生产构建如果只渲染少量图表类型，可以稍后替换为按需 `echarts.use([...])` 注册；图表 API 不变。
-
-### 2. 渲染图表
+### 1. 渲染图表
 
 最简单的组件用法 — 无需手动管理 ref：
 
@@ -120,7 +109,7 @@ function MyChart() {
 
 通过 `ref` 可访问命令式 API —— 完整列表见 [返回值](#返回值)（`setOption`、`dispatchAction`、`clear`、`resize`、`appendData`、`getDataURL`、`convertToPixel` 等）。
 
-### 3. 直接使用 Hook
+### 2. 直接使用 Hook
 
 需要完全控制时，直接使用 Hook。它返回一个用于挂载到容器的 callback `ref`、响应式的 `instance` 字段，以及完整的命令式 API：
 
@@ -140,8 +129,6 @@ function MyChart() {
 ```
 
 `instance` 在初始化前及销毁后为 `undefined`；通过 `useEffect([instance])` 即可订阅实时 ECharts 实例并在其上挂副作用。
-
-图表容器必须有明确尺寸，例如 `style={{ width: "100%", height: "400px" }}`。
 
 ## 使用示例
 
@@ -418,7 +405,7 @@ import { registerEchartsFull } from "react-use-echarts/preset-full"; // 一行�
 // EChartProps, EChartHandle, EChartsEvents, EChartsEventConfig, EChartsEventHandler,
 // EChartsEventPayloadMap, EChartsInitOpts, BuiltinTheme, LoadingOption,
 // ChartFinder, ChartScaleValue, Payload。
-// EChartsOption、SetOptionOpts、ResizeOpts 现在也从此处转出（源自 "echarts" 包），
+// EChartsOption、SetOptionOpts、ResizeOpts 也从此处转出（源自 "echarts" 包），
 // 可与上面的类型一起从 react-use-echarts 统一导入，无需再单独 import "echarts"。
 ```
 

--- a/README.md
+++ b/README.md
@@ -82,20 +82,9 @@ Or, for tree-shake-friendly production builds, register only what you actually r
 
 ## Quick Start
 
-### 1. Register ECharts Once
+With ECharts modules registered (previous section), you're one component or one hook away from a chart.
 
-For the fastest start, register the full ECharts surface at your app entry:
-
-```ts
-// main.tsx / index.tsx
-import { registerEchartsFull } from "react-use-echarts/preset-full";
-
-registerEchartsFull();
-```
-
-For production bundles that only render a few chart types, replace this with selective `echarts.use([...])` registration later; the chart API stays the same.
-
-### 2. Render a Chart
+### 1. Render a Chart
 
 The simplest component path — no ref needed:
 
@@ -120,7 +109,7 @@ The chart container must have an explicit size. The example above sets it on `<E
 
 Pass `ref` to access the imperative API — see [Returns](#returns) for the full list (`setOption`, `dispatchAction`, `clear`, `resize`, `appendData`, `getDataURL`, `convertToPixel`, …).
 
-### 3. Use the Hook Directly
+### 2. Use the Hook Directly
 
 For full control, use the hook directly. It returns a callback `ref` to attach to your container plus a reactive `instance` field and the full imperative API:
 
@@ -140,8 +129,6 @@ function MyChart() {
 ```
 
 `instance` is `undefined` before init and after dispose; subscribe via `useEffect([instance])` to run side effects against the live ECharts instance.
-
-The chart container must have an explicit size, for example `style={{ width: "100%", height: "400px" }}`.
 
 ## Recipes
 


### PR DESCRIPTION
## Summary

A full audit of both READMEs against the current source found the content accurate (API tables, export lists, `useLazyInit` defaults, dev-warning wording, version requirements all match) and the two translations fully in sync. The only issues were internal redundancy, fixed here — applied identically to `README.md` and `README-zh_CN.md`:

- **Drop the Quick Start "Register ECharts Once" step** — it repeated the "Register ECharts modules" section immediately above it verbatim (same code block, same selective-registration note). A one-line lead-in now points back to that section, and the remaining steps are renumbered. No links referenced the removed sub-heading anchor; the dev-hint in `use-chart-core.ts` points to the "Register ECharts modules" section, which stays.
- **Remove the duplicated container-size reminder** after the hook example — the same rule is already stated after the component example and again in Gotchas, and the example code itself shows an explicit size.
- **Drop a stale temporal qualifier** ("现在") in the zh-CN "Other Exports" comment to match the English wording.

Net −26 lines; both files keep mirrored structure (same headings and code-block counts).

## Validation

- `vp check` — format, lint, and typecheck all pass
- Heading/code-fence structural diff between EN and ZH confirms the translations remain in lockstep

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011JDJyJkj3EvgtV3yxXXAtZ

---
_Generated by [Claude Code](https://claude.ai/code/session_011JDJyJkj3EvgtV3yxXXAtZ)_