### PR TITLE
chore: add changeset for docs alignment patch release

### DIFF
--- a/.changeset/docs-alignment-refresh.md
+++ b/.changeset/docs-alignment-refresh.md
@@ -1,0 +1,7 @@
+---
+"react-use-echarts": patch
+---
+
+Refresh the published documentation to match the implementation precisely. The README and the shipped `AGENTS.md` now state the exact `JSON.stringify` keying semantics for `initOpts` and custom `theme` objects (serialization is non-canonical, so property insertion order affects the key), that lazy init forwards only `root` / `rootMargin` / `threshold` to the `IntersectionObserver` (`scrollMargin` is not supported), the full `onError` coverage including the deliberately bare `off()` during dynamic event rebinding, and the `onChartReady`-style migration pattern via the reactive `instance` field. The README quick start was also deduplicated against the module-registration section.
+
+Documentation only — no runtime behavior change.


### PR DESCRIPTION
## Summary

Adds a patch changeset so the documentation work accumulated since v3.1.7 ships to npm. The published package is affected because `AGENTS.md` is in the package `files` and the README is the package's npm page:

- #530 — README quick-start deduplication (EN + zh-CN)
- #532 — precision alignment of README / AGENTS.md / CLAUDE.md / CONTRIBUTING.md with the implementation (`JSON.stringify` keying semantics, lazy-init option forwarding, `onError` coverage, `onChartReady` migration pattern)

Dev-dependency bumps (#531, #533) don't affect the published bundle; the changeset describes this as documentation-only with no runtime behavior change.

Merging this PR lets the release automation (`release.yml` via Changesets) open the "Version Packages" PR for v3.1.8; merging that publishes via npm OIDC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011JDJyJkj3EvgtV3yxXXAtZ

---
_Generated by [Claude Code](https://claude.ai/code/session_011JDJyJkj3EvgtV3yxXXAtZ)_